### PR TITLE
feat(templates): customizable ward-member invitation message

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -10,6 +10,7 @@ import { MembersPage } from "./routes/members";
 import { NotificationSettingsPage } from "./routes/notification-settings";
 import { SettingsIndex } from "./routes/settings";
 import { SpeakerLetterTemplatePage } from "./routes/templates-speakers";
+import { WardInviteTemplatePage } from "./routes/templates-ward-invites";
 import { WardSettingsPage } from "./routes/ward-settings";
 import { Week } from "./routes/week";
 
@@ -26,6 +27,7 @@ export const router = createBrowserRouter([
       { path: "settings/members", element: <MembersPage /> },
       { path: "settings/notifications", element: <NotificationSettingsPage /> },
       { path: "settings/templates/speakers", element: <SpeakerLetterTemplatePage /> },
+      { path: "settings/templates/ward-invites", element: <WardInviteTemplatePage /> },
     ],
   },
   // Print views share AuthGate's auth + ward resolution (so

--- a/src/app/routes/accept-invite.tsx
+++ b/src/app/routes/accept-invite.tsx
@@ -55,6 +55,7 @@ export function AcceptInvitePage() {
             calling: invite.calling,
             invitedByName: invite.invitedByName,
           },
+          messageBody: invite.messageBody,
         });
         return;
       }

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -21,6 +21,11 @@ const links = [
     label: "Speaker invitation letter",
     desc: "Ward default template shown to speakers + printed letter",
   },
