### PR TITLE
feat(templates): per-speaker letter override (slice 4 of #8)

### DIFF
--- a/src/features/schedule/SpeakerCardHeader.tsx
+++ b/src/features/schedule/SpeakerCardHeader.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/cn";
+import { RemoveIcon } from "./SpeakerInviteIcons";
+
+interface Props {
+  index: number;
+  canEditLetter: boolean;
+  onEditLetter: () => void;
+  onRemove: () => void;
+}
+
+/** The top row of a SpeakerEditCard: "Speaker · 01" label, optional
+ *  "Edit letter" action, and the remove button. Extracted to keep the
+ *  card under the 150-LOC ceiling. */
+export function SpeakerCardHeader({ index, canEditLetter, onEditLetter, onRemove }: Props) {
+  return (
+    <div className="flex items-center gap-2 mb-2.5">
+      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+        Speaker · {String(index + 1).padStart(2, "0")}
+      </span>
+      {canEditLetter && (
+        <button
+          type="button"
+          onClick={onEditLetter}
+          className="ml-auto font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 hover:text-bordeaux px-2 py-1 rounded hover:bg-parchment-2 transition-colors"
+        >
+          Edit letter
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label="Remove speaker"
+        className={cn(
+          "text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 rounded p-1 transition-colors",
+          !canEditLetter && "ml-auto",
+        )}
+      >
+        <RemoveIcon />
+      </button>
+    </div>
+  );
+}

--- a/src/features/schedule/SpeakerEditCard.tsx
+++ b/src/features/schedule/SpeakerEditCard.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react";
 import { SPEAKER_ROLES } from "@/lib/types";
+import { SpeakerLetterOverrideDialog } from "@/features/templates/SpeakerLetterOverrideDialog";
 import { cn } from "@/lib/cn";
 import { isValidEmail } from "@/lib/email";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { printInvitationLetter } from "./printInvitationLetter";
+import { SpeakerCardHeader } from "./SpeakerCardHeader";
 import type { Draft } from "./speakerDraft";
 import { InviteAction } from "./SpeakerInviteAction";
-import { RemoveIcon } from "./SpeakerInviteIcons";
 import { SpeakerStatusPills } from "./SpeakerStatusPills";
 
 interface Props {
@@ -21,18 +24,31 @@ const INPUT_CLS =
 const LABEL_CLS = "font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep font-medium";
 
 export function SpeakerEditCard({ draft, index, date, onChange, onRemove }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const [overrideOpen, setOverrideOpen] = useState(false);
+  const persisted = draft.id !== null;
+  const canEditLetter = persisted && Boolean(wardId);
+
   return (
     <div className="bg-chalk border border-border rounded-lg p-3">
-      <div className="flex items-center gap-2 mb-2.5">
-        <span className={LABEL_CLS}>Speaker · {String(index + 1).padStart(2, "0")}</span>
-        <button
-          onClick={onRemove}
-          className="ml-auto text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 rounded p-1 transition-colors"
-          aria-label="Remove speaker"
-        >
-          <RemoveIcon />
-        </button>
-      </div>
+      <SpeakerCardHeader
+        index={index}
+        canEditLetter={canEditLetter}
+        onEditLetter={() => setOverrideOpen(true)}
+        onRemove={onRemove}
+      />
+
+      {wardId && draft.id && (
+        <SpeakerLetterOverrideDialog
+          wardId={wardId}
+          date={date}
+          speakerId={draft.id}
+          speakerName={draft.name}
+          speakerTopic={draft.topic}
+          open={overrideOpen}
+          onClose={() => setOverrideOpen(false)}
+        />
+      )}
 
       <SpeakerStatusPills status={draft.status} onChange={(status) => onChange({ status })} />
 

--- a/src/features/templates/OverrideDialogFooter.tsx
+++ b/src/features/templates/OverrideDialogFooter.tsx
@@ -1,0 +1,43 @@
+interface Props {
+  saving: boolean;
+  canReset: boolean;
+  onCancel: () => void;
+  onReset: () => void;
+  onSave: () => void;
+}
+
+/** Cancel / Reset / Save footer extracted from
+ *  SpeakerLetterOverrideDialog to keep the dialog under the 150-LOC
+ *  ceiling. */
+export function OverrideDialogFooter({ saving, canReset, onCancel, onReset, onSave }: Props) {
+  return (
+    <div className="mt-5 flex flex-wrap justify-end gap-2">
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={saving}
+        className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+      >
+        Cancel
+      </button>
+      {canReset && (
+        <button
+          type="button"
+          onClick={onReset}
+          disabled={saving}
+          className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+        >
+          {saving ? "Resetting…" : "Reset to ward default"}
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={saving}
+        className="rounded-md border border-bordeaux bg-bordeaux px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed"
+      >
+        {saving ? "Saving…" : "Save override"}
+      </button>
+    </div>
+  );
+}

--- a/src/features/templates/SpeakerLetterOverrideDialog.tsx
+++ b/src/features/templates/SpeakerLetterOverrideDialog.tsx
@@ -1,0 +1,118 @@
+import { useMemo } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { LetterCanvas } from "./LetterCanvas";
+import { OverrideDialogFooter } from "./OverrideDialogFooter";
+import { EditorSection } from "./SpeakerLetterEditor";
+import { interpolate } from "./interpolate";
+import { formatAssignedDate, formatToday } from "./letterDates";
+import { useLetterOverrideForm } from "./useLetterOverrideForm";
+import { useSpeakerLetterTemplate } from "./useSpeakerLetterTemplate";
+
+interface Props {
+  wardId: string;
+  date: string;
+  speakerId: string;
+  speakerName: string;
+  speakerTopic: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Per-speaker override editor. Starts from the current override (if
+ * any) or the ward template. Variables stay as `{{tokens}}` in the
+ * stored Markdown; the preview shows them interpolated for this
+ * speaker so the sender reads it the way the recipient will.
+ */
+export function SpeakerLetterOverrideDialog(props: Props) {
+  const { wardId, date, speakerId, speakerName, speakerTopic, open, onClose } = props;
+  const ward = useWardSettings();
+  const { data: template } = useSpeakerLetterTemplate();
+  const form = useLetterOverrideForm({
+    wardId,
+    date,
+    speakerId,
+    open,
+    template,
+    onDone: onClose,
+  });
+  useLockBodyScroll(open);
+
+  const wardName = ward.data?.name ?? "";
+  const vars = useMemo(
+    () => ({
+      speakerName,
+      topic: speakerTopic.trim() || "a topic of your choosing",
+      date: formatAssignedDate(date),
+      today: formatToday(),
+      wardName,
+      inviterName: "Bishop (example)",
+    }),
+    [speakerName, speakerTopic, date, wardName],
+  );
+  const renderedBody = useMemo(() => interpolate(form.body, vars), [form.body, vars]);
+  const renderedFooter = useMemo(() => interpolate(form.footer, vars), [form.footer, vars]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 grid place-items-center bg-black/30 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Edit letter for ${speakerName}`}
+    >
+      <div className="w-full max-w-230 max-h-[90vh] overflow-auto rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+        <div className="mb-4 font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+          Per-speaker letter
+        </div>
+        <h2 className="font-display text-[20px] font-semibold text-walnut mb-1">
+          Edit letter for {speakerName}
+        </h2>
+        <p className="mb-5 font-serif italic text-[13px] text-walnut-3">
+          Tweaks live on this speaker only; the ward default stays as-is.
+          {form.hasOverride ? " Reset to return to the ward default." : ""}
+        </p>
+
+        <div className="grid gap-6 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <div className="flex flex-col gap-4">
+            <EditorSection
+              label="Letter body"
+              initialMarkdown={form.body}
+              onChange={form.setBody}
+            />
+            <EditorSection
+              label="Footer (scripture)"
+              initialMarkdown={form.footer}
+              onChange={form.setFooter}
+            />
+          </div>
+          <aside className="flex flex-col gap-2">
+            <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
+              Preview — this speaker
+            </div>
+            <LetterCanvas
+              compact
+              wardName={wardName}
+              assignedDate={vars.date}
+              today={vars.today}
+              bodyMarkdown={renderedBody}
+              footerMarkdown={renderedFooter}
+            />
+          </aside>
+        </div>
+
+        {form.error && <p className="mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>}
+
+        <OverrideDialogFooter
+          saving={form.saving}
+          canReset={Boolean(form.hasOverride)}
+          onCancel={onClose}
+          onReset={() => void form.reset()}
+          onSave={() => void form.save()}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/features/templates/letterDates.ts
+++ b/src/features/templates/letterDates.ts
@@ -1,0 +1,23 @@
+/** Shared letter-date formatters. The assigned Sunday (e.g. "Sunday,
+ *  April 26, 2026") and today (e.g. "April 21, 2026") are rendered
+ *  identically by both `sendSpeakerInvitation` at snapshot time and
+ *  the override-dialog preview at author time. */
+
+export function formatAssignedDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function formatToday(): string {
+  return new Date().toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}

--- a/src/features/templates/sendSpeakerInvitation.ts
+++ b/src/features/templates/sendSpeakerInvitation.ts
@@ -1,12 +1,18 @@
 import { addDoc, collection, doc, getDoc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
-import { speakerLetterTemplateSchema, type SpeakerInvitation, wardSchema } from "@/lib/types";
+import {
+  speakerLetterTemplateSchema,
+  speakerSchema,
+  type SpeakerInvitation,
+  wardSchema,
+} from "@/lib/types";
 import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
 import {
   DEFAULT_SPEAKER_LETTER_BODY,
   DEFAULT_SPEAKER_LETTER_FOOTER,
 } from "./speakerLetterDefaults";
 import { interpolate } from "./interpolate";
+import { formatAssignedDate, formatToday } from "./letterDates";
 
 export interface SendSpeakerInvitationInput {
   wardId: string;
@@ -32,15 +38,24 @@ export async function sendSpeakerInvitation(
 ): Promise<{ token: string }> {
   reportSaving();
   try {
-    const [templateSnap, wardSnap] = await Promise.all([
+    const [templateSnap, wardSnap, speakerSnap] = await Promise.all([
       getDoc(doc(db, "wards", input.wardId, "templates", "speakerLetter")),
       getDoc(doc(db, "wards", input.wardId)),
+      getDoc(
+        doc(db, "wards", input.wardId, "meetings", input.meetingDate, "speakers", input.speakerId),
+      ),
     ]);
     const parsedTemplate = templateSnap.exists()
       ? speakerLetterTemplateSchema.safeParse(templateSnap.data())
       : null;
     const template = parsedTemplate?.success ? parsedTemplate.data : null;
     const wardName = wardSnap.exists() ? wardSchema.parse(wardSnap.data()).name : "";
+    const parsedSpeaker = speakerSnap.exists() ? speakerSchema.safeParse(speakerSnap.data()) : null;
+    // Per-speaker override wins over the ward default, if present.
+    const source =
+      parsedSpeaker?.success && parsedSpeaker.data.letterOverride
+        ? parsedSpeaker.data.letterOverride
+        : template;
 
     const vars = {
       speakerName: input.speakerName,
@@ -54,9 +69,9 @@ export async function sendSpeakerInvitation(
       inviterName: input.inviterName,
     };
 
-    const bodyMarkdown = interpolate(template?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY, vars);
+    const bodyMarkdown = interpolate(source?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY, vars);
     const footerMarkdown = interpolate(
-      template?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+      source?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
       vars,
     );
 
@@ -82,23 +97,4 @@ export async function sendSpeakerInvitation(
     reportSaveError(e);
     throw e;
   }
-}
-
-function formatAssignedDate(iso: string): string {
-  const [y, m, d] = iso.split("-").map(Number);
-  if (!y || !m || !d) return iso;
-  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
-}
-
-function formatToday(): string {
-  return new Date().toLocaleDateString(undefined, {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  });
 }

--- a/src/features/templates/speakerLetterOverride.ts
+++ b/src/features/templates/speakerLetterOverride.ts
@@ -1,0 +1,61 @@
+import { deleteField, doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+function speakerRef(wardId: string, date: string, speakerId: string) {
+  return doc(db, "wards", wardId, "meetings", date, "speakers", speakerId);
+}
+
+export interface LetterOverrideInput {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+}
+
+/**
+ * Write a per-speaker override of the ward invitation letter template.
+ * Stored as Markdown with `{{variable}}` tokens intact — variables are
+ * resolved at send time (see `sendSpeakerInvitation`). The override
+ * persists on the speaker doc until explicitly cleared.
+ */
+export async function saveSpeakerLetterOverride(
+  wardId: string,
+  date: string,
+  speakerId: string,
+  input: LetterOverrideInput,
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(speakerRef(wardId, date, speakerId), {
+      letterOverride: {
+        bodyMarkdown: input.bodyMarkdown,
+        footerMarkdown: input.footerMarkdown,
+        updatedAt: serverTimestamp(),
+      },
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+/** Remove a per-speaker override so the next send falls back to the
+ *  ward default template. */
+export async function clearSpeakerLetterOverride(
+  wardId: string,
+  date: string,
+  speakerId: string,
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(speakerRef(wardId, date, speakerId), {
+      letterOverride: deleteField(),
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/templates/useLetterOverrideForm.ts
+++ b/src/features/templates/useLetterOverrideForm.ts
@@ -1,0 +1,87 @@
+import { useEffect, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { speakerSchema, type SpeakerLetterTemplate } from "@/lib/types";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import {
+  DEFAULT_SPEAKER_LETTER_BODY,
+  DEFAULT_SPEAKER_LETTER_FOOTER,
+} from "./speakerLetterDefaults";
+import { clearSpeakerLetterOverride, saveSpeakerLetterOverride } from "./speakerLetterOverride";
+
+interface Args {
+  wardId: string;
+  date: string;
+  speakerId: string;
+  open: boolean;
+  template: SpeakerLetterTemplate | null;
+  onDone: () => void;
+}
+
+/** Encapsulates the seed-from-override-or-template-or-defaults hydration,
+ *  save / reset handlers, and busy / error state so the dialog itself
+ *  stays focused on layout. */
+export function useLetterOverrideForm(args: Args) {
+  const { wardId, date, speakerId, open, template, onDone } = args;
+  const [body, setBody] = useState("");
+  const [footer, setFooter] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [hasOverride, setHasOverride] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      // Re-read the speaker doc on each open so we show the latest
+      // override if another session edited it.
+      const snap = await getDoc(doc(db, "wards", wardId, "meetings", date, "speakers", speakerId));
+      if (cancelled) return;
+      const parsed = snap.exists() ? speakerSchema.safeParse(snap.data()) : null;
+      const override = parsed?.success ? parsed.data.letterOverride : undefined;
+      const src = override ??
+        template ?? {
+          bodyMarkdown: DEFAULT_SPEAKER_LETTER_BODY,
+          footerMarkdown: DEFAULT_SPEAKER_LETTER_FOOTER,
+        };
+      setBody(src.bodyMarkdown);
+      setFooter(src.footerMarkdown);
+      setHasOverride(Boolean(override));
+      setError(null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, wardId, date, speakerId, template]);
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await saveSpeakerLetterOverride(wardId, date, speakerId, {
+        bodyMarkdown: body,
+        footerMarkdown: footer,
+      });
+      onDone();
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function reset() {
+    setSaving(true);
+    setError(null);
+    try {
+      await clearSpeakerLetterOverride(wardId, date, speakerId);
+      onDone();
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return { body, footer, setBody, setFooter, error, saving, save, reset, hasOverride };
+}

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -109,6 +109,17 @@ export const sacramentMeetingSchema = z.object({
 });
 export type SacramentMeeting = z.infer<typeof sacramentMeetingSchema>;
 
+// Per-speaker override of the ward invitation letter template. Stored
+// as Markdown with `{{variable}}` tokens still intact — tokens are
+// resolved at send time so `{{today}}` etc. stay current. Absent
+// override means "use the ward default template".
+export const speakerLetterOverrideSchema = z.object({
+  bodyMarkdown: z.string(),
+  footerMarkdown: z.string(),
+  updatedAt: z.any().optional(),
+});
+export type SpeakerLetterOverride = z.infer<typeof speakerLetterOverrideSchema>;
+
 // Tolerate legacy speaker docs that stored a status outside the current
 // enum (e.g. "draft", "sent") — fall back to "planned" rather than failing
 // the whole list parse.
@@ -119,6 +130,7 @@ export const speakerSchema = z.object({
   status: speakerStatusSchema.catch("planned"),
   role: speakerRoleSchema.catch("Member"),
   order: z.number().int().min(0).optional(),
+  letterOverride: speakerLetterOverrideSchema.optional(),
   createdAt: z.any().optional(),
   updatedAt: z.any().optional(),
 });


### PR DESCRIPTION
## Summary

Last slice for #8. A sender can now tweak the letter for a specific speaker before sending, without touching the ward default.

**Fixes #8** — this PR closes the whole feature. Four-slice rollup: template editor (#10), public landing page (#12), print/save-as-PDF (#14), per-speaker override (this one).

## What's in it

### Data
- ``speakerSchema`` gets an optional ``letterOverride: { bodyMarkdown, footerMarkdown, updatedAt }``. The stored Markdown keeps ``{{var}}`` tokens intact — ``sendSpeakerInvitation`` resolves them at send time so ``{{today}}``, ``{{inviterName}}``, etc. stay current.
- ``saveSpeakerLetterOverride`` / ``clearSpeakerLetterOverride`` — write through the existing ``speakers/{id}`` doc path, reusing the speaker rule. No new Firestore rule needed.
- ``sendSpeakerInvitation`` now reads the speaker doc too and prefers the override over the ward template.

### UI
- ``SpeakerLetterOverrideDialog`` — side-by-side MDXEditor (body + footer) + live ``LetterCanvas`` preview with this speaker's variables interpolated. Seeds from: existing override → ward template → hardcoded defaults (in that order). Cancel / Reset to ward default / Save.
- **Edit letter** button in the speaker card header. Shown only for persisted speakers (override lives on a ``speakerId``, so the row must be saved first — matches the ``Send email`` gate from slice 2).
- Extracted ``SpeakerCardHeader`` + ``OverrideDialogFooter`` + ``letterDates.ts`` + ``useLetterOverrideForm.ts`` to keep the card + dialog under the 150-LOC ceiling.

### Tests
- Unit + rules all still green (197 unit, 84 rules) — no schema/rule changes needed beyond the optional speaker field.

## Merge order

1. Merge #14 first (slice 3 — print button) since it's already open + green
2. Then merge this (slice 4) to close #8

## Test plan

- [ ] CI green
- [ ] On a persisted planned speaker, click **Edit letter** → dialog opens with the ward template preloaded
- [ ] Make a tweak (change one sentence) → click Save → dialog closes
- [ ] Click **Send email** → the resulting landing page reflects the tweak
- [ ] Open the dialog again → "Reset to ward default" is visible → click it → dialog closes and future sends use the ward template

🤖 Generated with [Claude Code](https://claude.com/claude-code)