### PR TITLE
feat(templates): public speaker invitation landing page (slice 2 of #8)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -122,6 +122,17 @@ service cloud.firestore {
         allow create, update, delete: if isActiveMember(wardId);
       }
 
+      // Speaker invitations: frozen snapshots of a letter at send time.
+      // Public read — the doc ID is the shareable token, and Firestore
+      // auto-IDs are cryptographically random (~120 bits) so the URL
+      // itself authorizes access. The recipient has no other way into
+      // the ward. Writes still require an active member so only the
+      // bishopric or clerks can send.
+      match /speakerInvitations/{token} {
+        allow read: if true;
+        allow create, update, delete: if isActiveMember(wardId);
+      }
+
       // Invites: bishopric creates/lists/revokes pending invites keyed by
       // the invitee's lower-cased email. The invitee themselves can read
       // the doc targeted at their email (so an invite-acceptance page can

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -4,6 +4,7 @@ import { ConductingProgram } from "@/features/print/ConductingProgram";
 import { ScheduleView } from "@/features/schedule/ScheduleView";
 import { AuthGate } from "./auth-gate";
 import { AcceptInvitePage } from "./routes/accept-invite";
+import { SpeakerInvitationLandingPage } from "./routes/invite-speaker";
 import { Login } from "./routes/login";
 import { MembersPage } from "./routes/members";
 import { NotificationSettingsPage } from "./routes/notification-settings";
@@ -42,5 +43,9 @@ export const router = createBrowserRouter([
   // yet — AccessRequired would block them. The page handles its own
   // signed-in check.
   { path: "/accept-invite/:wardId", element: <AcceptInvitePage /> },
+  // Speaker invitation landing: fully public (no auth at all). The
+  // unguessable token in the URL authorizes the read per Firestore
+  // rules.
+  { path: "/invite/speaker/:wardId/:token", element: <SpeakerInvitationLandingPage /> },
   { path: "/login", element: <Login /> },
 ]);

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -1,0 +1,60 @@
+import { useParams } from "react-router";
+import { LetterCanvas } from "@/features/templates/LetterCanvas";
+import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation";
+
+/**
+ * Public landing page: a speaker opens this URL from the mailto link
+ * the bishop sent them, and sees their invitation letter rendered at
+ * full letter-sheet proportions. No auth — the unguessable token in
+ * the URL IS the auth. Rendered content is the frozen snapshot
+ * created at `sendSpeakerInvitation` time.
+ */
+export function SpeakerInvitationLandingPage() {
+  const { wardId, token } = useParams<{ wardId: string; token: string }>();
+  const state = useSpeakerInvitation(wardId, token);
+
+  return (
+    <main className="min-h-dvh bg-[#e6ddc7] py-10 px-4 sm:px-6 flex items-start justify-center">
+      <Body state={state} />
+    </main>
+  );
+}
+
+function Body({ state }: { state: ReturnType<typeof useSpeakerInvitation> }) {
+  if (state.kind === "loading") {
+    return <div className="mt-20 font-serif italic text-[14px] text-walnut-2">Loading letter…</div>;
+  }
+  if (state.kind === "not-found") {
+    return <NotFound />;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="mt-20 max-w-md rounded-lg border border-border bg-chalk p-6 text-center">
+        <p className="font-display text-[20px] text-walnut mb-2">We couldn't load the letter</p>
+        <p className="font-serif italic text-[13.5px] text-walnut-2">{state.message}</p>
+      </div>
+    );
+  }
+  const { invitation } = state;
+  return (
+    <LetterCanvas
+      wardName={invitation.wardName}
+      assignedDate={invitation.assignedDate}
+      today={invitation.sentOn}
+      bodyMarkdown={invitation.bodyMarkdown}
+      footerMarkdown={invitation.footerMarkdown}
+    />
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="mt-20 max-w-md rounded-lg border border-border bg-chalk p-6 text-center">
+      <p className="font-display text-[20px] text-walnut mb-2">Invitation not found</p>
+      <p className="font-serif italic text-[13.5px] text-walnut-2">
+        The link may have been mistyped, retracted, or expired. Ask whoever sent it for a fresh
+        link.
+      </p>
+    </div>
+  );
+}

--- a/src/features/schedule/SpeakerInviteAction.tsx
+++ b/src/features/schedule/SpeakerInviteAction.tsx
@@ -1,5 +1,11 @@
+import { useState } from "react";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useAuthStore } from "@/stores/authStore";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { sendSpeakerInvitation } from "@/features/templates/sendSpeakerInvitation";
 import { cn } from "@/lib/cn";
 import { isValidEmail } from "@/lib/email";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
 import type { Draft } from "./speakerDraft";
 import { CheckIcon, MailIcon, PrintIcon, SendIcon } from "./SpeakerInviteIcons";
 
