### PR TITLE
fix(pwa): make installed PWA behave like a native app on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#0f172a" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -93,6 +93,24 @@
   body {
     @apply bg-parchment text-walnut font-sans text-base leading-relaxed antialiased;
     text-rendering: optimizeLegibility;
+    /* Native-app feel in the installed PWA: no rubber-band bounce on
+       the page, and no double-tap zoom (manipulation still allows
+       pan + pinch on inner scroll containers). Pinch-zoom on the
+       page itself is blocked by the viewport meta. */
+    overscroll-behavior: none;
+    touch-action: manipulation;
+  }
+
+  /* iOS Safari auto-zooms any focused input whose computed font-size
+     is under 16px, and doesn't fully zoom back out. Force a 16px
+     floor on touch devices only — desktop keeps the intended small
+     visual size from Tailwind utilities. */
+  @media (hover: none) and (pointer: coarse) {
+    input,
+    textarea,
+    select {
+      font-size: 16px;
+    }
   }
 
   /* Semantic typography */


### PR DESCRIPTION
## Summary

Three coordinated changes so the standalone PWA on iOS/Android stops feeling like a browser tab:

1. **Viewport meta** (`index.html:5-8`) — added `maximum-scale=1, user-scalable=no`. iOS Safari ignores `user-scalable` alone but honors `maximum-scale=1`; the pair together disables pinch-zoom and the input-focus auto-zoom jump.
2. **Global CSS** (`src/styles/index.css:93-101`) — `overscroll-behavior: none` on `html, body` kills the page-level rubber-band; `touch-action: manipulation` on `body` removes the 300ms double-tap-zoom delay without blocking inner pan/pinch on scroll containers.
3. **Input font-size floor of 16px** (`src/styles/index.css:103-114`), gated behind `@media (hover: none) and (pointer: coarse)` — belt-and-suspenders against iOS auto-zoom in case the viewport cap is relaxed. Desktop layouts keep the designed `text-sm` / `text-xs` inputs.

Fixes #40

## A11y tradeoff (explicit)

`user-scalable=no` + `maximum-scale=1` blocks pinch-zoom on mobile, which hurts users who rely on it. This is a small-audience bishopric tool and the ask was explicitly "behave like a native app" — native apps carry the same constraint. Desktop Ctrl+/- zoom is unaffected.

If we later want to relax this for a wider audience, the 16px input floor and `overscroll-behavior` stay; only the viewport meta would change.

## Test plan

- [x] `pnpm run lint` — clean (60 pre-existing warnings, 0 errors)
- [x] `pnpm run typecheck` — clean
- [x] `pnpm run format:check` — clean
- [x] `pnpm run test` — 249/249 passing
- [ ] Manual (iOS installed PWA): pull-down at top of `/schedule` → no rubber-band
- [ ] Manual (iOS installed PWA): pinch anywhere → no zoom
- [ ] Manual (iOS installed PWA): double-tap a paragraph → no zoom, no 300ms delay
- [ ] Manual (iOS installed PWA): focus a speaker-form input → no viewport jump
- [ ] Manual (desktop): layout unchanged, small-font inputs still render at designed size, Ctrl+/- page zoom still works

## Scope notes

Left untouched deliberately:
- Individual scroll containers (`AssignDialog`, `HistoryModal`, etc.) — the `overscroll-behavior: none` on `body` absorbs any chained scroll, so no visible bounce regardless. Adding `contain` on each container is a follow-up if we ever want stricter chain isolation.
- `-webkit-user-select: none` on chrome surfaces — separate polish, not part of #40's asks.


---
_Generated by [Claude Code](https://claude.ai/code/session_018dJC11M5ez6nDgyvMfr3Xj)_