### PR TITLE
Release v0.1.2 — backlog scaffolding

### DIFF
--- a/.claude/skills/feature-branch-workflow.md
+++ b/.claude/skills/feature-branch-workflow.md
@@ -1,0 +1,133 @@
+---
+name: feature-branch-workflow
+description: Start a non-trivial change on a feature branch off develop and open a PR into develop when done — never commit directly to develop or main. Use when the user says "let's add X", "let's fix X", "implement Y", "work on Z", or any similar start-of-task phrase that implies code or non-trivial docs changes.
+---
+
+# Feature-branch workflow
+
+Every non-trivial change — feature, bugfix, refactor, docs sprint —
+lands on its own branch, ships as a PR into `develop`, and merges with
+a merge commit. Nothing goes directly onto `develop` or `main` except
+via a PR. The `log-issue` skill files the ticket; this skill does the
+implementation side.
+
+## When this applies
+
+- User says "let's add X", "let's fix X", "implement Y", "work on Z".
+- The task will produce one or more commits.
+- The change is non-trivial — i.e. not a one-line typo fix or a
+  session-local experiment.
+
+## When to skip
+
+- One-line typo / comment fix in a doc file (commit directly via a
+  short-lived branch still preferable, but judgment call).
+- Exploration / spike work that won't be kept.
+- A release PR (use the `release-to-main` skill instead — that one
+  targets `main`).
+
+## Branch naming
+
+Prefix by change kind, then a kebab-case slug. Match the commit
+prefix so the branch and first commit line up:
+
+| Prefix | For |
+| --- | --- |
+| `feat/…` | New user-facing capability |
+| `fix/…` | Bugfix |
+| `chore/…` | Tooling, CI, deps, non-user-facing |
+| `docs/…` | README / CHANGELOG / in-code docs |
+| `refactor/…` | Internal restructuring, no behavior change |
+| `test/…` | Coverage-only changes |
+| `ci/…` | GitHub Actions / workflow changes |
+
+Examples:
+- `feat/invite-email-preview`
+- `fix/offline-banner-flicker-on-reload`
+- `chore/bump-firebase-admin`
+- `docs/clarify-approval-lifecycle`
+
+Keep it under 50 chars. Reference an issue if one exists:
+`fix/42-offline-banner-flicker`.
+
+## Steps
+
+### 1. At task start, propose + create the branch
+
+Before writing any code, tell the user the branch name you're about
+to create. Ask once if it's not obvious:
+
+> "I'll do this on `feat/invite-email-preview` — OK?"
+
+Then create + switch:
+```bash
+git fetch origin develop
+git checkout -b feat/invite-email-preview origin/develop
+```
+
+If the user is already on a feature branch from a prior session
+(something other than `develop` / `main`), stay on that branch rather
+than branching-off-a-branch unless it's clearly a separate task.
+
+### 2. Work in small atomic commits
+
+Same conventions as the rest of the repo — short imperative subject
+lines prefixed by type:
+```
+feat(invites): preview the mailto body before sending
+fix(offline): don't flash "back online" on first load
+```
+
+Reference issues with `Refs #N` while in progress; save `Fixes #N` for
+the commit that actually resolves it (auto-closes on merge).
+
+### 3. Push the branch on first commit
+
+```bash
+git push -u origin feat/invite-email-preview
+```
+
+### 4. When the work is ready, open a PR into develop
+
+```bash
+gh pr create --base develop --head feat/invite-email-preview \
+  --title "feat(invites): preview the mailto body before sending" \
+  --body "<summary · approach · test plan · screenshots if UI · Fixes #N>"
+```
+
+Wait for CI green.
+
+### 5. Merge
+
+Merge-commit is the only method enabled at the repo level, so there's
+no "which button" question. Click Merge. GitHub auto-deletes the
+branch; if not, delete it manually.
+
+### 6. Post-merge cleanup
+
+```bash
+git checkout develop
+git pull --ff-only origin develop
+git branch -d feat/invite-email-preview   # local cleanup
+git fetch --prune origin                   # drops the remote-tracking ref
+```
+
+## What NOT to do
+
+- **Don't commit directly to `develop`** — even for a one-line doc
+  fix. GitHub isn't enforcing this on the free tier; discipline is.
+- **Don't commit directly to `main`** — ever.
+- **Don't force-push to `develop` or `main`**, even with
+  `--force-with-lease`. (The `release-to-main` skill used to, for
+  drift cleanup. It no longer does, because merge-commit-only is now
+  enforced repo-wide — the drift that necessitated the force-push
+  can't recur.)
+- **Don't squash or rebase on merge** — the repo settings hide those
+  buttons for a reason.
+
+## Escape hatch
+
+Admin bypass is on (solo dev, free tier). If a direct push or
+force-push is genuinely the right move (e.g. recovering from a
+mistake), ask the user explicitly and log what was done in a follow-up
+issue so the trail isn't silent.

--- a/.claude/skills/log-issue.md
+++ b/.claude/skills/log-issue.md
@@ -1,0 +1,100 @@
+---
+name: log-issue
+description: Create a GitHub issue for a discovered bug, feature request, or tech-debt item. Use when the user says "log this", "file a bug", "create an issue", "add to backlog", or when you proactively surface a mid-session discovery worth tracking. Skip for fixes you're about to do right now.
+---
+
+# Log a GitHub issue
+
+Turn a mid-session discovery into a trackable backlog item instead of
+losing it in chat history. The repo has issue templates at
+`.github/ISSUE_TEMPLATE/` — follow the shape so UI-filed issues and
+CLI-filed issues read the same.
+
+## When to use
+
+- User explicitly asks: "log this", "file a bug", "create an issue".
+- **Proactive surface**: you discover something that WON'T be fixed in
+  the next step — a bug you're documenting but not fixing, a feature
+  idea mentioned in passing, a known shortcut you're taking, a flaky
+  test, a TODO you're intentionally leaving. Ask the user once:
+  > "Log this as an issue, or skip?"
+
+## When NOT to use
+
+- Trivial fixes you're about to do in the next 5–10 minutes (commit
+  message is enough).
+- Code review feedback you're about to address in the same session.
+- Design preferences that belong in `CLAUDE.md` or design docs, not
+  the issue tracker.
+
+## Category → template → labels
+
+| Kind | Template | Labels |
+| --- | --- | --- |
+| Something is broken | Bug report | `bug`, `needs-triage` |
+| New capability / workflow | Feature request | `enhancement`, `needs-triage` |
+| Refactor, shortcut to unwind | Tech debt / cleanup | `tech-debt`, `needs-triage` |
+| Rules / data exposure / auth | Bug report | add `security` on top of `bug` |
+
+The issue templates already apply the primary + `needs-triage` labels
+automatically when a user files from the GitHub UI. When you file via
+the CLI (below), pass the same labels explicitly with `--label`.
+
+## Steps
+
+1. **De-dupe first.** Search open issues for keywords from the title:
+   ```bash
+   gh issue list --state open --search "<2-3 keywords>"
+   ```
+   If a close match exists, reference it instead of filing a duplicate
+   (add a comment on the existing issue with `gh issue comment`).
+
+2. **Write a title under 70 chars.** Describe the problem, not the
+   fix. Good: "Couldn't save toast persists after successful retry".
+   Bad: "Fix toast".
+
+3. **Write the body to match the template shape**:
+   - *Bug*: summary · steps to reproduce · context · screenshots/logs
+   - *Feature*: problem · proposed behavior · done-when checklist
+   - *Tech debt*: what's the shortcut · why fix · rough plan · refs
+
+4. **Create**:
+   ```bash
+   gh issue create \
+     --title "<title>" \
+     --label "bug,needs-triage" \
+     --body "$(cat <<'EOF'
+     ## Summary
+     ...
+
+     ## Steps to reproduce
+     1. ...
+     2. ...
+
+     ## Context
+     ...
+     EOF
+     )"
+   ```
+   For feature / tech-debt, use the matching section headings from
+   the template.
+
+5. **Return the URL** to the user and (if mid-session) note what
+   you're doing next.
+
+## Linking
+
+- In a commit that fixes an issue: use `Fixes #N` or `Closes #N` in
+  the message body so GitHub auto-closes on merge to `main`.
+- In the `CHANGELOG.md` entry: reference the issue inline as `(#N)`.
+
+## Guardrails
+
+- Never assign issues to yourself or anyone else — default unassigned.
+- Never add priority labels (`p0`, `p1`…) without explicit user
+  direction. `needs-triage` is the default.
+- Security issues: if the content is sensitive (an actively exploitable
+  bug), ask before filing publicly. Otherwise file with the `security`
+  label so it stands out in triage.
+- If the de-dupe search turns up 2+ close matches, stop and ask the
+  user which to reference rather than guessing.