+  {
+    to: "/settings/templates/ward-invites",
+    label: "Ward invitation message",
+    desc: "Greeting shown when you invite a new bishopric or clerk member",
+  },
 ];
 
 export function SettingsIndex() {

--- a/src/app/routes/templates-ward-invites.tsx
+++ b/src/app/routes/templates-ward-invites.tsx
@@ -1,0 +1,128 @@
+import Markdown from "react-markdown";
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router";
+import { EditorSection } from "@/features/templates/SpeakerLetterEditor";
+import { renderWardInviteMessage } from "@/features/templates/renderWardInviteMessage";
+import { useWardInviteTemplate } from "@/features/templates/useWardInviteTemplate";
+import { DEFAULT_WARD_INVITE_BODY } from "@/features/templates/wardInviteDefaults";
+import { writeWardInviteTemplate } from "@/features/templates/writeWardInviteTemplate";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+
+export function WardInviteTemplatePage() {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const ward = useWardSettings();
+  const me = useCurrentMember();
+  const { data: template, loading } = useWardInviteTemplate();
+
+  const [body, setBody] = useState(DEFAULT_WARD_INVITE_BODY);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (loading || seeded) return;
+    if (template) setBody(template.bodyMarkdown);
+    setSeeded(true);
+  }, [loading, seeded, template]);
+
+  const canEdit = Boolean(me?.data.active);
+  const wardName = ward.data?.name ?? "";
+
+  const preview = useMemo(
+    () =>
+      renderWardInviteMessage(
+        {
+          inviteeName: "Sister Hannah Reeves",
+          wardName: wardName || "Your Ward",
+          inviterName: me?.data.displayName ?? "Bishop",
+          calling: "ward_clerk",
+          role: "clerk",
+        },
+        { override: body, template: null },
+      ),
+    [body, wardName, me?.data.displayName],
+  );
+
+  async function handleSave() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeWardInviteTemplate(wardId, { bodyMarkdown: body });
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <main className="pb-16">
+      <nav className="mb-4 text-sm text-walnut-2">
+        <Link to="/settings" className="hover:text-walnut">
+          ← Settings
+        </Link>
+      </nav>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="font-display text-[24px] font-semibold text-walnut">
+          Ward invitation message
+        </h1>
+        <p className="font-serif text-[14px] text-walnut-2">
+          The greeting shown at the top of the accept-invite page and used as the{" "}
+          <code>mailto:</code> body. The sign-in link and "— Sent from Steward" footer are appended
+          automatically. Variables: <code>{"{{inviteeName}}"}</code>, <code>{"{{wardName}}"}</code>,{" "}
+          <code>{"{{inviterName}}"}</code>, <code>{"{{calling}}"}</code>, <code>{"{{role}}"}</code>.
+        </p>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-4">
+          <EditorSection
+            label="Invitation greeting"
+            initialMarkdown={body}
+            onChange={setBody}
+            disabled={!canEdit}
+          />
+          {error && <p className="font-sans text-[12.5px] text-bordeaux">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!canEdit || saving}
+              className="rounded-md border border-bordeaux bg-bordeaux px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {saving ? "Saving…" : "Save template"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setBody(DEFAULT_WARD_INVITE_BODY)}
+              disabled={!canEdit || saving}
+              className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+            >
+              Reset to default
+            </button>
+          </div>
+        </div>
+        <aside className="flex flex-col gap-2">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
+            Preview — sample data
+          </div>
+          <div className="rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-1">
+            <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep mb-3">
+              Ward invitation
+            </div>
+            <div className="prose prose-sm max-w-none font-serif text-[14px] text-walnut-2 leading-relaxed mb-4">
+              <Markdown>{preview}</Markdown>
+            </div>
+            <div className="rounded-md border border-border bg-parchment-2 p-3 text-center font-sans text-[12.5px] italic text-walnut-3">
+              [ Accept invite button appears here ]
+            </div>
+          </div>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/src/app/routes/templates-ward-invites.tsx
+++ b/src/app/routes/templates-ward-invites.tsx
@@ -35,10 +35,10 @@ export function WardInviteTemplatePage() {
     () =>
       renderWardInviteMessage(
         {
-          inviteeName: "Sister Hannah Reeves",
+          inviteeName: "Brother Lloyd Flores",
           wardName: wardName || "Your Ward",
           inviterName: me?.data.displayName ?? "Bishop",
-          calling: "ward_clerk",
+          calling: "executive_secretary",
           role: "clerk",
         },
         { override: body, template: null },

--- a/src/features/invites/AcceptInviteBody.tsx
+++ b/src/features/invites/AcceptInviteBody.tsx
@@ -1,10 +1,11 @@
+import Markdown from "react-markdown";
 import type { PendingInvite } from "@/features/invites/inviteActions";
 import { CALLING_LABELS } from "@/features/settings/callingLabels";
 
 export type AcceptInviteState =
   | { kind: "loading" }
   | { kind: "signed-out" }
-  | { kind: "ready"; invite: PendingInvite }
+  | { kind: "ready"; invite: PendingInvite; messageBody?: string }
   | { kind: "accepting" }
   | { kind: "done" }
   | { kind: "no-invite"; email: string }
@@ -31,7 +32,7 @@ export function AcceptInviteBody({ state, onAccept, onSignOut }: Props) {
   if (state.kind === "wrong-ward") {
     return <WrongWard elsewhere={state.elsewhere} />;
   }
-  return <ReadyBody invite={state.invite} onAccept={onAccept} />;
+  return <ReadyBody invite={state.invite} messageBody={state.messageBody} onAccept={onAccept} />;
 }
 
 function NoInvite({ email, onSignOut }: { email: string; onSignOut: () => void }) {
@@ -82,9 +83,22 @@ function WrongWard({ elsewhere }: { elsewhere: readonly PendingInvite[] }) {
   );
 }
 
-function ReadyBody({ invite, onAccept }: { invite: PendingInvite; onAccept: () => void }) {
+function ReadyBody({
+  invite,
+  messageBody,
+  onAccept,
+}: {
+  invite: PendingInvite;
+  messageBody?: string | undefined;
+  onAccept: () => void;
+}) {
   return (
     <>
+      {messageBody && messageBody.trim().length > 0 && (
+        <div className="prose prose-sm max-w-none font-serif text-[14px] text-walnut-2 leading-relaxed mb-5">
+          <Markdown>{messageBody}</Markdown>
+        </div>
+      )}
       <h1 className="font-display text-[22px] font-semibold text-walnut mb-2">
         Join {invite.wardName}?
       </h1>

--- a/src/features/invites/InviteMemberDialog.tsx
+++ b/src/features/invites/InviteMemberDialog.tsx
@@ -1,11 +1,14 @@
 import { useState } from "react";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import { isValidEmail } from "@/lib/email";
-import { type Calling, type Ward } from "@/lib/types";
+import { callingToRole, type Calling, type Ward } from "@/lib/types";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
-import { CALLING_OPTIONS } from "../settings/callingLabels";
+import { renderWardInviteMessage } from "@/features/templates/renderWardInviteMessage";
+import { useWardInviteTemplate } from "@/features/templates/useWardInviteTemplate";
+import { DEFAULT_WARD_INVITE_BODY } from "@/features/templates/wardInviteDefaults";
 import { sendInvite } from "./inviteActions";
-import { INVITE_INPUT_CLS, InviteField } from "./inviteFormField";
+import { InviteMemberFields } from "./InviteMemberFields";
+import { InviteMessageOverridePanel } from "./InviteMessageOverridePanel";
 import { openInviteMailto } from "./inviteMailto";
 
 interface Props {
@@ -20,15 +23,22 @@ export function InviteMemberDialog({ wardId, ward, inviter, open, onClose }: Pro
   const [email, setEmail] = useState("");
   const [displayName, setDisplayName] = useState("");
   const [calling, setCalling] = useState<Calling>("ward_clerk");
+  const [customOpen, setCustomOpen] = useState(false);
+  const [customBody, setCustomBody] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { data: template } = useWardInviteTemplate();
   useLockBodyScroll(open);
   if (!open) return null;
+
+  const templateBody = template?.bodyMarkdown ?? DEFAULT_WARD_INVITE_BODY;
 
   function reset() {
     setEmail("");
     setDisplayName("");
     setCalling("ward_clerk");
+    setCustomOpen(false);
+    setCustomBody("");
     setBusy(false);
     setError(null);
   }
@@ -39,6 +49,16 @@ export function InviteMemberDialog({ wardId, ward, inviter, open, onClose }: Pro
     if (!inviter || !ward) return;
     setBusy(true);
     setError(null);
+    const messageBody = renderWardInviteMessage(
+      {
+        inviteeName: displayName.trim(),
+        wardName: ward.name,
+        inviterName: inviter.displayName,
+        calling,
+        role: callingToRole(calling),
+      },
+      { override: customOpen ? customBody : null, template: template?.bodyMarkdown },
+    );
     try {
       await sendInvite({
         wardId,
@@ -48,14 +68,9 @@ export function InviteMemberDialog({ wardId, ward, inviter, open, onClose }: Pro
         calling,
         invitedBy: inviter.uid,
         invitedByName: inviter.displayName,
+        messageBody,
       });
-      openInviteMailto({
-        email,
-        displayName,
-        wardName: ward.name,
-        wardId,
-        inviterName: inviter.displayName,
-      });
+      openInviteMailto({ email, wardName: ward.name, wardId, messageBody });
       reset();
       onClose();
     } catch (e) {
@@ -72,7 +87,7 @@ export function InviteMemberDialog({ wardId, ward, inviter, open, onClose }: Pro
       aria-modal="true"
       aria-label="Invite member"
     >
-      <div className="w-full max-w-md rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+      <div className="w-full max-w-md rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3 max-h-[90vh] overflow-y-auto">
         <h2 className="font-display text-[20px] font-semibold text-walnut tracking-[-0.005em]">
           Invite member
         </h2>
@@ -81,36 +96,24 @@ export function InviteMemberDialog({ wardId, ward, inviter, open, onClose }: Pro
           accept it in one click.
         </p>
         <div className="mt-4 flex flex-col gap-3">
-          <InviteField label="Email">
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className={INVITE_INPUT_CLS}
-              placeholder="name@example.com"
-            />
-          </InviteField>
-          <InviteField label="Display name">
-            <input
-              value={displayName}
-              onChange={(e) => setDisplayName(e.target.value)}
-              className={INVITE_INPUT_CLS}
-              placeholder="Jane Doe"
-            />
-          </InviteField>
-          <InviteField label="Calling">
-            <select
-              value={calling}
-              onChange={(e) => setCalling(e.target.value as Calling)}
-              className={INVITE_INPUT_CLS}
-            >
-              {CALLING_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </InviteField>
+          <InviteMemberFields
+            email={email}
+            setEmail={setEmail}
+            displayName={displayName}
+            setDisplayName={setDisplayName}
+            calling={calling}
+            setCalling={setCalling}
+          />
+          <InviteMessageOverridePanel
+            open={customOpen}
+            onToggle={() => {
+              if (!customOpen) setCustomBody(templateBody);
+              setCustomOpen((v) => !v);
+            }}
+            initialBody={customBody || templateBody}
+            onChange={setCustomBody}
+            disabled={busy}
+          />
         </div>
         {error && <p className="mt-3 font-sans text-[12.5px] text-bordeaux">{error}</p>}
         <div className="mt-5 flex justify-end gap-2">

--- a/src/features/invites/InviteMemberFields.tsx
+++ b/src/features/invites/InviteMemberFields.tsx
@@ -1,0 +1,58 @@
+import type { Calling } from "@/lib/types";
+import { CALLING_OPTIONS } from "../settings/callingLabels";
+import { INVITE_INPUT_CLS, InviteField } from "./inviteFormField";
+
+interface Props {
+  email: string;
+  setEmail: (v: string) => void;
+  displayName: string;
+  setDisplayName: (v: string) => void;
+  calling: Calling;
+  setCalling: (v: Calling) => void;
+}
+
+/** Stacked email / display-name / calling inputs for the Invite Member
+ *  dialog. Extracted so the dialog stays under the 150-LOC ceiling. */
+export function InviteMemberFields({
+  email,
+  setEmail,
+  displayName,
+  setDisplayName,
+  calling,
+  setCalling,
+}: Props) {
+  return (
+    <>
+      <InviteField label="Email">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className={INVITE_INPUT_CLS}
+          placeholder="name@example.com"
+        />
+      </InviteField>
+      <InviteField label="Display name">
+        <input
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          className={INVITE_INPUT_CLS}
+          placeholder="Jane Doe"
+        />
+      </InviteField>
+      <InviteField label="Calling">
+        <select
+          value={calling}
+          onChange={(e) => setCalling(e.target.value as Calling)}
+          className={INVITE_INPUT_CLS}
+        >
+          {CALLING_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>
+              {o.label}
+            </option>
+          ))}
+        </select>
+      </InviteField>
+    </>
+  );
+}

--- a/src/features/invites/InviteMessageOverridePanel.tsx
+++ b/src/features/invites/InviteMessageOverridePanel.tsx
@@ -1,0 +1,52 @@
+import { SpeakerLetterEditor } from "@/features/templates/SpeakerLetterEditor";
+
+interface Props {
+  open: boolean;
+  onToggle: () => void;
+  initialBody: string;
+  onChange: (body: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Collapsible "Customize message" panel for the Invite Member dialog.
+ * Closed by default — bishops who don't need to tweak per-invite copy
+ * never see the editor. Reuses `SpeakerLetterEditor` (MDXEditor wrapper)
+ * so the ward-invite and speaker-letter authoring UX match.
+ */
+export function InviteMessageOverridePanel({
+  open,
+  onToggle,
+  initialBody,
+  onChange,
+  disabled,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={disabled}
+        className="self-start font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 hover:text-bordeaux disabled:opacity-60"
+      >
+        {open ? "− Use ward default" : "+ Customize message"}
+      </button>
+      {open && (
+        <div>
+          <div className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep mb-1.5">
+            Message (greeting above the accept button)
+          </div>
+          <SpeakerLetterEditor
+            initialMarkdown={initialBody}
+            onChange={onChange}
+            ariaLabel="Invite message override"
+          />
+          <p className="mt-1 font-serif italic text-[11.5px] text-walnut-3">
+            Variables: {"{{inviteeName}}"}, {"{{wardName}}"}, {"{{inviterName}}"}, {"{{calling}}"},{" "}
+            {"{{role}}"}. The sign-in link and "— Sent from Steward" footer are added automatically.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/invites/inviteActions.ts
+++ b/src/features/invites/inviteActions.ts
@@ -24,6 +24,10 @@ export interface SendInviteInput {
   calling: Calling;
   invitedBy: string;
   invitedByName: string;
+  /** Pre-rendered greeting (template/override already interpolated).
+   *  Snapshotted onto the invite so the accept page can display it
+   *  without needing template-doc access. */
+  messageBody: string;
 }
 
 export async function sendInvite(input: SendInviteInput): Promise<void> {
@@ -37,6 +41,7 @@ export async function sendInvite(input: SendInviteInput): Promise<void> {
     invitedBy: input.invitedBy,
     invitedByName: input.invitedByName,
     invitedAt: null,
+    messageBody: input.messageBody,
   });
   await setDoc(doc(db, "wards", input.wardId, "invites", emailKey), {
     ...data,

--- a/src/features/invites/inviteMailto.ts
+++ b/src/features/invites/inviteMailto.ts
@@ -1,22 +1,23 @@
 interface InviteMailtoArgs {
   email: string;
-  displayName: string;
   wardName: string;
   wardId: string;
-  inviterName: string;
+  /** Pre-rendered greeting body (template/override already interpolated). */
+  messageBody: string;
 }
 
 /**
- * Open the user's email client with a pre-filled invitation message.
- * Using mailto: keeps the app within its "no server-side email" constraint.
+ * Open the user's email client with a pre-filled invitation. The body
+ * is the authored greeting + a fixed tail that carries the accept URL
+ * and "— Sent from Steward" signature, so the bishop can't accidentally
+ * omit the sign-in link. `mailto:` keeps the app within its
+ * "no server-side email" constraint.
  */
 export function openInviteMailto(args: InviteMailtoArgs): void {
   const acceptUrl = `${window.location.origin}/accept-invite/${encodeURIComponent(args.wardId)}`;
   const subject = `You're invited to help plan ${args.wardName} sacrament meetings`;
   const body = [
-    `Hi ${args.displayName},`,
-    "",
-    `${args.inviterName} has invited you to help plan sacrament meetings for ${args.wardName} in Steward.`,
+    args.messageBody.trimEnd(),
     "",
     "To accept, sign in with this email and then open the link below:",
     acceptUrl,

--- a/src/features/templates/renderWardInviteMessage.ts
+++ b/src/features/templates/renderWardInviteMessage.ts
@@ -1,0 +1,33 @@
+import { CALLING_LABELS } from "@/features/settings/callingLabels";
+import type { Calling, Role } from "@/lib/types";
+import { interpolate } from "./interpolate";
+import { DEFAULT_WARD_INVITE_BODY } from "./wardInviteDefaults";
+
+export interface WardInviteMessageVars {
+  inviteeName: string;
+  wardName: string;
+  inviterName: string;
+  calling: Calling;
+  role: Role;
+}
+
+/**
+ * Resolve the greeting body for an outgoing ward-member invite.
+ * Precedence: per-invite override → ward template → seed default.
+ * Variables are interpolated here so the returned string can be
+ * snapshotted onto the invite doc (the invitee can't read the template
+ * doc) and reused verbatim for the `mailto:` body.
+ */
+export function renderWardInviteMessage(
+  vars: WardInviteMessageVars,
+  sources: { override?: string | null | undefined; template?: string | null | undefined },
+): string {
+  const source = sources.override?.trim() || sources.template?.trim() || DEFAULT_WARD_INVITE_BODY;
+  return interpolate(source, {
+    inviteeName: vars.inviteeName,
+    wardName: vars.wardName,
+    inviterName: vars.inviterName,
+    calling: CALLING_LABELS[vars.calling],
+    role: vars.role,
+  });
+}

--- a/src/features/templates/useWardInviteTemplate.ts
+++ b/src/features/templates/useWardInviteTemplate.ts
@@ -1,0 +1,14 @@
+import { wardInviteTemplateSchema } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { useDocSnapshot } from "@/hooks/_sub";
+
+/**
+ * Subscribes to the ward's member-invitation message template at
+ * `wards/{wardId}/templates/wardInvite`. Returns `data: null` when no
+ * template has been written yet — callers should fall back to
+ * `DEFAULT_WARD_INVITE_BODY`.
+ */
+export function useWardInviteTemplate() {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  return useDocSnapshot(["wards", wardId, "templates", "wardInvite"], wardInviteTemplateSchema);
+}

--- a/src/features/templates/wardInviteDefaults.ts
+++ b/src/features/templates/wardInviteDefaults.ts
@@ -1,0 +1,14 @@
+/**
+ * Seed copy for the ward-member invitation message. Used as the default
+ * when the ward has not authored its own template, and as the starting
+ * point on the `/settings/templates/ward-invites` editor.
+ *
+ * Variables: {{inviteeName}}, {{wardName}}, {{inviterName}},
+ * {{calling}} (pretty-printed), {{role}}.
+ */
+
+export const DEFAULT_WARD_INVITE_BODY = `Hi {{inviteeName}},
+
+{{inviterName}} has invited you to help plan sacrament meetings for {{wardName}} in Steward, as {{calling}}.
+
+We're grateful for your willingness to serve — Steward keeps the bishopric, clerks, and executive secretary in sync on speakers, music, and the weekly program so Sunday worship is prayerfully prepared.`;

--- a/src/features/templates/writeWardInviteTemplate.ts
+++ b/src/features/templates/writeWardInviteTemplate.ts
@@ -1,0 +1,29 @@
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+export interface WardInviteTemplateInput {
+  bodyMarkdown: string;
+}
+
+/**
+ * Write the ward-member invitation message template. Any active member
+ * (bishopric or clerk) may edit per the shared template rule at
+ * `wards/{wardId}/templates/{templateId}`.
+ */
+export async function writeWardInviteTemplate(
+  wardId: string,
+  input: WardInviteTemplateInput,
+): Promise<void> {
+  reportSaving();
+  try {
+    await setDoc(doc(db, "wards", wardId, "templates", "wardInvite"), {
+      bodyMarkdown: input.bodyMarkdown,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/lib/types/invite.ts
+++ b/src/lib/types/invite.ts
@@ -21,5 +21,10 @@ export const inviteSchema = z.object({
   invitedBy: z.string().min(1),
   invitedByName: z.string().min(1),
   invitedAt: z.any(),
+  // Pre-rendered Markdown greeting snapshotted at send time (ward
+  // template or per-invite override, with variables interpolated). The
+  // accept page reads this without needing to read the template doc
+  // (which the invitee can't access — they're not a member yet).
+  messageBody: z.string().optional(),
 });
 export type Invite = z.infer<typeof inviteSchema>;

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -21,3 +21,21 @@ export const speakerLetterTemplateSchema = z.object({
   updatedAt: z.any().optional(),
 });
 export type SpeakerLetterTemplate = z.infer<typeof speakerLetterTemplateSchema>;
+
+/**
+ * Ward-level editable template for the ward-member invitation message.
+ *
+ * Single Markdown block authored by the bishopric/clerks. Renders as a
+ * greeting at the top of the accept-invite page AND as the body of the
+ * `mailto:` link the bishop sends. The accept URL, sign-in prompt, and
+ * "— Sent from Steward" signature are appended automatically so the
+ * template can focus on the personal greeting.
+ *
+ * Variables: `{{inviteeName}}`, `{{wardName}}`, `{{inviterName}}`,
+ * `{{calling}}` (pretty-printed), `{{role}}` (`bishopric` | `clerk`).
+ */
+export const wardInviteTemplateSchema = z.object({
+  bodyMarkdown: z.string(),
+  updatedAt: z.any().optional(),
+});
+export type WardInviteTemplate = z.infer<typeof wardInviteTemplateSchema>;

--- a/tests/rules/templates.test.ts
+++ b/tests/rules/templates.test.ts
@@ -74,4 +74,22 @@ describe("letter template rules", () => {
     const db = authedAs(env, "clerk", "c@x.com").firestore();
     await assertSucceeds(deleteDoc(doc(db, T_PATH)));
   });
+
+  // Same rule applies to every templateId under /templates/{templateId};
+  // spot-check the ward-invite template path to guard against a future
+  // split where someone narrows the wildcard.
+  it("covers the wardInvite template under the same rule", async () => {
+    const db = authedAs(env, "clerk", "c@x.com").firestore();
+    await assertSucceeds(
+      setDoc(doc(db, `wards/${WARD}/templates/wardInvite`), {
+        bodyMarkdown: "Hi {{inviteeName}}, …",
+      }),
+    );
+    const stranger = authedAs(env, "stranger", "s@x.com").firestore();
+    await assertFails(
+      setDoc(doc(stranger, `wards/${WARD}/templates/wardInvite`), {
+        bodyMarkdown: "tampered",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Closes #9. Reuses the template infrastructure shipped in #8 for a second
template — this one keyed to **ward-member invitations**.

- `wards/{wardId}/templates/wardInvite` stores the ward default (single
  Markdown block, same permissive `templates/{templateId}` rule as the
  speaker letter).
- New settings page `/settings/templates/ward-invites` with editor +
  live preview.
- `InviteMemberDialog` gains a collapsible **Customize message** panel.
  On send, the rendered greeting (override → template → default, with
  `{{inviteeName}}` / `{{wardName}}` / `{{inviterName}}` / `{{calling}}`
  (pretty-printed) / `{{role}}` interpolated) is snapshotted onto the
  invite doc as `messageBody`, so the accept page can display it
  without needing template-doc access (the invitee isn't a member yet).
- `openInviteMailto` now takes the rendered body and appends the
  accept URL + sign-off tail automatically — the template can focus on
  the personal greeting.
- Accept-invite page renders `messageBody` as a Markdown greeting
  above the "Join X Ward?" CTA.
- Subject line stays fixed per the issue scope.
- Rules test pins the `wardInvite` template path to the same rule as
  `speakerLetter` so a future wildcard narrowing is caught.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run format:check` — clean (after `npm run format`)
- [x] `npm run test` — 197 passed
- [x] `npm run test:rules` — 85 passed (+1 new wardInvite coverage)
- [x] `npm run build` — successful
- [ ] Manually: open `/settings/templates/ward-invites`, tweak greeting,
      save, and confirm preview updates with sample data.
- [ ] Manually: open Invite Member dialog → "+ Customize message"
      reveals the MDXEditor pre-loaded with the ward template; send →
      the resulting `mailto:` body contains the interpolated greeting.
- [ ] Manually: sign in as the invitee and open
      `/accept-invite/{wardId}` — the rendered greeting appears above
      the "Join X Ward?" CTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)