### PR TITLE
fix(schedule): scope Sunday card navigation to the date text only

### DIFF
--- a/src/features/schedule/SundayCard.tsx
+++ b/src/features/schedule/SundayCard.tsx
@@ -90,12 +90,7 @@ export function SundayCard({
     step === "invite" ? `Send invitations — ${formatShortDate(date)}` : formatShortDate(date);
 
   return (
-    <article
-      className={cn(
-        "rounded-lg border border-border shadow-elev-1 hover:shadow-elev-2 hover:border-border-strong transition-all duration-200",
-        CARD_BG[kind.variant],
-      )}
-    >
+    <article className={cn("rounded-lg border border-border shadow-elev-1", CARD_BG[kind.variant])}>
       <SundayCardHeader
         date={date}
         wardId={wardId}

--- a/src/features/schedule/SundayCardHeader.tsx
+++ b/src/features/schedule/SundayCardHeader.tsx
@@ -38,10 +38,13 @@ export function SundayCardHeader({
   return (
     <div className="flex items-start justify-between gap-3 p-4 pb-2">
       <div className="flex items-start gap-2 flex-1 min-w-0">
-        <Link to={`/week/${date}`} className="flex-1 min-w-0 hover:opacity-80 transition-opacity">
-          <div className="text-2xl font-display font-semibold text-walnut leading-tight">
+        <div className="flex-1 min-w-0">
+          <Link
+            to={`/week/${date}`}
+            className="text-2xl font-display font-semibold text-walnut leading-tight hover:text-bordeaux-deep hover:underline underline-offset-4 decoration-from-font transition-colors"
+          >
             {formatShortDate(date)}
-          </div>
+          </Link>
           <div
             className={cn(
               "text-[11px] font-mono tracking-[0.08em] uppercase mt-1",
@@ -50,7 +53,7 @@ export function SundayCardHeader({
           >
             {formatCountdown(date)}
           </div>
-        </Link>
+        </div>
         {needsApply && (
           <span
             aria-label="Speaker response awaiting your review"


### PR DESCRIPTION
## Summary

- Shrinks the `/week/:date` link in `SundayCardHeader` to the **date text only** (was wrapping the date + countdown block).
- Drops the card-wide hover affordance on the Sunday card `<article>` (`hover:shadow-elev-2 hover:border-border-strong transition-all`) so the card no longer implies "click me".
- Adds a link affordance on the date itself: `hover:text-bordeaux-deep` + `hover:underline` + `underline-offset-4`, using the `--color-bordeaux-deep` design token (`src/styles/index.css:24`).

Countdown text and the rest of the card body are no longer navigation targets.

Fixes #38

## Test plan

- [x] `pnpm run lint` — clean (60 pre-existing warnings, 0 errors)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 249 passed, 35 files (`SundayCard.test.tsx` included)
- [ ] Manual: hover the date → underline + bordeaux-deep shift; hover elsewhere on the card → no shadow lift, no click
- [ ] Manual: click the countdown → does nothing; click the date → routes to `/week/:date`
- [ ] Manual: cancelled variant still reads correctly (unchanged by this PR)

## Notes

The cancelled-variant card (`SundayCardCancelled`) had no link before and still has none — flagged as an open question in the issue; keeping scope tight here. Happy to apply the same date-only link treatment in a follow-up if we want consistency.


---
_Generated by [Claude Code](https://claude.ai/code/session_018dJC11M5ez6nDgyvMfr3Xj)_