--- a/.claude/skills/release-to-main.md
+++ b/.claude/skills/release-to-main.md
@@ -82,6 +82,16 @@ Do this as a single commit titled `chore(release): vX.Y.Z`:
    - Group entries under **Added / Changed / Fixed / Security /
      Infrastructure** subheads. Commit subjects are a starting point,
      not the final copy — rewrite for the end reader.
+   - **Pull closed-issue references** for the release window so the
+     changelog links back to the backlog that drove the work:
+     ```bash
+     LAST_TAG=$(git describe --tags --abbrev=0 origin/main)
+     LAST_DATE=$(git log -1 --format=%aI "$LAST_TAG" | cut -d'T' -f1)
+     gh issue list --state closed --limit 100 \
+       --search "closed:>=$LAST_DATE" --json number,title,labels
+     ```
+     Attach `(#N)` references inline where a bullet corresponds to a
+     closed issue.
    - Re-add an empty `## [Unreleased]` at the top of the file.
    - Update the compare links at the bottom:
      ```

--- a/.claude/skills/release-to-main.md
+++ b/.claude/skills/release-to-main.md
@@ -1,34 +1,32 @@
 ---
 name: release-to-main
-description: Promote develop → main for a Steward production release. Handles the PR, the correct merge strategy, the post-merge develop realignment, and the Firestore deploys. Use when the user says "ship to prod", "publish to production", "release", or similar.
+description: Promote develop → main for a Steward production release. Handles the PR, the changelog + version bump, tagging, and the Firebase rules/indexes deploys. Use when the user says "ship to prod", "publish to production", "release", or similar.
 ---
 
 # Release develop → main (Steward)
 
-This skill encodes the release workflow for Steward. It exists because
-the release path touches three systems (GitHub, Vercel auto-deploy off
-`main`, Firebase rules/indexes on `steward-prod-65a36`) and the
-previous release drifted the branches ("N commits ahead, N commits
-behind") due to the wrong merge strategy.
+This skill encodes the release workflow for Steward. It exists
+because the release path touches three systems: GitHub (PR merge),
+Vercel (auto-deploy off `main`), and Firebase (rules + indexes on
+`steward-prod-65a36`, deployed by hand).
 
 ## Branch topology
 
 - `main` → production (Vercel auto-deploys from here)
 - `develop` → staging / CI target
-- Feature branches → PR into `develop`
+- Feature branches → PR into `develop` (see `feature-branch-workflow`)
 - Release → PR from `develop` → `main`
 
-## Merge strategy matters
+## Merge strategy
 
-- Feature PRs into `develop`: **"Rebase and merge"** is fine.
-- Release PRs (`develop` → `main`): **"Create a merge commit"** — NOT
-  rebase-and-merge. Rebase-and-merge creates new SHAs on `main` and
-  leaves `develop` and `main` permanently divergent ("N ahead, N
-  behind") even though they contain the same changes.
-
-If the repo's default merge button is still "Rebase and merge", either
-change it in GitHub Settings → General → Pull Requests, or pick
-"Create a merge commit" manually when merging the release PR.
+Merge-commit is the **only** method enabled at the repo level (squash
+and rebase are disabled). This is by design: rebase-and-merge and
+squash-merge both rewrite commit SHAs on the merge target, which
+historically left `develop` and `main` divergent ("N ahead / N
+behind") even though they contained the same changes. With
+merge-commit-only enforced repo-wide, the GitHub UI only offers one
+button and `develop` stays in sync with `main` automatically after
+the release merge — no post-merge realignment needed.
 
 ## Versioning
 
@@ -123,30 +121,31 @@ Wait for CI to go green on the PR before merging.
 
 ## Merge
 
-Use **"Create a merge commit"** on the GitHub UI. Confirm with the
-user before the click — this is a high-severity production action.
+Click Merge on the GitHub UI — the only available method is "Create
+a merge commit" (enforced at the repo level). Confirm with the user
+before the click — this is a high-severity production action.
 
-## Post-merge realignment (CRITICAL — do this every time)
+## Post-merge sync
 
-Even with a merge commit, staying strictly aligned is cleaner if the
-release PR used rebase-and-merge (legacy). After every release,
-realign `develop` so future `develop ↔ main` diffs are clean:
+Merge-commit preserves develop's SHAs on main, so the post-merge
+state is: `main == develop + one merge commit`. Pull the merge
+commit down onto develop with a fast-forward:
 
 ```bash
