### PR TITLE
feat(topbar): show app version below the Steward wordmark

### DIFF
--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -10,7 +10,15 @@ export function Topbar() {
         {/* Brand */}
         <div className="flex items-center gap-2.5 flex-shrink-0">
           <img src="/icons/logo-monogram.svg" alt="Steward" className="h-6 w-6" />
-          <span className="font-display text-base font-semibold tracking-tight">Steward</span>
+          <div className="flex flex-col leading-none">
+            <span className="font-display text-base font-semibold tracking-tight">Steward</span>
+            <span
+              aria-label={`Version ${__APP_VERSION__}`}
+              className="mt-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3"
+            >
+              v{__APP_VERSION__}
+            </span>
+          </div>
           {wardName && (
             <>
               <span aria-hidden className="text-walnut-3">

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -10,7 +10,7 @@ export function Topbar() {
         {/* Brand */}
         <div className="flex items-center gap-2.5 flex-shrink-0">
           <img src="/icons/logo-monogram.svg" alt="Steward" className="h-6 w-6" />
-          <div className="flex flex-col leading-none">
+          <div className="flex flex-col items-center leading-none">
             <span className="font-display text-base font-semibold tracking-tight">Steward</span>
             <span
               aria-label={`Version ${__APP_VERSION__}`}

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -12,12 +12,15 @@ export function Topbar() {
           <img src="/icons/logo-monogram.svg" alt="Steward" className="h-6 w-6" />
           <div className="flex flex-col items-center leading-none">
             <span className="font-display text-base font-semibold tracking-tight">Steward</span>
-            <span
-              aria-label={`Version ${__APP_VERSION__}`}
-              className="mt-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3"
+            <a
+              href={`https://github.com/aylabyuk/steward/releases/tag/v${__APP_VERSION__}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Version ${__APP_VERSION__} — open release notes`}
+              className="mt-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut hover:underline underline-offset-2 transition-colors"
             >
               v{__APP_VERSION__}
-            </span>
+            </a>
           </div>
           {wardName && (
             <>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,3 +14,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/**
+ * App version injected by Vite at build time from package.json.
+ * See vite.config.ts `define`.
+ */
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+
+const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, "package.json"), "utf8"));
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -9,6 +12,11 @@ export default defineConfig({
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
     },
+  },
+  define: {
+    // Surfaced in the UI (see Topbar). Read at build time so the bundle
+    // always carries the package.json version the commit was tagged with.
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
Adds a small ``v{version}`` label directly below the "Steward" wordmark in the topbar so the currently-deployed version is visible at a glance, and links it to the matching GitHub Release.

Fixes #5.

## Approach
- ``vite.config.ts`` reads ``package.json.version`` at build time and exposes it as the ``__APP_VERSION__`` global via Vite's ``define``.
- ``src/env.d.ts`` declares the global so TypeScript is happy.
- Topbar brand block becomes a vertical stack: "Steward" on top, ``v0.1.2`` centered underneath in mono eyebrow style (9px, walnut-3). Ward name continues inline to the right.
- Version label is an anchor to ``github.com/aylabyuk/steward/releases/tag/v{version}``, opens in a new tab, hover underline + walnut color on interaction.

## Test plan
- [ ] CI green
- [ ] ``v0.1.2`` visible in the topbar on both desktop + mobile
- [ ] Click the version → release notes open in a new tab
- [ ] Ward name still renders inline, no layout shift

## Out of scope (tracked separately)
- Short commit SHA alongside the version

🤖 Generated with [Claude Code](https://claude.com/claude-code)