### PR TITLE
feat(templates): print / save-as-PDF on the speaker landing (slice 3 of #8)

### DIFF
--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -14,8 +14,10 @@ export function SpeakerInvitationLandingPage() {
   const state = useSpeakerInvitation(wardId, token);
 
   return (
-    <main className="min-h-dvh bg-[#e6ddc7] py-10 px-4 sm:px-6 flex items-start justify-center">
+    <main className="min-h-dvh bg-[#e6ddc7] py-10 px-4 sm:px-6 flex items-start justify-center print:bg-white print:py-0 print:px-0">
+      {state.kind === "ready" && <PrintToolbar />}
       <Body state={state} />
+      <PrintStyles />
     </main>
   );
 }
@@ -24,9 +26,7 @@ function Body({ state }: { state: ReturnType<typeof useSpeakerInvitation> }) {
   if (state.kind === "loading") {
     return <div className="mt-20 font-serif italic text-[14px] text-walnut-2">Loading letter…</div>;
   }
-  if (state.kind === "not-found") {
-    return <NotFound />;
-  }
+  if (state.kind === "not-found") return <NotFound />;
   if (state.kind === "error") {
     return (
       <div className="mt-20 max-w-md rounded-lg border border-border bg-chalk p-6 text-center">
@@ -44,6 +44,61 @@ function Body({ state }: { state: ReturnType<typeof useSpeakerInvitation> }) {
       bodyMarkdown={invitation.bodyMarkdown}
       footerMarkdown={invitation.footerMarkdown}
     />
+  );
+}
+
+function PrintToolbar() {
+  return (
+    <div className="print:hidden fixed top-4 right-4 z-10 flex gap-2">
+      <button
+        type="button"
+        onClick={() => window.print()}
+        className="inline-flex items-center gap-1.5 rounded-md border border-walnut bg-walnut px-3.5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-chalk hover:bg-walnut-2 shadow-elev-2"
+      >
+        <PrinterIcon />
+        Print · Save as PDF
+      </button>
+    </div>
+  );
+}
+
+function PrinterIcon() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M6 9V2h12v7" />
+      <rect x="3" y="9" width="18" height="9" rx="2" />
+      <path d="M6 14h12v7H6z" />
+    </svg>
+  );
+}
+
+/**
+ * Print-only overrides for the landing page. The letter itself is
+ * designed to look like a physical page (8.5×11, parchment border
+ * inset, mono eyebrows) — print CSS just needs to flatten the
+ * drop shadow, zero the page margins (the letter has its own inner
+ * margin), and keep the whole letter on one sheet.
+ */
+function PrintStyles() {
+  return (
+    <style>{`
+      @media print {
+        @page { size: letter; margin: 0; }
+        html, body { background: #ffffff !important; }
+        .print\\:hidden { display: none !important; }
+        /* Drop any LetterCanvas shadow in print */
+        [class*="shadow-"] { box-shadow: none !important; }
+      }
+    `}</style>
   );
 }
 


### PR DESCRIPTION
## Summary

Stacked on #12. Adds a quiet **Print · Save as PDF** button to the top-right of the public speaker invitation landing page. Clicking it triggers ``window.print()``; the speaker gets the browser's native print dialog and picks either a physical printer or "Save as PDF" as the destination.

No server-side PDF, no ``html2pdf.js`` / ``jsPDF`` dep, ~60 lines of code total. The letter was already designed at letter-sheet proportions in slice 2, so print just flattens the shadow and zeroes the ``@page`` margin.

Refs #8.

## What's in it

- ``PrintToolbar`` — fixed top-right, shows only when the invitation loaded successfully, hidden in print
- ``PrintStyles`` — single ``<style>`` tag with ``@media print`` overrides: ``@page { size: letter; margin: 0 }``, body background white, drop any ``shadow-*`` utility
- The main wrapper gets ``print:bg-white print:py-0 print:px-0``

## Merge order

1. Merge #12 first (slice 2 — landing page)
2. Rebase this onto ``develop``
3. Merge this

## Test plan

- [ ] CI green
- [ ] Send an invitation, open the URL in a browser
- [ ] Click **Print · Save as PDF** → print preview appears with the letter on one sheet, toolbar hidden, no drop shadow, no parchment backdrop (white sheet only)

## Out of scope (slice 4)

- Per-speaker template override in the speaker edit modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)