### PR TITLE
feat(templates): editable speaker-email body (slice 1 of #26)

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -10,6 +10,7 @@ import { MembersPage } from "./routes/members";
 import { NotificationSettingsPage } from "./routes/notification-settings";
 import { SettingsIndex } from "./routes/settings";
 import { SpeakerLetterTemplatePage } from "./routes/templates-speakers";
+import { SpeakerEmailTemplatePage } from "./routes/templates-speaker-email";
 import { WardInviteTemplatePage } from "./routes/templates-ward-invites";
 import { WardSettingsPage } from "./routes/ward-settings";
 import { Week } from "./routes/week";
@@ -27,6 +28,7 @@ export const router = createBrowserRouter([
       { path: "settings/members", element: <MembersPage /> },
       { path: "settings/notifications", element: <NotificationSettingsPage /> },
       { path: "settings/templates/speakers", element: <SpeakerLetterTemplatePage /> },
+      { path: "settings/templates/speaker-email", element: <SpeakerEmailTemplatePage /> },
       { path: "settings/templates/ward-invites", element: <WardInviteTemplatePage /> },
     ],
   },

--- a/src/app/routes/settings.tsx
+++ b/src/app/routes/settings.tsx
@@ -22,6 +22,11 @@ const links = [
     desc: "Ward default template shown to speakers + printed letter",
   },
   {
+    to: "/settings/templates/speaker-email",
+    label: "Speaker invitation email",
+    desc: "Plain-text email body when you hit Send email on a planned speaker",
+  },
+  {
     to: "/settings/templates/ward-invites",
     label: "Ward invitation message",
     desc: "Greeting shown when you invite a new bishopric or clerk member",

--- a/src/app/routes/templates-speaker-email.tsx
+++ b/src/app/routes/templates-speaker-email.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router";
+import { EditorSection } from "@/features/templates/SpeakerLetterEditor";
+import { renderSpeakerEmailBody } from "@/features/templates/renderSpeakerEmailBody";
+import { DEFAULT_SPEAKER_EMAIL_BODY } from "@/features/templates/speakerEmailDefaults";
+import { useSpeakerEmailTemplate } from "@/features/templates/useSpeakerEmailTemplate";
+import { writeSpeakerEmailTemplate } from "@/features/templates/writeSpeakerEmailTemplate";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+
+const SAMPLE_URL = "https://example.com/invite/speaker/your-ward/sample-token";
+
+export function SpeakerEmailTemplatePage() {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const ward = useWardSettings();
+  const me = useCurrentMember();
+  const { data: template, loading } = useSpeakerEmailTemplate();
+
+  const [body, setBody] = useState(DEFAULT_SPEAKER_EMAIL_BODY);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (loading || seeded) return;
+    if (template) setBody(template.bodyMarkdown);
+    setSeeded(true);
+  }, [loading, seeded, template]);
+
+  const canEdit = Boolean(me?.data.active);
+  const wardName = ward.data?.name ?? "";
+
+  const preview = useMemo(
+    () =>
+      renderSpeakerEmailBody(
+        {
+          speakerName: "Brother Lloyd Flores",
+          date: "Sunday, April 26, 2026",
+          wardName: wardName || "Your Ward",
+          inviterName: me?.data.displayName ?? "Bishop",
+          topic: "repentance and the grace of Christ",
+          inviteUrl: SAMPLE_URL,
+        },
+        { override: body, template: null },
+      ),
+    [body, wardName, me?.data.displayName],
+  );
+
+  async function handleSave() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeSpeakerEmailTemplate(wardId, { bodyMarkdown: body });
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <main className="pb-16">
+      <nav className="mb-4 text-sm text-walnut-2">
+        <Link to="/settings" className="hover:text-walnut">
+          ← Settings
+        </Link>
+      </nav>
+      <header className="mb-6 flex flex-col gap-1">
+        <h1 className="font-display text-[24px] font-semibold text-walnut">
+          Speaker invitation email
+        </h1>
+        <p className="font-serif text-[14px] text-walnut-2">
+          The plain-text message your email client sends when you click "Send email" on a planned
+          speaker — distinct from the letter on the landing page. Name the Sunday and purpose here
+          so the email doesn't read like a phishing link. Variables:{" "}
+          <code>{"{{speakerName}}"}</code>, <code>{"{{date}}"}</code>, <code>{"{{wardName}}"}</code>
+          , <code>{"{{inviterName}}"}</code>, <code>{"{{topic}}"}</code>,{" "}
+          <code>{"{{inviteUrl}}"}</code>.
+        </p>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-4">
+          <EditorSection
+            label="Email body"
+            initialMarkdown={body}
+            onChange={setBody}
+            disabled={!canEdit}
+          />
+          {error && <p className="font-sans text-[12.5px] text-bordeaux">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!canEdit || saving}
+              className="rounded-md border border-bordeaux bg-bordeaux px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed"
+            >
+              {saving ? "Saving…" : "Save template"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setBody(DEFAULT_SPEAKER_EMAIL_BODY)}
+              disabled={!canEdit || saving}
+              className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+            >
+              Reset to default
+            </button>
+          </div>
+        </div>
+        <aside className="flex flex-col gap-2">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
+            Preview — sample data
+          </div>
+          <pre className="rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-1 font-serif text-[14px] text-walnut-2 leading-relaxed whitespace-pre-wrap break-words">
+            {preview}
+          </pre>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/src/features/schedule/SpeakerInviteAction.tsx
+++ b/src/features/schedule/SpeakerInviteAction.tsx
@@ -1,12 +1,16 @@
 import { useState } from "react";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { formatAssignedDate } from "@/features/templates/letterDates";
+import { renderSpeakerEmailBody } from "@/features/templates/renderSpeakerEmailBody";
 import { sendSpeakerInvitation } from "@/features/templates/sendSpeakerInvitation";
-import { cn } from "@/lib/cn";
+import { useSpeakerEmailTemplate } from "@/features/templates/useSpeakerEmailTemplate";
 import { isValidEmail } from "@/lib/email";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
 import type { Draft } from "./speakerDraft";
+import { InviteActionBtn } from "./SpeakerInviteActionBtn";
 import { CheckIcon, MailIcon, PrintIcon, SendIcon } from "./SpeakerInviteIcons";
 
 interface Props {
@@ -19,7 +23,9 @@ interface Props {
 export function InviteAction({ draft, date, onMarkInvited, onPrint }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId);
   const me = useCurrentMember();
+  const ward = useWardSettings();
   const authUser = useAuthStore((s) => s.user);
+  const { data: emailTemplate } = useSpeakerEmailTemplate();
   const inviterName =
     me?.data.displayName ?? authUser?.displayName ?? authUser?.email ?? "The bishopric";
   const email = draft.email.trim();
@@ -43,12 +49,20 @@ export function InviteAction({ draft, date, onMarkInvited, onPrint }: Props) {
         speakerTopic: draft.topic.trim() || undefined,
         inviterName,
       });
-      const url = `${window.location.origin}/invite/speaker/${wardId}/${token}`;
-      const subject = encodeURIComponent(`Invitation to speak — ${prettyDate(date)}`);
-      const body = encodeURIComponent(
-        `Dear ${draft.name},\n\nPlease open your invitation letter at the link below:\n${url}\n\nWith gratitude,\nThe bishopric`,
+      const inviteUrl = `${window.location.origin}/invite/speaker/${wardId}/${token}`;
+      const body = renderSpeakerEmailBody(
+        {
+          speakerName: draft.name,
+          date: formatAssignedDate(date),
+          wardName: ward.data?.name ?? "",
+          inviterName,
+          topic: draft.topic.trim() || "a topic of your choosing",
+          inviteUrl,
+        },
+        { template: emailTemplate?.bodyMarkdown },
       );
-      window.location.href = `mailto:${email}?subject=${subject}&body=${body}`;
+      const subject = encodeURIComponent(`Invitation to speak — ${prettyDate(date)}`);
+      window.location.href = `mailto:${email}?subject=${subject}&body=${encodeURIComponent(body)}`;
       onMarkInvited();
     } catch (e) {
       setError(friendlyWriteError(e));
@@ -82,21 +96,21 @@ export function InviteAction({ draft, date, onMarkInvited, onPrint }: Props) {
           )}
         </div>
         <div className="inline-flex gap-1.5 shrink-0 flex-wrap ml-auto">
-          <Btn onClick={onMarkInvited} icon={invited ? <CheckIcon /> : null}>
+          <InviteActionBtn onClick={onMarkInvited} icon={invited ? <CheckIcon /> : null}>
             Mark invited
-          </Btn>
-          <Btn onClick={onPrint} icon={<PrintIcon />} primary={!emailValid}>
+          </InviteActionBtn>
+          <InviteActionBtn onClick={onPrint} icon={<PrintIcon />} primary={!emailValid}>
             Print letter
-          </Btn>
+          </InviteActionBtn>
           {hasEmail && (
-            <Btn
+            <InviteActionBtn
               onClick={() => void handleSendEmail()}
               icon={<SendIcon />}
               primary
               disabled={!emailValid || !persisted || sending}
             >
               {sending ? "Sending…" : "Send email"}
-            </Btn>
+            </InviteActionBtn>
           )}
         </div>
       </div>
@@ -108,36 +122,6 @@ export function InviteAction({ draft, date, onMarkInvited, onPrint }: Props) {
       )}
       {error && <p className="font-sans text-[12px] text-bordeaux">{error}</p>}
     </div>
-  );
-}
-
-function Btn({
-  onClick,
-  icon,
-  primary,
-  disabled,
-  children,
-}: {
-  onClick: () => void;
-  icon?: React.ReactNode;
-  primary?: boolean;
-  disabled?: boolean;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "font-sans text-[12.5px] font-semibold px-3 py-1.5 rounded-md border inline-flex items-center gap-1.5 transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed",
-        primary
-          ? "bg-bordeaux text-parchment border-bordeaux-deep hover:bg-bordeaux-deep shadow-[0_1px_0_rgba(35,24,21,0.18)] disabled:hover:bg-bordeaux"
-          : "bg-chalk text-walnut border-border-strong hover:bg-parchment-2 disabled:hover:bg-chalk",
-      )}
-    >
-      {icon}
-      {children}
-    </button>
   );
 }
 