@@ -11,55 +17,96 @@ interface Props {
 }
 
 export function InviteAction({ draft, date, onMarkInvited, onPrint }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const me = useCurrentMember();
+  const authUser = useAuthStore((s) => s.user);
+  const inviterName =
+    me?.data.displayName ?? authUser?.displayName ?? authUser?.email ?? "The bishopric";
   const email = draft.email.trim();
   const hasEmail = email.length > 0;
   const emailValid = isValidEmail(email);
   const invited = draft.status === "invited" || draft.status === "confirmed";
+  const persisted = draft.id !== null;
+  const [sending, setSending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  function handleSendEmail() {
-    if (!emailValid) return;
-    const subject = encodeURIComponent(`Speaker invitation — ${date}`);
-    const body = encodeURIComponent(
-      `Dear ${draft.name},\n\nThe bishopric invites you to speak in sacrament meeting on ${date}.\n\nTopic: ${draft.topic || "(To be determined)"}\nDuration: 10–15 minutes\n\nPlease let us know if this works.\n\nThank you!`,
-    );
-    window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
-    onMarkInvited();
+  async function handleSendEmail() {
+    if (!emailValid || !wardId || !persisted || !draft.id) return;
+    setError(null);
+    setSending(true);
+    try {
+      const { token } = await sendSpeakerInvitation({
+        wardId,
+        meetingDate: date,
+        speakerId: draft.id,
+        speakerName: draft.name,
+        speakerTopic: draft.topic.trim() || undefined,
+        inviterName,
+      });
+      const url = `${window.location.origin}/invite/speaker/${wardId}/${token}`;
+      const subject = encodeURIComponent(`Invitation to speak — ${prettyDate(date)}`);
+      const body = encodeURIComponent(
+        `Dear ${draft.name},\n\nPlease open your invitation letter at the link below:\n${url}\n\nWith gratitude,\nThe bishopric`,
+      );
+      window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
+      onMarkInvited();
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSending(false);
+    }
   }
 
   return (
-    <div className="bg-parchment-2 border border-border rounded-lg px-3 py-2.5 mb-3 flex items-center flex-wrap gap-y-2.5 gap-x-3.5">
-      <div className="flex items-center gap-2 text-[13px] text-walnut-2 min-w-0 flex-1 basis-50 font-serif italic">
-        {!hasEmail && (
-          <span>No email on file — deliver a printed letter or reach out directly.</span>
-        )}
-        {hasEmail && emailValid && (
-          <>
-            <MailIcon />
-            <span className="truncate">
-              Send invitation to{" "}
-              <strong className="font-semibold not-italic text-bordeaux font-sans">{email}</strong>
+    <div className="bg-parchment-2 border border-border rounded-lg px-3 py-2.5 mb-3 flex flex-col gap-2">
+      <div className="flex items-center flex-wrap gap-y-2.5 gap-x-3.5">
+        <div className="flex items-center gap-2 text-[13px] text-walnut-2 min-w-0 flex-1 basis-50 font-serif italic">
+          {!hasEmail && (
+            <span>No email on file — deliver a printed letter or reach out directly.</span>
+          )}
+          {hasEmail && emailValid && (
+            <>
+              <MailIcon />
+              <span className="truncate">
+                Send invitation to{" "}
+                <strong className="font-semibold not-italic text-bordeaux font-sans">
+                  {email}
+                </strong>
+              </span>
+            </>
+          )}
+          {hasEmail && !emailValid && (
+            <span className="text-bordeaux">
+              Invalid email format — fix the address or deliver a printed letter.
             </span>
-          </>
-        )}
-        {hasEmail && !emailValid && (
-          <span className="text-bordeaux">
-            Invalid email format — fix the address or deliver a printed letter.
-          </span>
-        )}
-      </div>
-      <div className="inline-flex gap-1.5 shrink-0 flex-wrap ml-auto">
-        <Btn onClick={onMarkInvited} icon={invited ? <CheckIcon /> : null}>
-          Mark invited
-        </Btn>
-        <Btn onClick={onPrint} icon={<PrintIcon />} primary={!emailValid}>
-          Print letter
-        </Btn>
-        {hasEmail && (
-          <Btn onClick={handleSendEmail} icon={<SendIcon />} primary disabled={!emailValid}>
-            Send email
+          )}
+        </div>
+        <div className="inline-flex gap-1.5 shrink-0 flex-wrap ml-auto">
+          <Btn onClick={onMarkInvited} icon={invited ? <CheckIcon /> : null}>
+            Mark invited
           </Btn>
-        )}
+          <Btn onClick={onPrint} icon={<PrintIcon />} primary={!emailValid}>
+            Print letter
+          </Btn>
+          {hasEmail && (
+            <Btn
+              onClick={() => void handleSendEmail()}
+              icon={<SendIcon />}
+              primary
+              disabled={!emailValid || !persisted || sending}
+            >
+              {sending ? "Sending…" : "Send email"}
+            </Btn>
+          )}
+        </div>
       </div>
+      {hasEmail && emailValid && !persisted && (
+        <p className="font-sans text-[11.5px] text-walnut-3">
+          Save the speaker first to enable email — we generate a personal invitation link tied to
+          this row.
+        </p>
+      )}
+      {error && <p className="font-sans text-[12px] text-bordeaux">{error}</p>}
     </div>
   );
 }
@@ -92,4 +139,14 @@ function Btn({
       {children}
     </button>
   );
+}
+
+function prettyDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
 }

--- a/src/features/templates/sendSpeakerInvitation.ts
+++ b/src/features/templates/sendSpeakerInvitation.ts
@@ -1,0 +1,104 @@
+import { addDoc, collection, doc, getDoc, serverTimestamp } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { speakerLetterTemplateSchema, type SpeakerInvitation, wardSchema } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import {
+  DEFAULT_SPEAKER_LETTER_BODY,
+  DEFAULT_SPEAKER_LETTER_FOOTER,
+} from "./speakerLetterDefaults";
+import { interpolate } from "./interpolate";
+
+export interface SendSpeakerInvitationInput {
+  wardId: string;
+  meetingDate: string; // ISO YYYY-MM-DD
+  speakerId: string;
+  speakerName: string;
+  speakerTopic?: string | undefined;
+  inviterName: string;
+}
+
+/**
+ * Snapshot the current ward template + speaker details into a new
+ * `wards/{wardId}/speakerInvitations/{autoId}` doc and return the
+ * token (= doc ID). The caller uses the token to build the public
+ * landing URL.
+ *
+ * The returned invitation is self-contained: the recipient never
+ * reads the template or speaker doc, so we don't need cross-doc
+ * public reads.
+ */
+export async function sendSpeakerInvitation(
+  input: SendSpeakerInvitationInput,
+): Promise<{ token: string }> {
+  reportSaving();
+  try {
+    const [templateSnap, wardSnap] = await Promise.all([
+      getDoc(doc(db, "wards", input.wardId, "templates", "speakerLetter")),
+      getDoc(doc(db, "wards", input.wardId)),
+    ]);
+    const parsedTemplate = templateSnap.exists()
+      ? speakerLetterTemplateSchema.safeParse(templateSnap.data())
+      : null;
+    const template = parsedTemplate?.success ? parsedTemplate.data : null;
+    const wardName = wardSnap.exists() ? wardSchema.parse(wardSnap.data()).name : "";
+
+    const vars = {
+      speakerName: input.speakerName,
+      topic:
+        input.speakerTopic && input.speakerTopic.trim().length > 0
+          ? input.speakerTopic
+          : "a topic of your choosing",
+      date: formatAssignedDate(input.meetingDate),
+      today: formatToday(),
+      wardName,
+      inviterName: input.inviterName,
+    };
+
+    const bodyMarkdown = interpolate(template?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY, vars);
+    const footerMarkdown = interpolate(
+      template?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+      vars,
+    );
+
+    const payload: Omit<SpeakerInvitation, "createdAt"> = {
+      speakerRef: { meetingDate: input.meetingDate, speakerId: input.speakerId },
+      assignedDate: vars.date,
+      sentOn: vars.today,
+      wardName,
+      speakerName: input.speakerName,
+      speakerTopic: input.speakerTopic,
+      inviterName: input.inviterName,
+      bodyMarkdown,
+      footerMarkdown,
+    };
+
+    const ref = await addDoc(collection(db, "wards", input.wardId, "speakerInvitations"), {
+      ...payload,
+      createdAt: serverTimestamp(),
+    });
+    reportSaved();
+    return { token: ref.id };
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+function formatAssignedDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function formatToday(): string {
+  return new Date().toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/src/features/templates/useSpeakerInvitation.ts
+++ b/src/features/templates/useSpeakerInvitation.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { speakerInvitationSchema, type SpeakerInvitation } from "@/lib/types";
+
+export type SpeakerInvitationState =
+  | { kind: "loading" }
+  | { kind: "not-found" }
+  | { kind: "error"; message: string }
+  | { kind: "ready"; invitation: SpeakerInvitation };
+
+/**
+ * One-shot public read of a speaker invitation by its token doc ID.
+ * Not a live subscription — the letter content is a frozen snapshot,
+ * so a single fetch is correct.
+ */
+export function useSpeakerInvitation(
+  wardId: string | undefined,
+  token: string | undefined,
+): SpeakerInvitationState {
+  const [state, setState] = useState<SpeakerInvitationState>({ kind: "loading" });
+
+  useEffect(() => {
+    if (!wardId || !token) {
+      setState({ kind: "not-found" });
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const snap = await getDoc(doc(db, "wards", wardId, "speakerInvitations", token));
+        if (cancelled) return;
+        if (!snap.exists()) {
+          setState({ kind: "not-found" });
+          return;
+        }
+        const parsed = speakerInvitationSchema.safeParse(snap.data());
+        if (!parsed.success) {
+          setState({ kind: "error", message: "Invitation is malformed." });
+          return;
+        }
+        setState({ kind: "ready", invitation: parsed.data });
+      } catch (e) {
+        if (cancelled) return;
+        setState({ kind: "error", message: (e as Error).message });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [wardId, token]);
+
+  return state;
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -5,4 +5,5 @@ export * from "./history";
 export * from "./member";
 export * from "./invite";
 export * from "./template";
+export * from "./speakerInvitation";
 export * from "./ward";

--- a/src/lib/types/speakerInvitation.ts
+++ b/src/lib/types/speakerInvitation.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+/**
+ * A frozen snapshot of a speaker invitation letter, stored under
+ * `wards/{wardId}/speakerInvitations/{token}`. The doc's auto-
+ * generated ID doubles as the shareable link token: anyone with the
+ * URL can read the doc (rule: `allow read: if true`), which is safe
+ * because the token is unguessable (~120 bits of entropy from
+ * Firestore's auto-ID).
+ *
+ * Snapshotting means the speaker keeps the exact letter they were
+ * sent, even if the ward edits the template later.
+ */
+export const speakerInvitationSchema = z.object({
+  /** Denormalized speaker reference back to the originating doc. */
+  speakerRef: z.object({
+    meetingDate: z.string(), // ISO YYYY-MM-DD
+    speakerId: z.string().min(1),
+  }),
+  /** Pre-formatted "Sunday, April 26, 2026" for the assigned-Sunday callout. */
+  assignedDate: z.string().min(1),
+  /** Pre-formatted "April 21, 2026" for the letter date line. */
+  sentOn: z.string().min(1),
+  wardName: z.string(),
+  speakerName: z.string().min(1),
+  speakerTopic: z.string().optional(),
+  inviterName: z.string().min(1),
+  /** Markdown body post-interpolation — all `{{vars}}` already replaced. */
+  bodyMarkdown: z.string(),
+  /** Scripture footer post-interpolation. */
+  footerMarkdown: z.string(),
+  createdAt: z.any().optional(),
+});
+export type SpeakerInvitation = z.infer<typeof speakerInvitationSchema>;

--- a/tests/rules/speakerInvitations.test.ts
+++ b/tests/rules/speakerInvitations.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, beforeEach, describe, it } from "vitest";
+import {
+  assertFails,
+  assertSucceeds,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing";
+import { deleteDoc, doc, setDoc } from "firebase/firestore";
+import { authedAs, createTestEnv, seedMember, seedWard } from "./_helpers";
+
+const WARD = "w1";
+const TOKEN = "ABC123abcDEF456";
+const PATH = `wards/${WARD}/speakerInvitations/${TOKEN}`;
+
+const sample = {
+  speakerRef: { meetingDate: "2026-04-26", speakerId: "s1" },
+  assignedDate: "Sunday, April 26, 2026",
+  sentOn: "April 21, 2026",
+  wardName: "Eglinton Ward",
+  speakerName: "Sebastian Tan",
+  speakerTopic: "Repentance",
+  inviterName: "Bishop Paul",
+  bodyMarkdown: "Dear Sebastian Tan, …",
+  footerMarkdown: "And all things whatsoever …",
+};
+
+async function seedInvitation(env: RulesTestEnvironment) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await setDoc(doc(ctx.firestore(), PATH), sample);
+  });
+}
+
+describe("speaker invitation rules", () => {
+  let env: RulesTestEnvironment;
+  beforeAll(async () => {
+    env = await createTestEnv();
+  });
+  afterAll(async () => {
+    await env.cleanup();
+  });
+  beforeEach(async () => {
+    await env.clearFirestore();
+    await seedWard(env, WARD);
+    await seedMember(env, { wardId: WARD, uid: "bishop", email: "b@x.com", role: "bishopric" });
+    await seedMember(env, { wardId: WARD, uid: "clerk", email: "c@x.com", role: "clerk" });
+  });
+
+  describe("read (public)", () => {
+    it("lets an anonymous user read the invitation by token", async () => {
+      await seedInvitation(env);
+      const db = env.unauthenticatedContext().firestore();
+      await assertSucceeds(
+        import("firebase/firestore").then(({ getDoc }) => getDoc(doc(db, PATH))),
+      );
+    });
+
+    it("lets a signed-in non-member read the invitation by token", async () => {
+      await seedInvitation(env);
+      const db = authedAs(env, "stranger", "s@x.com").firestore();
+      await assertSucceeds(
+        import("firebase/firestore").then(({ getDoc }) => getDoc(doc(db, PATH))),
+      );
+    });
+  });
+
+  describe("write (bishopric / clerk only)", () => {
+    it("lets an active bishopric member send an invitation", async () => {
+      const db = authedAs(env, "bishop", "b@x.com").firestore();
+      await assertSucceeds(setDoc(doc(db, PATH), sample));
+    });
+
+    it("lets an active clerk send an invitation", async () => {
+      const db = authedAs(env, "clerk", "c@x.com").firestore();
+      await assertSucceeds(setDoc(doc(db, PATH), sample));
+    });
+
+    it("blocks an anonymous user from creating an invitation", async () => {
+      const db = env.unauthenticatedContext().firestore();
+      await assertFails(setDoc(doc(db, PATH), sample));
+    });
+
+    it("blocks a signed-in non-member from creating an invitation", async () => {
+      const db = authedAs(env, "stranger", "s@x.com").firestore();
+      await assertFails(setDoc(doc(db, PATH), sample));
+    });
+
+    it("lets an active member delete their ward's invitation", async () => {
+      await seedInvitation(env);
+      const db = authedAs(env, "clerk", "c@x.com").firestore();
+      await assertSucceeds(deleteDoc(doc(db, PATH)));
+    });
+
+    it("blocks an anonymous user from deleting the invitation", async () => {
+      await seedInvitation(env);
+      const db = env.unauthenticatedContext().firestore();
+      await assertFails(deleteDoc(doc(db, PATH)));
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Re-opened after the stacked-PR got auto-closed on rebase when #10 merged. Content is unchanged from the original #11 description — rebased onto ``develop`` now that slice 1 has landed.

Ships the recipient-facing side of the letter end-to-end: the bishop clicks **Send email** on a planned speaker, the recipient opens a polished landing page at ``/invite/speaker/{wardId}/{token}``, no auth required.

Refs #8.

## What's in it

### Data
- ``wards/{wardId}/speakerInvitations/{token}`` subcollection. Auto-generated doc ID doubles as the URL token (Firestore auto-IDs are ~120 bits of entropy — unguessable).
- ``speakerInvitationSchema``: a **frozen snapshot** of the letter — speaker name/topic, ward name, pre-formatted dates, inviter name, post-interpolation body + footer Markdown. The letter stays as the speaker received it even if the ward edits the template later.
- ``sendSpeakerInvitation()`` reads the current template (falls back to defaults), resolves all ``{{vars}}``, writes the snapshot, returns the token.

### Rules
``match /speakerInvitations/{token}`` — ``allow read: if true`` (the URL is the auth), ``create/update/delete`` gated to active members.

### UI
- ``/invite/speaker/:wardId/:token`` — public route outside AuthGate. Renders ``LetterCanvas`` at letter-sheet size against the parchment backdrop from the v2 design.
- Empty / not-found / malformed states each get a friendly card.
- ``InviteAction``'s **Send email** button now calls ``sendSpeakerInvitation`` and opens a mailto with a short lead-in + the landing URL. Disabled with a helpful hint when the draft isn't saved yet.

### Tests
- **+8 rules tests** (84 total) — anonymous read, stranger-write block, bishopric/clerk write, member delete, anon-delete block.
- Unit tests all still green (197).

## Test plan

- [ ] CI green on this PR
- [ ] End-to-end: edit the template in ``/settings/templates/speakers`` → save → on a planned speaker with an email, click **Send email** → mailto opens with the landing URL → opening the URL in another browser (incognito, no sign-in) shows the letter at letter-sheet size

## Out of scope (next slices)

- PDF download from the landing page (slice 3)
- Per-speaker template override before sending (slice 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)