-git fetch origin main
+git fetch origin
 git checkout develop
-git reset --hard origin/main
-git push origin develop --force-with-lease
+git pull --ff-only origin develop    # picks up the merge commit
 ```
 
-Safe here because `develop` doesn't carry commits that `main` doesn't
-have after the release merge — `main` is the superset.
-
-Also sync local `version-2` or any other long-running branches to the
-new `main`:
+If you maintain any long-running local branches (e.g. `version-2`),
+fast-forward them too:
 ```bash
-git checkout version-2 && git merge --ff-only origin/main
+git checkout version-2 && git merge --ff-only origin/develop
 ```
+
+Never force-push to `develop` or `main` as part of this flow. The
+legacy `git reset --hard && git push --force-with-lease` dance is no
+longer needed and is explicitly forbidden — see Guardrails.
 
 ## Tag the release
 
@@ -236,8 +235,19 @@ After rules + indexes deploy + the Vercel prod build lands:
 
 ## Guardrails
 
-- Never force-push to `main`.
-- Never merge a red PR into `main`.
-- Firebase deploys target `prod` explicitly via `--project=prod`; never
-  omit the flag (the default project is `steward-dev-5e4dc`).
+- **Never direct-push to `develop` or `main`** — everything flows
+  through PRs. GitHub's free tier doesn't enforce this, so it's on
+  discipline + this skill.
+- **Never force-push to `develop` or `main`** under any circumstance.
+  The legacy realignment step that used `--force-with-lease` is
+  removed; merge-commit-only prevents the drift that required it.
+- **Never merge a red PR into `main`.**
+- Firebase deploys target `prod` explicitly via `--project=prod`;
+  never omit the flag (the default project is `steward-dev-5e4dc`).
 - When in doubt, open an extra PR rather than fix-in-main.
+
+## Escape hatch
+
+Admin bypass is on (solo dev, free tier). If a direct push or
+force-push is genuinely the right move (emergency rollback, say),
+ask the user explicitly and log what was done in a follow-up issue.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,34 @@
+name: Bug report
+description: Something isn't working
+labels: [bug, needs-triage]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: What's wrong?
+      description: One or two sentences — what did you expect, what happened instead.
+      placeholder: "When I click Request approval, the button stays spinning and nothing saves."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal ordered list. Skip if it's obvious.
+      placeholder: |
+        1. Open /week/2026-04-26
+        2. Assign two speakers + set them to confirmed
+        3. Click Request approval
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Context (optional)
+      description: Ward role, device, browser, network. Anything that might matter.
+      placeholder: "Signed in as bishop, Safari on iPhone, on wifi."
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Screenshots / logs (optional)
+      description: Drag images in, paste console errors, or link to the failing URL.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: A new capability or workflow
+labels: [enhancement, needs-triage]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are we solving?
+      description: The underlying need, not the solution.
+      placeholder: "Bishops forget to remind speakers the Thursday before their Sunday."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: How you'd like it to work. Rough is fine.
+      placeholder: "Send a reminder push to each confirmed speaker 72 hours before their assigned meeting."
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Done when…
+      description: Checklist of concrete acceptance criteria.
+      placeholder: |
+        - [ ] Each confirmed speaker gets one push at T-72h
+        - [ ] Cancelled / rescheduled meetings skip the reminder
+        - [ ] Covered by a rules-unit test + e2e
+  - type: textarea
+    id: context
+    attributes:
+      label: Out of scope (optional)
+      description: What you explicitly don't want bundled into this.

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,30 @@
+name: Tech debt / cleanup
+description: Internal refactor, known shortcut, or followup from a previous change
+labels: [tech-debt, needs-triage]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What's the shortcut?
+      description: The thing that's simpler / faster / good-enough today but should eventually change.
+      placeholder: "ApprovalsArrayOk unrolls positionally for max 2 approvals; if the cap ever moves to 3+, the rule breaks."
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why fix it?
+      description: What breaks, slows down, or becomes risky if we don't.
+      placeholder: "Silent rule misbehavior on future schema changes."
+    validations:
+      required: true
+  - type: textarea
+    id: approach
+    attributes:
+      label: Rough plan (optional)
+      description: If you already know how you'd unwind it.
+  - type: textarea
+    id: refs
+    attributes:
+      label: File / PR / commit references (optional)
+      placeholder: "firestore.rules:63 · introduced in #1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ templates so anything captured follows a consistent shape.
 - `.claude/skills/log-issue.md` — skill that turns a mid-session
   discovery into a GitHub issue (de-dupe search, template-shaped body,
   label selection, guardrails).
+- `.claude/skills/feature-branch-workflow.md` — skill that enforces
+  "non-trivial changes start on a `feat/…` / `fix/…` / `chore/…`
+  branch off `develop` and ship as a PR; no direct pushes to
+  `develop` or `main`, no squash/rebase, no force-pushes".
 - `.github/ISSUE_TEMPLATE/` with `bug.yml`, `feature.yml`, and
   `tech-debt.yml` so issues filed from the GitHub UI follow the same
   shape as ones filed via the CLI. `config.yml` disables blank
@@ -24,11 +28,28 @@ templates so anything captured follows a consistent shape.
 - `CLAUDE.md` "Backlog hygiene" section: Claude now proactively asks
   about logging any discovered bug / feature idea / tech-debt item
   mid-session, with a 10-minute rule-of-thumb threshold.
+- `CLAUDE.md` hard rules: "No direct pushes to `develop` or `main`"
+  and "Merge-commit is the only enabled merge method".
 
 ### Changed
-- `.claude/skills/release-to-main.md` — the changelog step now also
-  pulls closed issues since the last tag so each release links back
-  to the backlog that drove it.
+- **Merge methods at the repo level**: squash and rebase merges
+  disabled on GitHub (`gh repo edit --enable-squash-merge=false
+  --enable-rebase-merge=false`). Only "Create a merge commit" is
+  available now, which prevents the history drift that produced the
+  "N ahead / N behind" mirror on earlier releases.
+- `.claude/skills/release-to-main.md` — dropped the force-push
+  develop-realignment step (no longer needed, now that drift can't
+  occur) and added a simple fast-forward `git pull` post-merge sync.
+  Guardrails hardened: no direct pushes, no force-pushes, ever.
+  Changelog step also pulls closed issues since the last tag so each
+  release links back to the backlog that drove it.
+
+### Infrastructure
+- Branch protection on `develop` / `main` is NOT enforced at the
+  GitHub layer — classic protection and rulesets both require
+  GitHub Pro on private repos. The PR-only workflow is enforced by
+  skills + discipline. Revisit if the repo moves to a paid plan or
+  adds collaborators.
 
 ## [0.1.1] — 2026-04-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.1.2] — 2026-04-21
+
+Backlog scaffolding: a skill for filing issues mid-session plus issue
+templates so anything captured follows a consistent shape.
+
+### Added
+- `.claude/skills/log-issue.md` — skill that turns a mid-session
+  discovery into a GitHub issue (de-dupe search, template-shaped body,
+  label selection, guardrails).
+- `.github/ISSUE_TEMPLATE/` with `bug.yml`, `feature.yml`, and
+  `tech-debt.yml` so issues filed from the GitHub UI follow the same
+  shape as ones filed via the CLI. `config.yml` disables blank
+  issues.
+- Labels on GitHub: `tech-debt`, `needs-triage`, `security`.
+- `CLAUDE.md` "Backlog hygiene" section: Claude now proactively asks
+  about logging any discovered bug / feature idea / tech-debt item
+  mid-session, with a 10-minute rule-of-thumb threshold.
+
+### Changed
+- `.claude/skills/release-to-main.md` — the changelog step now also
+  pulls closed issues since the last tag so each release links back
+  to the backlog that drove it.
+
 ## [0.1.1] — 2026-04-21
 
 Docs + release tooling, plus a cleanup of an index config that drifted
@@ -117,6 +140,7 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/aylabyuk/steward/releases/tag/v0.1.2
 [0.1.1]: https://github.com/aylabyuk/steward/releases/tag/v0.1.1
 [0.1.0]: https://github.com/aylabyuk/steward/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ PWA for a ward bishopric to plan weekly sacrament meeting programs. Desktop + mo
 - **Components ≤ 150 LOC.** Enforced by oxlint `max-lines` + `max-lines-per-function` (error, not warn).
 - **Only three Cloud Functions.** No API server, no custom endpoints. Firestore rules are the rest of the backend.
 - **Multi-ward from day one.** All data scoped under `wards/{wardId}/`.
+- **No direct pushes to `develop` or `main`.** Every change flows through a PR: feature branch → PR into `develop` (see the [`feature-branch-workflow`](.claude/skills/feature-branch-workflow.md) skill); releases go via PR from `develop` → `main` (see [`release-to-main`](.claude/skills/release-to-main.md)). GitHub's free tier doesn't enforce this — discipline does. No force-pushes to either branch, ever.
+- **Merge-commit is the only enabled merge method** at the repo level (squash + rebase disabled). Keeps `develop` and `main` SHA-aligned and prevents "N ahead / N behind" drift.
 - **Every push to `develop` runs the full CI pipeline.** Lint + format + typecheck + unit + rules + e2e. All must pass; no retries on flakes.
 
 ## Directory layout

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,22 @@ functions/          # Firebase Cloud Functions
 - `npm run test:all` — CI target
 - `npm run emulators` — Firebase Local Emulator Suite
 
+## Backlog hygiene — log before you forget
+
+When you discover a bug, feature gap, or tech-debt item mid-session
+that you're NOT going to fix in the next step, proactively ask the
+user once: *"Log this as a GitHub issue, or skip?"* Use the
+[`log-issue`](.claude/skills/log-issue.md) skill to file it. The
+threshold: if it's a 10-minute fix you're about to make anyway, skip.
+Everything else — things you're documenting but not fixing, feature
+ideas mentioned in passing, known shortcuts — should get an issue so
+it doesn't evaporate in chat history.
+
+Issue templates live at `.github/ISSUE_TEMPLATE/` (bug / feature /
+tech-debt). Commit messages that resolve an issue should use
+`Fixes #N` so the PR auto-closes on merge to `main`. Changelog
+entries reference the issue inline as `(#N)`.
+
 ## Topic docs — load on demand for the current task
 
 - **[docs/domain.md](docs/domain.md)** — data model, Firestore shape, meeting types, cancellation, approval lifecycle, audit trail

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
## Summary