--- a/src/features/schedule/SpeakerInviteActionBtn.tsx
+++ b/src/features/schedule/SpeakerInviteActionBtn.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/cn";
+
+interface Props {
+  onClick: () => void;
+  icon?: React.ReactNode;
+  primary?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+/** Shared button used by the planned-speaker action strip. Extracted
+ *  so `SpeakerInviteAction.tsx` stays under the 150-LOC ceiling. */
+export function InviteActionBtn({ onClick, icon, primary, disabled, children }: Props) {
+  return (
+    <button
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        "font-sans text-[12.5px] font-semibold px-3 py-1.5 rounded-md border inline-flex items-center gap-1.5 transition-colors whitespace-nowrap disabled:opacity-50 disabled:cursor-not-allowed",
+        primary
+          ? "bg-bordeaux text-parchment border-bordeaux-deep hover:bg-bordeaux-deep shadow-[0_1px_0_rgba(35,24,21,0.18)] disabled:hover:bg-bordeaux"
+          : "bg-chalk text-walnut border-border-strong hover:bg-parchment-2 disabled:hover:bg-chalk",
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  );
+}

--- a/src/features/templates/renderSpeakerEmailBody.ts
+++ b/src/features/templates/renderSpeakerEmailBody.ts
@@ -1,0 +1,25 @@
+import { interpolate } from "./interpolate";
+import { DEFAULT_SPEAKER_EMAIL_BODY } from "./speakerEmailDefaults";
+
+export interface SpeakerEmailBodyVars {
+  speakerName: string;
+  date: string; // already-formatted, e.g. "Sunday, April 26, 2026"
+  wardName: string;
+  inviterName: string;
+  topic: string; // already-normalized; callers pass a fallback when empty
+  inviteUrl: string;
+}
+
+/**
+ * Resolve the plain-text `mailto:` body for a speaker invitation.
+ * Precedence: per-speaker override (slice 2) → ward template → seed
+ * default. Variables are interpolated here so the returned string is
+ * ready to paste into the mail client.
+ */
+export function renderSpeakerEmailBody(
+  vars: SpeakerEmailBodyVars,
+  sources: { override?: string | null | undefined; template?: string | null | undefined },
+): string {
+  const source = sources.override?.trim() || sources.template?.trim() || DEFAULT_SPEAKER_EMAIL_BODY;
+  return interpolate(source, vars);
+}

--- a/src/features/templates/speakerEmailDefaults.ts
+++ b/src/features/templates/speakerEmailDefaults.ts
@@ -1,0 +1,20 @@
+/**
+ * Seed copy for the speaker invitation **email body** (the mailto: body
+ * the bishop's mail client sends — NOT the rich letter on the landing
+ * page). The default names purpose, sender, and Sunday upfront so the
+ * message doesn't read as a phishing link. Wards can edit this at
+ * `/settings/templates/speaker-email`.
+ *
+ * Variables: {{speakerName}}, {{date}}, {{wardName}}, {{inviterName}},
+ * {{topic}}, {{inviteUrl}}.
+ */
+
+export const DEFAULT_SPEAKER_EMAIL_BODY = `Dear {{speakerName}},
+
+We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. The full invitation letter — including our suggested topic and length — is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+
+{{inviteUrl}}
+
+With gratitude,
+{{inviterName}}
+{{wardName}} bishopric`;

--- a/src/features/templates/useSpeakerEmailTemplate.ts
+++ b/src/features/templates/useSpeakerEmailTemplate.ts
@@ -1,0 +1,14 @@
+import { speakerEmailTemplateSchema } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { useDocSnapshot } from "@/hooks/_sub";
+
+/**
+ * Subscribes to the ward's speaker-email body template at
+ * `wards/{wardId}/templates/speakerEmail`. Returns `data: null` when
+ * no template has been written yet — callers should fall back to
+ * `DEFAULT_SPEAKER_EMAIL_BODY`.
+ */
+export function useSpeakerEmailTemplate() {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  return useDocSnapshot(["wards", wardId, "templates", "speakerEmail"], speakerEmailTemplateSchema);
+}

--- a/src/features/templates/writeSpeakerEmailTemplate.ts
+++ b/src/features/templates/writeSpeakerEmailTemplate.ts
@@ -1,0 +1,29 @@
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+export interface SpeakerEmailTemplateInput {
+  bodyMarkdown: string;
+}
+
+/**
+ * Write the speaker invitation **email body** template. Any active
+ * bishopric or clerk member can edit per the shared template rule at
+ * `wards/{wardId}/templates/{templateId}`.
+ */
+export async function writeSpeakerEmailTemplate(
+  wardId: string,
+  input: SpeakerEmailTemplateInput,
+): Promise<void> {
+  reportSaving();
+  try {
+    await setDoc(doc(db, "wards", wardId, "templates", "speakerEmail"), {
+      bodyMarkdown: input.bodyMarkdown,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -39,3 +39,21 @@ export const wardInviteTemplateSchema = z.object({
   updatedAt: z.any().optional(),
 });
 export type WardInviteTemplate = z.infer<typeof wardInviteTemplateSchema>;
+
+/**
+ * Ward-level editable template for the **speaker email body** — the
+ * plain-text message that goes into the `mailto:` when a bishop clicks
+ * "Send email" for a planned speaker. Distinct from the speaker letter
+ * template (which governs the rich letter on the public landing page):
+ * this is what lands in the recipient's inbox before they click the
+ * link. A good default names purpose, sender, and Sunday upfront so
+ * the email doesn't read like a phishing attempt.
+ *
+ * Variables: `{{speakerName}}`, `{{date}}`, `{{wardName}}`,
+ * `{{inviterName}}`, `{{topic}}`, `{{inviteUrl}}`.
+ */
+export const speakerEmailTemplateSchema = z.object({
+  bodyMarkdown: z.string(),
+  updatedAt: z.any().optional(),
+});
+export type SpeakerEmailTemplate = z.infer<typeof speakerEmailTemplateSchema>;

--- a/tests/rules/templates.test.ts
+++ b/tests/rules/templates.test.ts
@@ -92,4 +92,19 @@ describe("letter template rules", () => {
       }),
     );
   });
+
+  it("covers the speakerEmail template under the same rule", async () => {
+    const db = authedAs(env, "clerk", "c@x.com").firestore();
+    await assertSucceeds(
+      setDoc(doc(db, `wards/${WARD}/templates/speakerEmail`), {
+        bodyMarkdown: "Dear {{speakerName}}, …",
+      }),
+    );
+    const stranger = authedAs(env, "stranger", "s@x.com").firestore();
+    await assertFails(
+      setDoc(doc(stranger, `wards/${WARD}/templates/speakerEmail`), {
+        bodyMarkdown: "tampered",
+      }),
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the scammy-email complaint from #26 by making the speaker
`mailto:` body ward-editable, mirroring the #9 ward-invite template
infrastructure. Default seed names **purpose**, **sender**, and
**Sunday** upfront so the message doesn't read as phishing.

**Before** (hardcoded in `SpeakerInviteAction.tsx`):

> Dear Sister So En,
>
> Please open your invitation letter at the link below:
> http://localhost:5174/invite/speaker/stv1/HImruetyp0x2RMzNu541
>
> With gratitude,
> The bishopric

**After** (default template, variables interpolated at send time):

> Dear Brother Lloyd Flores,
>
> We have prayerfully considered the needs of our ward and feel inspired
> to invite you to speak in sacrament meeting on Sunday, April 26, 2026.
> The full invitation letter — including our suggested topic and length
> — is at the link below. Please let a member of the bishopric know if
> this Sunday works for you, or if you would prefer a different date.
>
> https://steward.app/invite/speaker/your-ward/…
>
> With gratitude,
> Bishop Ballard
> Eglinton Ward bishopric

Fully editable from `/settings/templates/speaker-email`.

## What's in this slice

- `wards/{wardId}/templates/speakerEmail` storage (single Markdown
  block, shares the permissive `/templates/{templateId}` rule — no
  rule changes).
- Settings editor + plain-text preview at
  `/settings/templates/speaker-email`.
- `SpeakerInviteAction` now subscribes to the template and renders the
  mailto body via `renderSpeakerEmailBody(vars, { template })`. Subject
  line stays fixed ("Invitation to speak — {shortDate}") per issue
  scope.
- Variables: `{{speakerName}}`, `{{date}}` (long form), `{{wardName}}`,
  `{{inviterName}}`, `{{topic}}`, `{{inviteUrl}}`.
- Extracted `InviteActionBtn` so `SpeakerInviteAction` stays under the
  150-LOC ceiling after the new hooks.

## What's NOT in this slice (slice 2 of #26)

- The single "Prepare invitation" modal that replaces the three-button
  strip + the card-header "Edit letter" button.
- Per-speaker override for the email body (in addition to the existing
  letter override).
- Consolidation of `SpeakerLetterOverrideDialog` into the new modal.

Slice 1 stands on its own — the scammy default is fixed without
waiting on the UX rework.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (39 pre-existing warnings)
- [x] `npm run format:check` — clean (after `npm run format`)
- [x] `npm run test` — 197 passed
- [x] `npm run test:rules` — 86 passed (+1 `speakerEmail` coverage)
- [x] `npm run build` — successful
- [ ] CI green
- [ ] Manual: open `/settings/templates/speaker-email`, edit the copy,
      save, confirm live preview updates with sample data.
- [ ] Manual: click **Send email** on a planned speaker — the opened
      `mailto:` body reflects the ward template (or the default if no
      template has been saved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)