### PR TITLE
Release v0.2.0 — version label in the topbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-04-21
+
+First feature release on the new branch-PR workflow.
+
+### Added
+- **Version label in the topbar** (#5). Shows `v{version}` directly
+  below the "Steward" wordmark, centered, in a quiet mono eyebrow.
+  Clicking opens the matching GitHub Release in a new tab. Version
+  is pulled from `package.json` at build time via a Vite `define`
+  (`__APP_VERSION__`), so the bundle always carries the version the
+  commit was tagged with.
+
 ## [0.1.2] — 2026-04-21
 
 Backlog scaffolding: a skill for filing issues mid-session plus issue
@@ -161,7 +173,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/aylabyuk/steward/releases/tag/v0.2.0
 [0.1.2]: https://github.com/aylabyuk/steward/releases/tag/v0.1.2
 [0.1.1]: https://github.com/aylabyuk/steward/releases/tag/v0.1.1
 [0.1.0]: https://github.com/aylabyuk/steward/releases/tag/v0.1.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -10,7 +10,15 @@ export function Topbar() {
         {/* Brand */}
         <div className="flex items-center gap-2.5 flex-shrink-0">
           <img src="/icons/logo-monogram.svg" alt="Steward" className="h-6 w-6" />
-          <span className="font-display text-base font-semibold tracking-tight">Steward</span>
+          <div className="flex flex-col leading-none">
+            <span className="font-display text-base font-semibold tracking-tight">Steward</span>
+            <span
+              aria-label={`Version ${__APP_VERSION__}`}
+              className="mt-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3"
+            >
+              v{__APP_VERSION__}
+            </span>
+          </div>
           {wardName && (
             <>
               <span aria-hidden className="text-walnut-3">

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -10,7 +10,7 @@ export function Topbar() {
         {/* Brand */}
         <div className="flex items-center gap-2.5 flex-shrink-0">
           <img src="/icons/logo-monogram.svg" alt="Steward" className="h-6 w-6" />
-          <div className="flex flex-col leading-none">
+          <div className="flex flex-col items-center leading-none">
             <span className="font-display text-base font-semibold tracking-tight">Steward</span>
             <span
               aria-label={`Version ${__APP_VERSION__}`}

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -12,12 +12,15 @@ export function Topbar() {
           <img src="/icons/logo-monogram.svg" alt="Steward" className="h-6 w-6" />
           <div className="flex flex-col items-center leading-none">
             <span className="font-display text-base font-semibold tracking-tight">Steward</span>
-            <span
-              aria-label={`Version ${__APP_VERSION__}`}
-              className="mt-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3"
+            <a
+              href={`https://github.com/aylabyuk/steward/releases/tag/v${__APP_VERSION__}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Version ${__APP_VERSION__} — open release notes`}
+              className="mt-0.5 font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut hover:underline underline-offset-2 transition-colors"
             >
               v{__APP_VERSION__}
-            </span>
+            </a>
           </div>
           {wardName && (
             <>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,3 +14,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/**
+ * App version injected by Vite at build time from package.json.
+ * See vite.config.ts `define`.
+ */
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { readFileSync } from "node:fs";
 import path from "node:path";
+
+const pkg = JSON.parse(readFileSync(path.resolve(import.meta.dirname, "package.json"), "utf8"));
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -9,6 +12,11 @@ export default defineConfig({
     alias: {
       "@": path.resolve(import.meta.dirname, "src"),
     },
+  },
+  define: {
+    // Surfaced in the UI (see Topbar). Read at build time so the bundle
+    // always carries the package.json version the commit was tagged with.
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary

Feature release. Adds a visible version indicator to the topbar that links to its GitHub Release.

### Closes
- #5 — feat: show app version in the topbar

## Contents

Picks up every commit on develop since v0.1.2:

- ``feat(topbar)``: show app version below the Steward wordmark
- ``fix(topbar)``: center the version label
- ``feat(topbar)``: link the version label to its GitHub Release
- ``chore(release)``: v0.2.0 (bump + CHANGELOG)

## Merge

Merge-commit is the only method available (repo-level setting). Click Merge.

## Test plan
- [ ] CI green
- [ ] Merge with "Create a merge commit"
- [ ] Tag ``v0.2.0`` on the merge commit + create GitHub Release
- [ ] Fast-forward develop to main (plain ``git pull`` — no force-push)
- [ ] No Firebase deploy needed (no ``firestore.rules`` / ``firestore.indexes.json`` / ``functions/`` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)