Adds the tooling for a backlog-driven workflow so discoveries made mid-session actually end up in the tracker instead of evaporating in chat history. No runtime changes.

## What's in it

- **`.claude/skills/log-issue.md`** — project-scoped Claude Code skill that turns a bug / feature idea / tech-debt note into a GitHub issue via ``gh issue create``. Handles de-dupe search, template-shaped body, label selection, and guardrails (never auto-assign, never set priority without direction, flag security issues).
- **`.github/ISSUE_TEMPLATE/`** — ``bug.yml`` / ``feature.yml`` / ``tech-debt.yml`` so issues filed from the GitHub UI follow the same shape as CLI-filed ones. ``config.yml`` disables blank issues.
- **Labels created on GitHub**: ``tech-debt``, ``needs-triage``, ``security``.
- **``CLAUDE.md`` "Backlog hygiene"** section — Claude now proactively asks about logging discoveries it won't fix in the next step. Rule of thumb: if the fix is ~10 minutes away, skip; otherwise offer to file.
- **``release-to-main`` skill** — changelog step now also pulls closed issues since the last tag (``gh issue list --state closed --search "closed:>=<last-tag-date>"``) so releases link back to the backlog.

## Merge strategy

**"Create a merge commit"** — not squash-and-merge. Squash created drift last time (mirror "N ahead / N behind" between develop and main); merge-commit avoids it.

## Test plan

- [ ] CI green
- [ ] Merge with "Create a merge commit"
- [ ] Tag ``v0.1.2`` on the merge commit + create GitHub Release
- [ ] Next time a bug / feature idea surfaces mid-session, I'll ask whether to ``gh issue create`` it

🤖 Generated with [Claude Code](https://claude.com/claude-code)