### PR TITLE
Release v0.7.0: chat polish, resend/copy invite, PWA + mobile fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,73 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-04-23
+
+Chat polish and invitation resend / copy-link, plus two mobile-fit
+fixes. The bishopric chat now feels like a real messenger — day
+separators, unread horizon with jump-to-latest, typing indicator,
+read receipts, composer auto-grow, optimistic send, per-message
+emoji reactions, and a full-screen mobile layout. Bishops can also
+resend an invitation SMS or copy the invite link directly from the
+chat dialog without leaving the thread, and the PWA on iOS/Android
+stops behaving like a browser tab.
+
+### Added
+
+- **Day separators + per-message timestamps** in the chat thread.
+- **Unread horizon + jump-to-latest pill** — the thread remembers
+  where the reader left off and offers a one-tap return to the
+  newest message.
+- **Typing indicator + read receipts** sourced from Twilio
+  Conversations, so both sides of the thread see presence state.
+- **Composer auto-grow, optimistic send, and SMS hint banner** —
+  messages render instantly while the API call is in flight, and
+  the composer explains that a reply will SMS the speaker.
+- **Emoji reactions on individual messages** — tap-and-hold to
+  react, same set visible to every participant.
+- **Bishop can copy or resend the invite link** from the chat
+  dialog's overflow menu. Resend triggers a fresh SMS with a
+  rotated capability token while preserving the Twilio
+  `conversationSid` (full message history stays intact).
+- **Full-screen bishop chat on mobile** with page-scroll lock so
+  the composer never hides behind iOS Safari chrome.
+
+### Changed
+
+- **`sendSpeakerInvitation` gains rotate-link mode** — the callable
+  now accepts a `rotate: true` flag that generates a new hashed
+  capability token, writes it to the invitation doc, and re-sends
+  the SMS without creating a second Twilio conversation.
+- **Chat UI polish** — redundant inner header removed, link
+  actions collapsed into the overflow menu, 36px avatars aligned
+  against the last bubble in a stack instead of the stack midpoint.
+- **a11y (chat)**: semantic separators for day breaks, an sr-only
+  label for optimistic pending messages, and a pass over
+  announcement markup.
+
+### Fixed
+
+- **Sunday card click target was too broad** — the whole top
+  region of the card navigated to `/week/:date`. Only the date
+  text now navigates, with a bordeaux-deep underline on hover;
+  the card-wide shadow lift was dropped so the card no longer
+  reads as a click target. (#38)
+- **PWA on mobile behaves like a browser tab** — overscroll
+  bounce, pinch-zoom, double-tap zoom, and iOS input-focus
+  auto-zoom are now disabled in the installed PWA via
+  `maximum-scale=1 + user-scalable=no` on the viewport meta,
+  `overscroll-behavior: none` + `touch-action: manipulation`
+  on `html, body`, and a 16px font-size floor on inputs gated
+  to touch devices. Desktop layouts and Ctrl+/- zoom are
+  unaffected. (#40)
+
+### Infrastructure
+
+- 249 unit tests passing — new coverage for the chat thread's
+  unread horizon, day separators, typing indicator, reaction
+  picker, rotate-link mode on `sendSpeakerInvitation`, and the
+  overflow-menu copy-link / resend flows.
+
 ## [0.6.0] — 2026-04-23
 
 Two-way speaker conversations (#16) and a reworked speaker scheduling flow
@@ -519,7 +586,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/aylabyuk/steward/releases/tag/v0.7.0
 [0.6.0]: https://github.com/aylabyuk/steward/releases/tag/v0.6.0
 [0.5.0]: https://github.com/aylabyuk/steward/releases/tag/v0.5.0
 [0.4.0]: https://github.com/aylabyuk/steward/releases/tag/v0.4.0

--- a/functions/package.json
+++ b/functions/package.json
@@ -12,7 +12,8 @@
     "build:watch": "tsc --watch --preserveWatchOutput",
     "lint": "oxlint",
     "test": "vitest run",
-    "deploy": "firebase deploy --only functions"
+    "deploy": "firebase deploy --only functions",
+    "configure-conversation-roles": "tsx scripts/configure-conversation-roles.ts"
   },
   "dependencies": {
     "@sendgrid/mail": "^8.1.6",
@@ -21,6 +22,7 @@
     "twilio": "^6.0.0"
   },
   "devDependencies": {
+    "tsx": "^4.21.0",
     "typescript": "^5.7.2",
     "vitest": "^4.1.4"
   }

--- a/functions/scripts/configure-conversation-roles.ts
+++ b/functions/scripts/configure-conversation-roles.ts
@@ -1,0 +1,75 @@
+import twilio from "twilio";
+
+/** One-off admin script: grants the Twilio Conversations service's
+ *  default "channel user" role the `editAnyMessage` permission so
+ *  any participant in a conversation (bishopric member OR speaker)
+ *  can update the attributes of any message, not just messages they
+ *  authored. The chat UI uses message attributes to persist emoji
+ *  reactions — without this, a speaker reacting to a bishop's
+ *  message (or vice-versa) silently fails with a 403.
+ *
+ *  Security tradeoff: `editAnyMessage` also allows body edits, not
+ *  just attributes. Twilio does not expose a narrower permission.
+ *  The exposure is bounded by (a) the conversation-scoped role
+ *  (only actual participants in that one conversation), (b) each
+ *  edit's `updatedAt` timestamp surfacing tampering, and (c) the
+ *  ward being a trusted membership in the first place. Acceptable
+ *  in this context.
+ *
+ *  Idempotent: a second run is a no-op. Replaces the role's
+ *  permission list wholesale, so we fetch first, union with
+ *  editAnyMessage, and write back.
+ *
+ *  Run from the functions workspace:
+ *    TWILIO_ACCOUNT_SID=AC... \
+ *    TWILIO_AUTH_TOKEN=... \
+ *    TWILIO_CONVERSATIONS_SERVICE_SID=IS... \
+ *    pnpm --filter @steward/functions configure-conversation-roles
+ */
+
+interface ConversationRole {
+  sid: string;
+  type: "conversation" | "service";
+  friendlyName: string;
+  permissions: string[];
+}
+async function main(): Promise<void> {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const serviceSid = process.env.TWILIO_CONVERSATIONS_SERVICE_SID;
+  if (!accountSid || !authToken || !serviceSid) {
+    throw new Error(
+      "Missing env: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_CONVERSATIONS_SERVICE_SID all required.",
+    );
+  }
+
+  const client = twilio(accountSid, authToken);
+  const service = client.conversations.v1.services(serviceSid);
+  const roles = (await service.roles.list()) as unknown as ConversationRole[];
+
+  const channelUser = roles.find(
+    (r) => r.type === "conversation" && r.friendlyName === "channel user",
+  );
+  if (!channelUser) {
+    throw new Error(
+      `Could not find the default 'channel user' role on service ${serviceSid}. Twilio-managed roles are expected to exist; has the service been manually reconfigured?`,
+    );
+  }
+
+  const current = new Set(channelUser.permissions);
+  if (current.has("editAnyMessage")) {
+    console.log(`channel user (${channelUser.sid}) already has editAnyMessage — no-op.`);
+    return;
+  }
+  current.add("editAnyMessage");
+  const next = [...current];
+
+  await service.roles(channelUser.sid).update({ permission: next });
+  console.log(`channel user (${channelUser.sid}) updated. Permissions:`);
+  console.log(`  ${next.toSorted().join(", ")}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -1,0 +1,97 @@
+import { getFirestore, FieldValue } from "firebase-admin/firestore";
+import { addChatParticipant, createConversation } from "./twilio/conversations.js";
+import {
+  addBishopricParticipants,
+  buildInviteUrl,
+  cleanupPriorConversations,
+  tryEmail,
+  trySms,
+} from "./sendSpeakerInvitation.helpers.js";
+import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
+import type {
+  DeliveryEntry,
+  FreshInvitationRequest,
+  FreshInvitationResponse,
+} from "./sendSpeakerInvitation.types.js";
+
+/** Create-new path: builds a new invitation doc + conversation,
+ *  delivers via chosen channels, and returns the new invitationId
+ *  plus conversationSid. The rotate path shares helpers but a fresh
+ *  send always starts from scratch (prior Twilio conversations for
+ *  the same speaker+date get cleaned up). */
+export async function createFreshInvitation(
+  input: FreshInvitationRequest,
+  origin: string,
+): Promise<FreshInvitationResponse> {
+  const db = getFirestore();
+  const wantsEmail = input.channels.includes("email") && Boolean(input.speakerEmail);
+  const wantsSms = input.channels.includes("sms") && Boolean(input.speakerPhone);
+
+  await cleanupPriorConversations(input.wardId, input.speakerId, input.meetingDate);
+
+  const conversationSid = await createConversation({
+    friendlyName: `${input.speakerName} — ${input.meetingDate}`,
+    attributes: { wardId: input.wardId, speakerId: input.speakerId },
+  });
+  const bishopricParticipants = await addBishopricParticipants(input.wardId, conversationSid);
+
+  const plaintextToken = generateInvitationToken();
+  const tokenHash = hashInvitationToken(plaintextToken);
+  const expiresAt = new Date(input.expiresAtMillis);
+
+  const docRef = await db.collection(`wards/${input.wardId}/speakerInvitations`).add({
+    speakerRef: { meetingDate: input.meetingDate, speakerId: input.speakerId },
+    assignedDate: input.assignedDate,
+    sentOn: input.sentOn,
+    wardName: input.wardName,
+    speakerName: input.speakerName,
+    speakerTopic: input.speakerTopic,
+    inviterName: input.inviterName,
+    bodyMarkdown: input.bodyMarkdown,
+    footerMarkdown: input.footerMarkdown,
+    speakerEmail: input.speakerEmail,
+    speakerPhone: input.speakerPhone,
+    expiresAt,
+    tokenHash,
+    tokenStatus: "active" as const,
+    tokenExpiresAt: expiresAt,
+    tokenRotationsByDay: {},
+    conversationSid,
+    deliveryRecord: [],
+    bishopricParticipants,
+    createdAt: FieldValue.serverTimestamp(),
+  });
+
+  await addChatParticipant(conversationSid, `speaker:${docRef.id}`, {
+    displayName: input.speakerName,
+    role: "speaker",
+  });
+
+  const inviteUrl = buildInviteUrl(origin, input.wardId, docRef.id, plaintextToken);
+  const emailArgs = {
+    speakerName: input.speakerName,
+    inviterName: input.inviterName,
+    assignedDate: input.assignedDate,
+    wardName: input.wardName,
+    inviteUrl,
+  };
+
+  const deliveryRecord: DeliveryEntry[] = [];
+  if (wantsEmail) {
+    deliveryRecord.push(
+      await tryEmail(
+        {
+          speakerEmail: input.speakerEmail!,
+          inviterName: input.inviterName,
+          assignedDate: input.assignedDate,
+          replyToEmail: input.bishopReplyToEmail,
+        },
+        emailArgs,
+      ),
+    );
+  }
+  if (wantsSms) deliveryRecord.push(await trySms(input.speakerPhone!, emailArgs));
+  await docRef.update({ deliveryRecord });
+
+  return { mode: "fresh", token: docRef.id, conversationSid, deliveryRecord };
+}

--- a/functions/src/invitationTypes.ts
+++ b/functions/src/invitationTypes.ts
@@ -14,6 +14,13 @@ export interface SpeakerInvitationShape {
   speakerEmail?: string;
   speakerPhone?: string;
   conversationSid?: string;
+  deliveryRecord?: {
+    channel: "email" | "sms";
+    status: "sent" | "failed";
+    providerId?: string;
+    error?: string;
+    at: Date | FirebaseFirestore.Timestamp;
+  }[];
   expiresAt?: FirebaseFirestore.Timestamp;
   /** Capability-token columns (see src/lib/types/speakerInvitation.ts
    *  for the full doc). The hash is kept after consumption so a

--- a/functions/src/rotateInvitationLink.ts
+++ b/functions/src/rotateInvitationLink.ts
@@ -1,0 +1,86 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { HttpsError } from "firebase-functions/v2/https";
+import { buildInviteUrl, tryEmail, trySms } from "./sendSpeakerInvitation.helpers.js";
+import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import type {
+  DeliveryEntry,
+  RotateInvitationRequest,
+  RotateInvitationResponse,
+} from "./sendSpeakerInvitation.types.js";
+
+/** Bishop-driven link rotation. Generates a new capability token on
+ *  an existing invitation, preserving conversationSid + chat history
+ *  + bishopricParticipants snapshot + any prior response. Returns the
+ *  plaintext URL once; Firestore keeps only the new hash.
+ *
+ *  Bishop-driven rotations don't count against ROTATION_DAILY_CAP —
+ *  that cap exists to limit SMS-cost exposure from a leaked link,
+ *  not to restrict the owner of the invitation. */
+export async function rotateInvitationLink(
+  input: RotateInvitationRequest,
+  origin: string,
+): Promise<RotateInvitationResponse> {
+  const db = getFirestore();
+  const ref = db.doc(`wards/${input.wardId}/speakerInvitations/${input.invitationId}`);
+  const snap = await ref.get();
+  if (!snap.exists) throw new HttpsError("not-found", "Invitation not found.");
+  const invitation = snap.data() as SpeakerInvitationShape;
+  const expiresAtMillis = invitation.expiresAt?.toMillis();
+  if (typeof expiresAtMillis === "number" && expiresAtMillis < Date.now()) {
+    throw new HttpsError(
+      "failed-precondition",
+      "Invitation has expired — start a fresh one instead.",
+    );
+  }
+
+  const plaintextToken = generateInvitationToken();
+  const tokenHash = hashInvitationToken(plaintextToken);
+  await ref.update({ tokenHash, tokenStatus: "active" as const });
+
+  const inviteUrl = buildInviteUrl(origin, input.wardId, input.invitationId, plaintextToken);
+  const deliveryRecord = await deliverIfRequested(input, invitation, inviteUrl);
+  if (deliveryRecord.length > 0) {
+    await ref.update({
+      deliveryRecord: [...(invitation.deliveryRecord ?? []), ...deliveryRecord],
+    });
+  }
+
+  return { mode: "rotate", inviteUrl, deliveryRecord };
+}
+
+async function deliverIfRequested(
+  input: RotateInvitationRequest,
+  invitation: SpeakerInvitationShape,
+  inviteUrl: string,
+): Promise<DeliveryEntry[]> {
+  const out: DeliveryEntry[] = [];
+  const emailArgs = {
+    speakerName: invitation.speakerName,
+    inviterName: invitation.inviterName,
+    assignedDate: invitation.assignedDate,
+    wardName: invitation.wardName,
+    inviteUrl,
+  };
+  if (input.channels.includes("email") && invitation.speakerEmail) {
+    out.push(
+      await tryEmail(
+        {
+          speakerEmail: invitation.speakerEmail,
+          inviterName: invitation.inviterName,
+          assignedDate: invitation.assignedDate,
+          // bishopReplyToEmail isn't persisted on the invitation doc;
+          // fall back to the speaker's own address so SendGrid has a
+          // valid Reply-To header. Speakers replying that way reach
+          // themselves, which is a no-op — acceptable fallback.
+          replyToEmail: invitation.speakerEmail,
+        },
+        emailArgs,
+      ),
+    );
+  }
+  if (input.channels.includes("sms") && invitation.speakerPhone) {
+    out.push(await trySms(invitation.speakerPhone, emailArgs));
+  }
+  return out;
+}

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -6,7 +6,7 @@ import { addChatParticipant, deleteConversation } from "./twilio/conversations.j
 import { sendSmsDirect } from "./twilio/messaging.js";
 import { buildEmailHtml, buildEmailText, buildSmsBody } from "./invitationEmailBody.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
-import type { DeliveryEntry, SendSpeakerInvitationRequest } from "./sendSpeakerInvitation.types.js";
+import type { DeliveryEntry } from "./sendSpeakerInvitation.types.js";
 import type { MemberDoc } from "./types.js";
 
 export async function assertActiveMember(wardId: string, uid: string): Promise<void> {
@@ -93,16 +93,26 @@ export async function cleanupPriorConversations(
 
 type EmailArgs = Parameters<typeof buildEmailText>[0];
 
+export interface EmailDeliveryParams {
+  speakerEmail: string;
+  inviterName: string;
+  assignedDate: string;
+  /** Reply-To used so a speaker replying to the email lands in the
+   *  bishop's inbox naturally. On rotate-mode we don't have it on the
+   *  invitation doc, so callers fall back to the speaker's own email. */
+  replyToEmail: string;
+}
+
 export async function tryEmail(
-  input: SendSpeakerInvitationRequest,
+  params: EmailDeliveryParams,
   args: EmailArgs,
 ): Promise<DeliveryEntry> {
   try {
     const messageId = await sendEmail({
-      to: input.speakerEmail!,
-      fromDisplayName: `${input.inviterName} (via Steward)`,
-      replyTo: input.bishopReplyToEmail,
-      subject: `Speaking invitation — ${input.assignedDate}`,
+      to: params.speakerEmail,
+      fromDisplayName: `${params.inviterName} (via Steward)`,
+      replyTo: params.replyToEmail,
+      subject: `Speaking invitation — ${params.assignedDate}`,
       text: buildEmailText(args),
       html: buildEmailHtml(args),
     });
@@ -110,7 +120,7 @@ export async function tryEmail(
     if (messageId) entry.providerId = messageId;
     return entry;
   } catch (err) {
-    logger.error("initial email send failed", { err: (err as Error).message });
+    logger.error("email send failed", { err: (err as Error).message });
     return { channel: "email", status: "failed", error: (err as Error).message, at: new Date() };
   }
 }

--- a/functions/src/sendSpeakerInvitation.ts
+++ b/functions/src/sendSpeakerInvitation.ts
@@ -1,28 +1,27 @@
-import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { HttpsError, onCall, type CallableRequest } from "firebase-functions/v2/https";
 import { STEWARD_ORIGIN, TWILIO_SECRETS } from "./secrets.js";
-import { addChatParticipant, createConversation } from "./twilio/conversations.js";
-import {
-  addBishopricParticipants,
-  assertActiveMember,
-  buildInviteUrl,
-  cleanupPriorConversations,
-  tryEmail,
-  trySms,
-} from "./sendSpeakerInvitation.helpers.js";
-import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
+import { assertActiveMember } from "./sendSpeakerInvitation.helpers.js";
+import { createFreshInvitation } from "./freshInvitation.js";
+import { rotateInvitationLink } from "./rotateInvitationLink.js";
 import type {
-  DeliveryEntry,
   SendSpeakerInvitationRequest,
   SendSpeakerInvitationResponse,
 } from "./sendSpeakerInvitation.types.js";
 
+/** Dispatches between two modes:
+ *
+ *  - `mode: 'fresh'` (default): creates a new invitation doc + Twilio
+ *    conversation and delivers the letter via chosen channels.
+ *  - `mode: 'rotate'`: generates a fresh capability token on an
+ *    existing invitation — same conversationSid, chat history, and
+ *    response preserved — and optionally re-delivers via email/SMS.
+ *    With `channels: []` the caller gets the URL to copy manually.
+ *
+ *  SendGrid secrets are intentionally omitted — SMS-only delivery is
+ *  the v1 contract. sendEmail() throws on the missing key; the
+ *  surrounding try/catch records the failure and other channels
+ *  continue unaffected. */
 export const sendSpeakerInvitation = onCall(
-  // SendGrid secrets are intentionally omitted — we're shipping SMS-only
-  // for v1. If the bishop asks for email delivery, the server attempts
-  // sendEmail() which throws on the missing key; the surrounding
-  // try/catch records the failure in deliveryRecord and the SMS path
-  // continues unaffected.
   { secrets: TWILIO_SECRETS },
   async (
     request: CallableRequest<SendSpeakerInvitationRequest>,
@@ -32,81 +31,10 @@ export const sendSpeakerInvitation = onCall(
     if (!auth) throw new HttpsError("unauthenticated", "Sign-in required.");
     await assertActiveMember(input.wardId, auth.uid);
 
-    const db = getFirestore();
-    const wantsEmail = input.channels.includes("email") && Boolean(input.speakerEmail);
-    const wantsSms = input.channels.includes("sms") && Boolean(input.speakerPhone);
-
-    // Free the speaker's phone number from any prior conversation for
-    // this (wardId, speakerId, meetingDate) — Twilio refuses to bind
-    // the same (phone, proxy) pair twice. Swallow per-deletion errors
-    // so one stale/missing SID doesn't block the re-send path.
-    await cleanupPriorConversations(input.wardId, input.speakerId, input.meetingDate);
-
-    const conversationSid = await createConversation({
-      friendlyName: `${input.speakerName} — ${input.meetingDate}`,
-      attributes: { wardId: input.wardId, speakerId: input.speakerId },
-    });
-    // Group-chat model: every active bishopric + clerk joins, each
-    // carrying their displayName via participant attributes so the
-    // speaker's UI can label message bubbles with real names.
-    const bishopricParticipants = await addBishopricParticipants(input.wardId, conversationSid);
-
-    // Fresh capability token: plaintext goes in the URL exactly once,
-    // Firestore keeps only the SHA-256. issueSpeakerSession verifies
-    // presented tokens against this hash + rotates it on rate-limited
-    // self-healing. `tokenExpiresAt` mirrors `expiresAt` on issue;
-    // rotation doesn't extend it (a past-date invitation is dead).
-    const plaintextToken = generateInvitationToken();
-    const tokenHash = hashInvitationToken(plaintextToken);
-    const expiresAt = new Date(input.expiresAtMillis);
-
-    const docRef = await db.collection(`wards/${input.wardId}/speakerInvitations`).add({
-      speakerRef: { meetingDate: input.meetingDate, speakerId: input.speakerId },
-      assignedDate: input.assignedDate,
-      sentOn: input.sentOn,
-      wardName: input.wardName,
-      speakerName: input.speakerName,
-      speakerTopic: input.speakerTopic,
-      inviterName: input.inviterName,
-      bodyMarkdown: input.bodyMarkdown,
-      footerMarkdown: input.footerMarkdown,
-      speakerEmail: input.speakerEmail,
-      speakerPhone: input.speakerPhone,
-      expiresAt,
-      tokenHash,
-      tokenStatus: "active" as const,
-      tokenExpiresAt: expiresAt,
-      tokenRotationsByDay: {},
-      conversationSid,
-      deliveryRecord: [],
-      bishopricParticipants,
-      createdAt: FieldValue.serverTimestamp(),
-    });
-
-    // Speaker's Twilio identity = `speaker:{invitationId}` (the
-    // Firestore doc ID, not the capability token). Stays stable
-    // across token rotations so the conversation history follows the
-    // same identity. issueSpeakerSession mints a Firebase custom
-    // token + Twilio JWT carrying this same identity.
-    await addChatParticipant(conversationSid, `speaker:${docRef.id}`, {
-      displayName: input.speakerName,
-      role: "speaker",
-    });
-
     const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
-    const emailArgs = {
-      speakerName: input.speakerName,
-      inviterName: input.inviterName,
-      assignedDate: input.assignedDate,
-      wardName: input.wardName,
-      inviteUrl: buildInviteUrl(origin, input.wardId, docRef.id, plaintextToken),
-    };
-
-    const deliveryRecord: DeliveryEntry[] = [];
-    if (wantsEmail) deliveryRecord.push(await tryEmail(input, emailArgs));
-    if (wantsSms) deliveryRecord.push(await trySms(input.speakerPhone!, emailArgs));
-    await docRef.update({ deliveryRecord });
-
-    return { token: docRef.id, conversationSid, deliveryRecord };
+    if (input.mode === "rotate") {
+      return rotateInvitationLink(input, origin);
+    }
+    return createFreshInvitation(input, origin);
   },
 );

--- a/functions/src/sendSpeakerInvitation.types.ts
+++ b/functions/src/sendSpeakerInvitation.types.ts
@@ -1,4 +1,14 @@
-export interface SendSpeakerInvitationRequest {
+export interface DeliveryEntry {
+  channel: "email" | "sms";
+  status: "sent" | "failed";
+  providerId?: string;
+  error?: string;
+  at: Date;
+}
+
+/** Create-new path: builds a new invitation doc + conversation. */
+export interface FreshInvitationRequest {
+  mode?: "fresh";
   wardId: string;
   speakerId: string;
   meetingDate: string;
@@ -18,16 +28,35 @@ export interface SendSpeakerInvitationRequest {
   expiresAtMillis: number;
 }
 
-export interface DeliveryEntry {
-  channel: "email" | "sms";
-  status: "sent" | "failed";
-  providerId?: string;
-  error?: string;
-  at: Date;
+/** Rotate-link path: generates a fresh capability token on an
+ *  existing invitation, preserving the conversationSid + chat
+ *  history. `channels` may be empty — the bishop may want to copy
+ *  the URL to their clipboard without triggering another SMS/email. */
+export interface RotateInvitationRequest {
+  mode: "rotate";
+  wardId: string;
+  invitationId: string;
+  channels: ("email" | "sms")[];
 }
 
-export interface SendSpeakerInvitationResponse {
+export type SendSpeakerInvitationRequest = FreshInvitationRequest | RotateInvitationRequest;
+
+export interface FreshInvitationResponse {
+  mode: "fresh";
+  /** Firestore invitationId. Named `token` historically — it is
+   *  never the plaintext capability value. */
   token: string;
   conversationSid: string;
   deliveryRecord: DeliveryEntry[];
 }
+
+export interface RotateInvitationResponse {
+  mode: "rotate";
+  /** Freshly-rotated URL carrying a new capability token. Plaintext
+   *  leaves the server here exactly once; Firestore stores only the
+   *  new hash. */
+  inviteUrl: string;
+  deliveryRecord: DeliveryEntry[];
+}
+
+export type SendSpeakerInvitationResponse = FreshInvitationResponse | RotateInvitationResponse;

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+    />
     <meta name="theme-color" content="#0f172a" />
     <link rel="manifest" href="/manifest.webmanifest" />
     <link rel="icon" type="image/svg+xml" href="/icon.svg" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,6 +127,9 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
     devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.7.2
         version: 5.9.3

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -79,3 +79,24 @@ pnpm tsx scripts/_reset-ward.ts stv1
 
 Positional arg is the ward id; defaults to `stv1`. **Never run this against
 a real production project.**
+
+## configure-conversation-roles (functions workspace)
+
+One-off Twilio admin: grants the default "channel user" conversation
+role the `editAnyMessage` permission so any participant can update the
+attributes of any message in a conversation. The chat UI persists emoji
+reactions as message attributes; without this permission, reacting to
+someone else's message silently fails with a Twilio 403.
+
+Lives inside the functions workspace because it uses the `twilio` SDK
+which is only declared as a functions dependency:
+
+```sh
+TWILIO_ACCOUNT_SID=AC... \
+TWILIO_AUTH_TOKEN=... \
+TWILIO_CONVERSATIONS_SERVICE_SID=IS... \
+pnpm --filter @steward/functions configure-conversation-roles
+```
+
+Idempotent. Run once per Twilio service (dev + prod each have their own
+Conversations service SID).

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -34,7 +34,7 @@ export function BishopInvitationChat({
   const user = useAuthStore((s) => s.user);
   const members = useWardMembers();
   const twilio = useTwilioChat();
-  const { messages, conversation, authors, loading } = useConversation(
+  const { messages, conversation, authors, loading, toggleReaction } = useConversation(
     invitation.conversationSid ?? null,
   );
   const firstUnreadIndex = useFirstUnreadIndex(conversation);
@@ -115,6 +115,9 @@ export function BishopInvitationChat({
         loading={loading && twilio.status !== "ready"}
         firstUnreadIndex={firstUnreadIndex}
         readHorizonIndex={readHorizon}
+        onReact={(sid, emoji) => {
+          if (twilio.identity) void toggleReaction(sid, emoji, twilio.identity);
+        }}
       />
 
       <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -1,14 +1,18 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useWardMembers } from "@/hooks/useWardMembers";
 import { useAuthStore } from "@/stores/authStore";
 import type { SpeakerInvitation } from "@/lib/types";
 import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
 import { ResponseStrip } from "./ResponseStrip";
+import { TypingIndicator } from "./TypingIndicator";
 import { applyResponseToSpeaker } from "./invitationActions";
 import { callIssueSpeakerSession } from "./invitationsCallable";
-import { useConversation, type AuthorInfo, type AuthorMap } from "./useConversation";
+import { useBishopAuthors } from "./useBishopAuthors";
+import { useConversation } from "./useConversation";
 import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
+import { useReadHorizon } from "./useReadHorizon";
+import { useTypingParticipants } from "./useTypingParticipants";
 import { useTwilioChat } from "./twilioClientProvider";
 
 interface Props {
@@ -34,53 +38,18 @@ export function BishopInvitationChat({
     invitation.conversationSid ?? null,
   );
   const firstUnreadIndex = useFirstUnreadIndex(conversation);
+  const readHorizon = useReadHorizon(conversation, twilio.identity);
+  const typing = useTypingParticipants(conversation, twilio.identity);
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
 
-  // Merge author resolution: ward-member displayNames + the speaker
-  // snapshot on the invitation + the current user's Firebase Auth
-  // photoURL form a fallback map, then Twilio participant attributes
-  // (when present) overlay it. That way old conversations without
-  // attributes still render real names, and new conversations get
-  // the richer Twilio-sourced data.
-  const resolvedAuthors: AuthorMap = useMemo(() => {
-    const map = new Map<string, AuthorInfo>();
-    for (const m of members.data ?? []) {
-      if (m.data.role !== "bishopric" && m.data.role !== "clerk") continue;
-      if (!m.data.active) continue;
-      const info: AuthorInfo = { displayName: m.data.displayName, role: m.data.role };
-      if (m.data.email) info.email = m.data.email;
-      map.set(`uid:${m.id}`, info);
-    }
-    const speakerInfo: AuthorInfo = { displayName: invitation.speakerName, role: "speaker" };
-    if (invitation.speakerEmail) speakerInfo.email = invitation.speakerEmail;
-    if (invitation.response?.actorEmail) speakerInfo.email = invitation.response.actorEmail;
-    map.set(`speaker:${invitationId}`, speakerInfo);
-    if (user?.uid) {
-      const existing = map.get(`uid:${user.uid}`);
-      const info: AuthorInfo = {
-        displayName: existing?.displayName ?? user.displayName ?? "You",
-      };
-      if (existing?.role) info.role = existing.role;
-      if (user.photoURL) info.photoURL = user.photoURL;
-      const email = existing?.email ?? user.email;
-      if (email) info.email = email;
-      map.set(`uid:${user.uid}`, info);
-    }
-    for (const [id, info] of authors) {
-      const existing = map.get(id);
-      map.set(id, { ...existing, ...info });
-    }
-    return map;
-  }, [
-    members.data,
+  const resolvedAuthors = useBishopAuthors({
+    members: members.data,
+    invitation,
     invitationId,
-    invitation.speakerName,
-    invitation.speakerEmail,
-    invitation.response?.actorEmail,
     user,
     authors,
-  ]);
+  });
 
   useEffect(() => {
     if (twilio.status === "idle") void twilio.connect({ wardId });
@@ -145,7 +114,10 @@ export function BishopInvitationChat({
         authors={resolvedAuthors}
         loading={loading && twilio.status !== "ready"}
         firstUnreadIndex={firstUnreadIndex}
+        readHorizonIndex={readHorizon}
       />
+
+      <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />
 
       <ConversationComposer
         conversation={conversation}

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -91,7 +91,7 @@ export function BishopInvitationChat({
   const needsApply = Boolean(response && !response.acknowledgedAt);
 
   return (
-    <section className="bg-chalk flex flex-col overflow-hidden">
+    <section className="bg-chalk flex-1 flex flex-col min-h-0 overflow-hidden">
       {response && (
         <ResponseStrip
           response={response}
@@ -112,6 +112,7 @@ export function BishopInvitationChat({
         onReact={(sid, emoji) => {
           if (twilio.identity) void toggleReaction(sid, emoji, twilio.identity);
         }}
+        fillHeight
       />
 
       <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -8,6 +8,7 @@ import { ResponseStrip } from "./ResponseStrip";
 import { applyResponseToSpeaker } from "./invitationActions";
 import { callIssueSpeakerSession } from "./invitationsCallable";
 import { useConversation, type AuthorInfo, type AuthorMap } from "./useConversation";
+import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
 import { useTwilioChat } from "./twilioClientProvider";
 
 interface Props {
@@ -32,6 +33,7 @@ export function BishopInvitationChat({
   const { messages, conversation, authors, loading } = useConversation(
     invitation.conversationSid ?? null,
   );
+  const firstUnreadIndex = useFirstUnreadIndex(conversation);
   const [applying, setApplying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
 
@@ -142,6 +144,7 @@ export function BishopInvitationChat({
         currentIdentity={twilio.identity}
         authors={resolvedAuthors}
         loading={loading && twilio.status !== "ready"}
+        firstUnreadIndex={firstUnreadIndex}
       />
 
       <ConversationComposer

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -120,13 +120,7 @@ export function BishopInvitationChat({
   const needsApply = Boolean(response && !response.acknowledgedAt);
 
   return (
-    <section className="bg-chalk border border-border rounded-lg shadow-elev-1 flex flex-col overflow-hidden">
-      <header className="px-4 py-3 border-b border-border bg-parchment">
-        <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
-          Conversation with {invitation.speakerName}
-        </div>
-      </header>
-
+    <section className="bg-chalk flex flex-col overflow-hidden">
       {response && (
         <ResponseStrip
           response={response}

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -123,6 +123,7 @@ export function BishopInvitationChat({
         conversation={conversation}
         placeholder="Message the speaker…"
         disabled={twilio.status !== "ready"}
+        showSmsHint
       />
     </section>
   );

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import type { SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
+import { InvitationLinkActions } from "./InvitationLinkActions";
 
 interface Props {
   open: boolean;
@@ -53,6 +54,11 @@ export function BishopInvitationDialog({
               {invitation.speakerName}
             </div>
           </div>
+          <InvitationLinkActions
+            wardId={wardId}
+            invitationId={invitationId}
+            invitation={invitation}
+          />
           <button
             onClick={onClose}
             className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import type { SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
 import { InvitationLinkActions } from "./InvitationLinkActions";
@@ -14,7 +15,10 @@ interface Props {
 /** Nested modal that hosts the bishop-side chat pane from inside the
  *  Assign Speakers modal. Renders at `z-[60]` (above the Assign
  *  modal's `z-50`), and closes on Escape or backdrop click. Uses the
- *  TwilioChatProvider established higher up the tree. */
+ *  TwilioChatProvider established higher up the tree. Full-screen on
+ *  mobile (100dvh, no padding), centered modal on sm+. Background
+ *  scroll is locked while open so mobile rubber-banding doesn't drag
+ *  the page behind it. */
 export function BishopInvitationDialog({
   open,
   onClose,
@@ -22,6 +26,8 @@ export function BishopInvitationDialog({
   invitationId,
   invitation,
 }: Props): React.ReactElement | null {
+  useLockBodyScroll(open);
+
   useEffect(() => {
     if (!open) return;
     function handleEsc(e: KeyboardEvent) {
@@ -44,7 +50,7 @@ export function BishopInvitationDialog({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="bg-chalk border border-border-strong shadow-elev-3 overflow-hidden flex flex-col w-full max-w-xl sm:rounded-[14px] max-h-[94vh]">
+      <div className="bg-chalk flex flex-col w-full max-w-xl h-[100dvh] sm:h-auto sm:max-h-[94vh] sm:rounded-[14px] sm:border sm:border-border-strong sm:shadow-elev-3 overflow-hidden">
         <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
           <div className="flex-1 min-w-0">
             <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
@@ -67,13 +73,7 @@ export function BishopInvitationDialog({
             Close
           </button>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          <BishopInvitationChat
-            wardId={wardId}
-            invitationId={invitationId}
-            invitation={invitation}
-          />
-        </div>
+        <BishopInvitationChat wardId={wardId} invitationId={invitationId} invitation={invitation} />
       </div>
     </div>
   );

--- a/src/features/invitations/ConversationAvatar.tsx
+++ b/src/features/invitations/ConversationAvatar.tsx
@@ -18,7 +18,7 @@ export function ConversationAvatar({ author }: { author: AuthorInfo }) {
         src={author.photoURL}
         alt=""
         aria-hidden="true"
-        className="shrink-0 w-8 h-8 rounded-full object-cover border border-border"
+        className="shrink-0 w-9 h-9 rounded-full object-cover border border-border"
       />
     );
   }
@@ -26,7 +26,7 @@ export function ConversationAvatar({ author }: { author: AuthorInfo }) {
     <div
       aria-hidden="true"
       className={cn(
-        "shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-display text-[11px] font-semibold border",
+        "shrink-0 w-9 h-9 rounded-full flex items-center justify-center font-display text-[11px] font-semibold border",
         colorClass,
       )}
     >

--- a/src/features/invitations/ConversationBubble.tsx
+++ b/src/features/invitations/ConversationBubble.tsx
@@ -1,4 +1,7 @@
 import { cn } from "@/lib/cn";
+import { ReactionBar } from "./ReactionBar";
+import { ReactionPicker } from "./ReactionPicker";
+import { readReactions } from "./reactions";
 import type { ChatMessage } from "./useConversation";
 
 export type BubblePosition = "single" | "first" | "middle" | "last";
@@ -32,14 +35,23 @@ interface Props {
   message: ChatMessage;
   mine: boolean;
   position: BubblePosition;
+  selfIdentity: string | null;
+  onReact: (sid: string, emoji: string) => void;
 }
 
 /** A single Messenger-style speech bubble. Response-type messages
  *  carry a small "Response · Yes/No" eyebrow above the bubble body
- *  and a colored 2px border — they're single bubbles in practice,
- *  so grouping position is usually "single" for them anyway. */
-export function ConversationBubble({ message, mine, position }: Props) {
+ *  and a colored 2px border. The "+" picker appears on hover over
+ *  the row; applied reactions render as chips below the bubble. */
+export function ConversationBubble({
+  message,
+  mine,
+  position,
+  selfIdentity,
+  onReact,
+}: Props): React.ReactElement {
   const responseType = message.attributes?.responseType as "yes" | "no" | undefined;
+  const reactions = readReactions(message.attributes);
   const radius = mine ? MINE_RADIUS[position] : THEIRS_RADIUS[position];
   return (
     <div className={cn("flex flex-col", mine ? "items-end" : "items-start")}>
@@ -48,17 +60,26 @@ export function ConversationBubble({ message, mine, position }: Props) {
           {responseType === "yes" ? "Response · Yes" : "Response · No"}
         </span>
       )}
-      <div
-        className={cn(
-          "px-3.5 py-2 text-[14px] leading-snug whitespace-pre-wrap wrap-break-word shadow-[0_1px_0_rgba(35,24,21,0.04)]",
-          radius,
-          mine ? "bg-bordeaux text-parchment" : "bg-parchment-2 border border-border text-walnut",
-          responseType === "yes" && "border-success border-2",
-          responseType === "no" && "border-bordeaux border-2",
-        )}
-      >
-        {message.body}
+      <div className={cn("flex items-center gap-1.5", mine ? "flex-row-reverse" : "flex-row")}>
+        <div
+          className={cn(
+            "px-3.5 py-2 text-[14px] leading-snug whitespace-pre-wrap wrap-break-word shadow-[0_1px_0_rgba(35,24,21,0.04)]",
+            radius,
+            mine ? "bg-bordeaux text-parchment" : "bg-parchment-2 border border-border text-walnut",
+            responseType === "yes" && "border-success border-2",
+            responseType === "no" && "border-bordeaux border-2",
+          )}
+        >
+          {message.body}
+        </div>
+        <ReactionPicker mine={mine} onPick={(emoji) => onReact(message.sid, emoji)} />
       </div>
+      <ReactionBar
+        reactions={reactions}
+        selfIdentity={selfIdentity}
+        onToggle={(emoji) => onReact(message.sid, emoji)}
+        mine={mine}
+      />
     </div>
   );
 }

--- a/src/features/invitations/ConversationComposer.tsx
+++ b/src/features/invitations/ConversationComposer.tsx
@@ -54,7 +54,10 @@ export function ConversationComposer({
       <div className="flex gap-2 items-end">
         <textarea
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={(e) => {
+            setValue(e.target.value);
+            if (conversation && e.target.value.trim()) void conversation.typing();
+          }}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
               e.preventDefault();
@@ -64,6 +67,7 @@ export function ConversationComposer({
           placeholder={placeholder}
           disabled={disabled || sending}
           rows={1}
+          aria-label={placeholder}
           className="flex-1 font-sans text-[13.5px] px-3 py-2 bg-chalk border border-border-strong rounded-md text-walnut placeholder:text-walnut-3 focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 resize-none disabled:bg-parchment-2"
         />
         <button

--- a/src/features/invitations/ConversationComposer.tsx
+++ b/src/features/invitations/ConversationComposer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Conversation } from "@twilio/conversations";
 
 interface Props {
@@ -10,75 +10,122 @@ interface Props {
   ensureReady?: () => Promise<boolean>;
   placeholder?: string;
   disabled?: boolean;
+  /** When true, render a subtle SMS-segment counter that appears
+   *  once the draft nears 160 chars. Bishop-side messages may be
+   *  delivered as SMS if the speaker is replying from their phone;
+   *  speakers who have the web open don't pay for SMS segments. */
+  showSmsHint?: boolean;
 }
 
-/** Single-line auto-growing composer. Sends a plain-text message
- *  via the Twilio conversation. Quick-action (Yes/No) posts go
- *  through QuickActionButtons instead — those carry structured
- *  attributes. */
+const MAX_ROWS_PX = 132;
+const SMS_SEGMENT = 160;
+
+/** Auto-growing composer with an optimistic pending bubble. Sends
+ *  plain-text messages via the Twilio conversation. Quick-action
+ *  (Yes/No) posts go through QuickActionButtons instead — those
+ *  carry structured attributes. */
 export function ConversationComposer({
   conversation,
   ensureReady,
   placeholder = "Type a message…",
   disabled,
+  showSmsHint,
 }: Props): React.ReactElement {
   const [value, setValue] = useState("");
   const [sending, setSending] = useState(false);
+  const [pendingText, setPendingText] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const t = taRef.current;
+    if (!t) return;
+    t.style.height = "auto";
+    t.style.height = `${Math.min(t.scrollHeight, MAX_ROWS_PX)}px`;
+  }, [value]);
 
   async function handleSend() {
-    if (!value.trim() || sending) return;
+    const text = value.trim();
+    if (!text || sending) return;
     setSending(true);
     setError(null);
+    setPendingText(text);
+    setValue("");
     try {
       if (ensureReady) {
         const ok = await ensureReady();
-        if (!ok) {
-          setSending(false);
-          return;
-        }
+        if (!ok) throw new Error("Sign-in required.");
       }
       if (!conversation) throw new Error("Not connected.");
-      await conversation.sendMessage(value.trim());
-      setValue("");
+      await conversation.sendMessage(text);
     } catch (err) {
       setError((err as Error).message);
+      setValue(text);
     } finally {
       setSending(false);
+      setPendingText(null);
     }
   }
 
   return (
-    <div className="flex flex-col gap-1.5 p-3 border-t border-border bg-chalk">
-      {error && <p className="font-sans text-[11.5px] text-bordeaux">{error}</p>}
-      <div className="flex gap-2 items-end">
-        <textarea
-          value={value}
-          onChange={(e) => {
-            setValue(e.target.value);
-            if (conversation && e.target.value.trim()) void conversation.typing();
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault();
-              void handleSend();
-            }
-          }}
-          placeholder={placeholder}
-          disabled={disabled || sending}
-          rows={1}
-          aria-label={placeholder}
-          className="flex-1 font-sans text-[13.5px] px-3 py-2 bg-chalk border border-border-strong rounded-md text-walnut placeholder:text-walnut-3 focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 resize-none disabled:bg-parchment-2"
-        />
-        <button
-          type="button"
-          onClick={handleSend}
-          disabled={!value.trim() || disabled || sending}
-          className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
-        >
-          {sending ? "Sending…" : "Send"}
-        </button>
+    <div className="flex flex-col bg-chalk border-t border-border">
+      {pendingText && <PendingBubble text={pendingText} />}
+      <div className="flex flex-col gap-1.5 p-3">
+        {error && <p className="font-sans text-[11.5px] text-bordeaux">{error}</p>}
+        <div className="flex gap-2 items-end">
+          <textarea
+            ref={taRef}
+            value={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+              if (conversation && e.target.value.trim()) void conversation.typing();
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey) {
+                e.preventDefault();
+                void handleSend();
+              }
+            }}
+            placeholder={placeholder}
+            disabled={disabled || sending}
+            rows={1}
+            aria-label={placeholder}
+            className="flex-1 font-sans text-[13.5px] px-3 py-2 bg-chalk border border-border-strong rounded-md text-walnut placeholder:text-walnut-3 focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 resize-none disabled:bg-parchment-2"
+          />
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!value.trim() || disabled || sending}
+            className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+          >
+            {sending ? "Sending…" : "Send"}
+          </button>
+        </div>
+        {showSmsHint && value.length >= 140 && <SmsHint length={value.length} />}
       </div>
     </div>
+  );
+}
+
+function PendingBubble({ text }: { text: string }) {
+  return (
+    <div className="flex justify-end px-4 pt-3" aria-live="polite">
+      <div className="max-w-[85%] rounded-[18px] bg-bordeaux/70 text-parchment px-3.5 py-2 text-[14px] whitespace-pre-wrap wrap-break-word opacity-75 flex items-center gap-2">
+        <span
+          aria-hidden="true"
+          className="inline-block w-2 h-2 rounded-full bg-parchment/70 animate-pulse"
+        />
+        {text}
+      </div>
+    </div>
+  );
+}
+
+function SmsHint({ length }: { length: number }) {
+  const segments = Math.ceil(length / SMS_SEGMENT);
+  return (
+    <p className="font-mono text-[10px] text-walnut-3">
+      {length} / {SMS_SEGMENT} — {segments > 1 ? `sends as ${segments} SMS segments` : "still one SMS segment"}
+    </p>
   );
 }

--- a/src/features/invitations/ConversationComposer.tsx
+++ b/src/features/invitations/ConversationComposer.tsx
@@ -115,6 +115,7 @@ function PendingBubble({ text }: { text: string }) {
           aria-hidden="true"
           className="inline-block w-2 h-2 rounded-full bg-parchment/70 animate-pulse"
         />
+        <span className="sr-only">Sending: </span>
         {text}
       </div>
     </div>
@@ -125,7 +126,8 @@ function SmsHint({ length }: { length: number }) {
   const segments = Math.ceil(length / SMS_SEGMENT);
   return (
     <p className="font-mono text-[10px] text-walnut-3">
-      {length} / {SMS_SEGMENT} — {segments > 1 ? `sends as ${segments} SMS segments` : "still one SMS segment"}
+      {length} / {SMS_SEGMENT} —{" "}
+      {segments > 1 ? `sends as ${segments} SMS segments` : "still one SMS segment"}
     </p>
   );
 }

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -8,13 +8,20 @@ interface Props {
   /** When true, the last mine=true bubble in the group is the latest
    *  message the other side has marked as read — show "Read" under it. */
   readByOther?: boolean;
+  selfIdentity: string | null;
+  onReact: (sid: string, emoji: string) => void;
 }
 
 /** Renders one author's run of consecutive messages as a connected
  *  stack with a single avatar + trailing timestamp. Read receipt is
  *  a small "Read" label under the last bubble on mine=true groups
  *  when the other participant has read up to that index. */
-export function ConversationGroup({ group, readByOther }: Props): React.ReactElement {
+export function ConversationGroup({
+  group,
+  readByOther,
+  selfIdentity,
+  onReact,
+}: Props): React.ReactElement {
   const last = group.messages.at(-1)!;
   const timestamp = last.dateCreated?.toLocaleTimeString(undefined, {
     hour: "numeric",
@@ -49,6 +56,8 @@ export function ConversationGroup({ group, readByOther }: Props): React.ReactEle
               message={m}
               mine={group.mine}
               position={bubblePositionOf(i, group.messages.length)}
+              selfIdentity={selfIdentity}
+              onReact={onReact}
             />
           ))}
           {timestamp && (

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -1,0 +1,71 @@
+import { cn } from "@/lib/cn";
+import { ConversationAvatar } from "./ConversationAvatar";
+import { ConversationBubble, bubblePositionOf } from "./ConversationBubble";
+import type { MessageGroup } from "./threadItems";
+
+interface Props {
+  group: MessageGroup;
+  /** When true, the last mine=true bubble in the group is the latest
+   *  message the other side has marked as read — show "Read" under it. */
+  readByOther?: boolean;
+}
+
+/** Renders one author's run of consecutive messages as a connected
+ *  stack with a single avatar + trailing timestamp. Read receipt is
+ *  a small "Read" label under the last bubble on mine=true groups
+ *  when the other participant has read up to that index. */
+export function ConversationGroup({ group, readByOther }: Props): React.ReactElement {
+  const last = group.messages.at(-1)!;
+  const timestamp = last.dateCreated?.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  const fullTimestamp = last.dateCreated?.toLocaleString();
+  const authorLabel = group.mine ? "You" : group.info.displayName;
+  return (
+    <div
+      className={cn("flex flex-col gap-1", group.mine ? "items-end" : "items-start")}
+      role="group"
+      aria-label={`${authorLabel} at ${fullTimestamp ?? "unknown time"}`}
+    >
+      <div
+        className={cn(
+          "flex items-end gap-2 max-w-[85%]",
+          group.mine ? "flex-row-reverse" : "flex-row",
+        )}
+      >
+        {!group.mine && <ConversationAvatar author={group.info} />}
+        <div
+          className={cn("flex flex-col gap-0.5 min-w-0", group.mine ? "items-end" : "items-start")}
+        >
+          {!group.mine && (
+            <span className="font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
+              {group.info.displayName}
+            </span>
+          )}
+          {group.messages.map((m, i) => (
+            <ConversationBubble
+              key={m.sid}
+              message={m}
+              mine={group.mine}
+              position={bubblePositionOf(i, group.messages.length)}
+            />
+          ))}
+          {timestamp && (
+            <span
+              className="font-mono text-[9.5px] text-walnut-3 mt-0.5"
+              title={fullTimestamp}
+            >
+              {timestamp}
+            </span>
+          )}
+          {group.mine && readByOther && (
+            <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep">
+              Read
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -32,7 +32,7 @@ export function ConversationGroup({
   const groupLabel = fullTimestamp ? `${authorLabel} at ${fullTimestamp}` : authorLabel;
   return (
     <div
-      className={cn("flex flex-col gap-1", group.mine ? "items-end" : "items-start")}
+      className={cn("flex flex-col gap-0.5", group.mine ? "items-end" : "items-start")}
       role="group"
       aria-label={groupLabel}
     >
@@ -61,18 +61,23 @@ export function ConversationGroup({
               onReact={onReact}
             />
           ))}
-          {timestamp && (
-            <span className="font-mono text-[9.5px] text-walnut-3 mt-0.5" title={fullTimestamp}>
-              {timestamp}
-            </span>
-          )}
-          {group.mine && readByOther && (
-            <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep">
-              Read
-            </span>
-          )}
         </div>
       </div>
+      {/* Timestamp + read receipt sit on their own row so the avatar
+          above aligns with the last bubble, not with this metadata. */}
+      {timestamp && (
+        <span
+          className={cn("font-mono text-[9.5px] text-walnut-3 mt-0.5", !group.mine && "ml-10")}
+          title={fullTimestamp}
+        >
+          {timestamp}
+        </span>
+      )}
+      {group.mine && readByOther && (
+        <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep">
+          Read
+        </span>
+      )}
     </div>
   );
 }

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -38,9 +38,8 @@ export function ConversationGroup({
     >
       {/* Name eyebrow sits above the avatar row, indented past the
           avatar slot so it lines up with the bubbles. Kept outside
-          the flex row so items-center below can center the avatar
-          against the bubble stack without the eyebrow skewing the
-          computation. */}
+          the flex row so the avatar below can align against the
+          bubble stack without the eyebrow skewing the computation. */}
       {!group.mine && (
         <span className="ml-10 font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
           {group.info.displayName}
@@ -48,7 +47,7 @@ export function ConversationGroup({
       )}
       <div
         className={cn(
-          "flex items-center gap-2 max-w-[85%]",
+          "flex items-end gap-2 max-w-[85%]",
           group.mine ? "flex-row-reverse" : "flex-row",
         )}
       >

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -36,9 +36,19 @@ export function ConversationGroup({
       role="group"
       aria-label={groupLabel}
     >
+      {/* Name eyebrow sits above the avatar row, indented past the
+          avatar slot so it lines up with the bubbles. Kept outside
+          the flex row so items-center below can center the avatar
+          against the bubble stack without the eyebrow skewing the
+          computation. */}
+      {!group.mine && (
+        <span className="ml-10 font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
+          {group.info.displayName}
+        </span>
+      )}
       <div
         className={cn(
-          "flex items-end gap-2 max-w-[85%]",
+          "flex items-center gap-2 max-w-[85%]",
           group.mine ? "flex-row-reverse" : "flex-row",
         )}
       >
@@ -46,11 +56,6 @@ export function ConversationGroup({
         <div
           className={cn("flex flex-col gap-0.5 min-w-0", group.mine ? "items-end" : "items-start")}
         >
-          {!group.mine && (
-            <span className="font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
-              {group.info.displayName}
-            </span>
-          )}
           {group.messages.map((m, i) => (
             <ConversationBubble
               key={m.sid}
@@ -63,8 +68,6 @@ export function ConversationGroup({
           ))}
         </div>
       </div>
-      {/* Timestamp + read receipt sit on their own row so the avatar
-          above aligns with the last bubble, not with this metadata. */}
       {timestamp && (
         <span
           className={cn("font-mono text-[9.5px] text-walnut-3 mt-0.5", !group.mine && "ml-10")}

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -41,7 +41,7 @@ export function ConversationGroup({
           the flex row so the avatar below can align against the
           bubble stack without the eyebrow skewing the computation. */}
       {!group.mine && (
-        <span className="ml-10 font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
+        <span className="ml-11 font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
           {group.info.displayName}
         </span>
       )}
@@ -69,7 +69,7 @@ export function ConversationGroup({
       </div>
       {timestamp && (
         <span
-          className={cn("font-mono text-[9.5px] text-walnut-3 mt-0.5", !group.mine && "ml-10")}
+          className={cn("font-mono text-[9.5px] text-walnut-3 mt-0.5", !group.mine && "ml-11")}
           title={fullTimestamp}
         >
           {timestamp}

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -29,11 +29,12 @@ export function ConversationGroup({
   });
   const fullTimestamp = last.dateCreated?.toLocaleString();
   const authorLabel = group.mine ? "You" : group.info.displayName;
+  const groupLabel = fullTimestamp ? `${authorLabel} at ${fullTimestamp}` : authorLabel;
   return (
     <div
       className={cn("flex flex-col gap-1", group.mine ? "items-end" : "items-start")}
       role="group"
-      aria-label={`${authorLabel} at ${fullTimestamp ?? "unknown time"}`}
+      aria-label={groupLabel}
     >
       <div
         className={cn(
@@ -61,10 +62,7 @@ export function ConversationGroup({
             />
           ))}
           {timestamp && (
-            <span
-              className="font-mono text-[9.5px] text-walnut-3 mt-0.5"
-              title={fullTimestamp}
-            >
+            <span className="font-mono text-[9.5px] text-walnut-3 mt-0.5" title={fullTimestamp}>
               {timestamp}
             </span>
           )}

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ConversationGroup } from "./ConversationGroup";
+import { JumpToLatest } from "./JumpToLatest";
+import { DayDivider, UnreadDivider } from "./ThreadDividers";
 import { buildThreadItems } from "./threadItems";
 import type { AuthorMap, ChatMessage } from "./useConversation";
 
@@ -18,13 +20,10 @@ interface Props {
   readHorizonIndex?: number | null;
 }
 
-/** Bubble list styled after Messenger: consecutive messages by the
- *  same author collapse into one group, one avatar at the bottom
- *  (theirs) or no avatar (mine), bubbles stack tight with shaped
- *  border-radius so the group reads as a single connected shape on
- *  the avatar-facing side. Day dividers appear between messages
- *  from different local days; a "New messages" divider appears
- *  before the first unread incoming message. */
+/** Bubble list styled after Messenger. Consecutive messages by the
+ *  same author collapse into one group; day dividers separate local
+ *  days; a "New" divider marks the unread horizon; a floating pill
+ *  appears when the user has scrolled up and new messages land. */
 export function ConversationThread({
   messages,
   currentIdentity,
@@ -35,6 +34,8 @@ export function ConversationThread({
 }: Props): React.ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);
+  const [unseenCount, setUnseenCount] = useState(0);
+  const lastSeenIndexRef = useRef<number | null>(null);
 
   const items = useMemo(
     () =>
@@ -50,8 +51,21 @@ export function ConversationThread({
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
-    if (atBottom) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-  }, [items, atBottom]);
+    if (atBottom) {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+      lastSeenIndexRef.current = messages.at(-1)?.index ?? null;
+      setUnseenCount(0);
+      return;
+    }
+    const seen = lastSeenIndexRef.current;
+    setUnseenCount(messages.filter((m) => (seen === null ? true : m.index > seen)).length);
+  }, [items, atBottom, messages]);
+
+  function jumpToBottom() {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }
 
   if (loading) {
     return <p className="font-serif italic text-[14px] text-walnut-3 p-4">Loading conversation…</p>;
@@ -66,37 +80,42 @@ export function ConversationThread({
 
   const lastMineIndex = findLastMineIndex(messages, currentIdentity);
   const readByOtherAt =
-    typeof readHorizonIndex === "number" && lastMineIndex !== null && readHorizonIndex >= lastMineIndex
+    typeof readHorizonIndex === "number" &&
+    lastMineIndex !== null &&
+    readHorizonIndex >= lastMineIndex
       ? lastMineIndex
       : null;
 
   return (
-    <div
-      ref={scrollRef}
-      className="flex flex-col gap-4 p-4 overflow-y-auto max-h-[60vh]"
-      role="log"
-      aria-live="polite"
-      aria-relevant="additions"
-      onScroll={(e) => {
-        const el = e.currentTarget;
-        setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 32);
-      }}
-    >
-      {items.map((item) => {
-        if (item.kind === "day") return <DayDivider key={item.key} label={item.label} />;
-        if (item.kind === "unread") return <UnreadDivider key={item.key} />;
-        return (
-          <ConversationGroup
-            key={item.key}
-            group={item.group}
-            readByOther={
-              item.group.mine &&
-              readByOtherAt !== null &&
-              item.group.messages.some((m) => m.index === readByOtherAt)
-            }
-          />
-        );
-      })}
+    <div className="relative">
+      <div
+        ref={scrollRef}
+        className="flex flex-col gap-4 p-4 overflow-y-auto max-h-[60vh]"
+        role="log"
+        aria-live="polite"
+        aria-relevant="additions"
+        onScroll={(e) => {
+          const el = e.currentTarget;
+          setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 32);
+        }}
+      >
+        {items.map((item) => {
+          if (item.kind === "day") return <DayDivider key={item.key} label={item.label} />;
+          if (item.kind === "unread") return <UnreadDivider key={item.key} />;
+          return (
+            <ConversationGroup
+              key={item.key}
+              group={item.group}
+              readByOther={
+                item.group.mine &&
+                readByOtherAt !== null &&
+                item.group.messages.some((m) => m.index === readByOtherAt)
+              }
+            />
+          );
+        })}
+      </div>
+      {!atBottom && <JumpToLatest unseenCount={unseenCount} onJump={jumpToBottom} />}
     </div>
   );
 }
@@ -112,26 +131,3 @@ function findLastMineIndex(
   return null;
 }
 
-function DayDivider({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-2 -my-1" aria-label={label}>
-      <div className="flex-1 h-px bg-border" />
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3">
-        {label}
-      </span>
-      <div className="flex-1 h-px bg-border" />
-    </div>
-  );
-}
-
-function UnreadDivider() {
-  return (
-    <div className="flex items-center gap-2 -my-1" aria-label="New messages">
-      <div className="flex-1 h-px bg-bordeaux/40" />
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-bordeaux">
-        New
-      </span>
-      <div className="flex-1 h-px bg-bordeaux/40" />
-    </div>
-  );
-}

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -18,6 +18,7 @@ interface Props {
    *  provided, the last mine=true bubble at or below this index gets
    *  a "Read" receipt rendered under it. */
   readHorizonIndex?: number | null;
+  onReact: (sid: string, emoji: string) => void;
 }
 
 /** Bubble list styled after Messenger. Consecutive messages by the
@@ -31,6 +32,7 @@ export function ConversationThread({
   loading,
   firstUnreadIndex,
   readHorizonIndex,
+  onReact,
 }: Props): React.ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);
@@ -111,6 +113,8 @@ export function ConversationThread({
                 readByOtherAt !== null &&
                 item.group.messages.some((m) => m.index === readByOtherAt)
               }
+              selfIdentity={currentIdentity}
+              onReact={onReact}
             />
           );
         })}

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -134,4 +134,3 @@ function findLastMineIndex(
   }
   return null;
 }
-

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { cn } from "@/lib/cn";
 import { ConversationGroup } from "./ConversationGroup";
 import { JumpToLatest } from "./JumpToLatest";
 import { DayDivider, UnreadDivider } from "./ThreadDividers";
@@ -19,6 +20,11 @@ interface Props {
    *  a "Read" receipt rendered under it. */
   readHorizonIndex?: number | null;
   onReact: (sid: string, emoji: string) => void;
+  /** When true, the thread expands to fill a flex parent (the full-
+   *  screen bishop dialog does this). When false (default) the thread
+   *  is capped at 60vh — right for the speaker landing page where the
+   *  thread sits inside a naturally-stacking scroll column. */
+  fillHeight?: boolean;
 }
 
 /** Bubble list styled after Messenger. Consecutive messages by the
@@ -33,6 +39,7 @@ export function ConversationThread({
   firstUnreadIndex,
   readHorizonIndex,
   onReact,
+  fillHeight,
 }: Props): React.ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);
@@ -89,10 +96,13 @@ export function ConversationThread({
       : null;
 
   return (
-    <div className="relative">
+    <div className={cn("relative", fillHeight && "flex-1 flex flex-col min-h-0")}>
       <div
         ref={scrollRef}
-        className="flex flex-col gap-4 p-4 overflow-y-auto max-h-[60vh]"
+        className={cn(
+          "flex flex-col gap-4 p-4 overflow-y-auto",
+          fillHeight ? "flex-1 min-h-0" : "max-h-[60vh]",
+        )}
         role="log"
         aria-live="polite"
         aria-relevant="additions"

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -1,39 +1,57 @@
-import { useEffect, useRef } from "react";
-import { cn } from "@/lib/cn";
-import { ConversationAvatar } from "./ConversationAvatar";
-import { ConversationBubble, bubblePositionOf } from "./ConversationBubble";
-import type { AuthorInfo, AuthorMap, ChatMessage } from "./useConversation";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ConversationGroup } from "./ConversationGroup";
+import { buildThreadItems } from "./threadItems";
+import type { AuthorMap, ChatMessage } from "./useConversation";
 
 interface Props {
   messages: readonly ChatMessage[];
   currentIdentity: string | null;
   authors: AuthorMap;
   loading?: boolean;
-}
-
-interface MessageGroup {
-  key: string;
-  author: string;
-  mine: boolean;
-  info: AuthorInfo;
-  messages: readonly ChatMessage[];
+  /** First unread Twilio message index as seen by the current
+   *  participant. When set, the thread inserts a "New messages"
+   *  divider just before that index. */
+  firstUnreadIndex?: number | null;
+  /** Highest message index the other side has marked as read. When
+   *  provided, the last mine=true bubble at or below this index gets
+   *  a "Read" receipt rendered under it. */
+  readHorizonIndex?: number | null;
 }
 
 /** Bubble list styled after Messenger: consecutive messages by the
  *  same author collapse into one group, one avatar at the bottom
  *  (theirs) or no avatar (mine), bubbles stack tight with shaped
  *  border-radius so the group reads as a single connected shape on
- *  the avatar-facing side. */
+ *  the avatar-facing side. Day dividers appear between messages
+ *  from different local days; a "New messages" divider appears
+ *  before the first unread incoming message. */
 export function ConversationThread({
   messages,
   currentIdentity,
   authors,
   loading,
+  firstUnreadIndex,
+  readHorizonIndex,
 }: Props): React.ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [atBottom, setAtBottom] = useState(true);
+
+  const items = useMemo(
+    () =>
+      buildThreadItems({
+        messages,
+        currentIdentity,
+        authors,
+        firstUnreadIndex: firstUnreadIndex ?? null,
+      }),
+    [messages, currentIdentity, authors, firstUnreadIndex],
+  );
+
   useEffect(() => {
-    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
-  }, [messages.length]);
+    const el = scrollRef.current;
+    if (!el) return;
+    if (atBottom) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }, [items, atBottom]);
 
   if (loading) {
     return <p className="font-serif italic text-[14px] text-walnut-3 p-4">Loading conversation…</p>;
@@ -46,84 +64,74 @@ export function ConversationThread({
     );
   }
 
-  const groups = groupMessages(messages, currentIdentity, authors);
+  const lastMineIndex = findLastMineIndex(messages, currentIdentity);
+  const readByOtherAt =
+    typeof readHorizonIndex === "number" && lastMineIndex !== null && readHorizonIndex >= lastMineIndex
+      ? lastMineIndex
+      : null;
 
   return (
-    <div ref={scrollRef} className="flex flex-col gap-4 p-4 overflow-y-auto max-h-[60vh]">
-      {groups.map((g) => (
-        <Group key={g.key} group={g} />
-      ))}
+    <div
+      ref={scrollRef}
+      className="flex flex-col gap-4 p-4 overflow-y-auto max-h-[60vh]"
+      role="log"
+      aria-live="polite"
+      aria-relevant="additions"
+      onScroll={(e) => {
+        const el = e.currentTarget;
+        setAtBottom(el.scrollHeight - el.scrollTop - el.clientHeight < 32);
+      }}
+    >
+      {items.map((item) => {
+        if (item.kind === "day") return <DayDivider key={item.key} label={item.label} />;
+        if (item.kind === "unread") return <UnreadDivider key={item.key} />;
+        return (
+          <ConversationGroup
+            key={item.key}
+            group={item.group}
+            readByOther={
+              item.group.mine &&
+              readByOtherAt !== null &&
+              item.group.messages.some((m) => m.index === readByOtherAt)
+            }
+          />
+        );
+      })}
     </div>
   );
 }
 
-function groupMessages(
+function findLastMineIndex(
   messages: readonly ChatMessage[],
   currentIdentity: string | null,
-  authors: AuthorMap,
-): MessageGroup[] {
-  const groups: MessageGroup[] = [];
-  for (const m of messages) {
-    const last = groups.at(-1);
-    if (last && last.author === m.author) {
-      last.messages = [...last.messages, m];
-      continue;
-    }
-    groups.push({
-      key: m.sid,
-      author: m.author,
-      mine: m.author === currentIdentity,
-      info: authors.get(m.author) ?? fallbackAuthor(m.author),
-      messages: [m],
-    });
+): number | null {
+  if (!currentIdentity) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.author === currentIdentity) return messages[i]!.index;
   }
-  return groups;
+  return null;
 }
 
-function fallbackAuthor(identity: string): AuthorInfo {
-  if (identity.startsWith("speaker:")) return { displayName: "Speaker", role: "speaker" };
-  if (identity.startsWith("uid:")) return { displayName: "Bishopric" };
-  return { displayName: "Unknown" };
-}
-
-function Group({ group }: { group: MessageGroup }) {
-  const lastMessage = group.messages.at(-1)!;
-  const timestamp = lastMessage.dateCreated?.toLocaleString(undefined, {
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "2-digit",
-  });
+function DayDivider({ label }: { label: string }) {
   return (
-    <div className={cn("flex flex-col gap-1", group.mine ? "items-end" : "items-start")}>
-      <div
-        className={cn(
-          "flex items-end gap-2 max-w-[85%]",
-          group.mine ? "flex-row-reverse" : "flex-row",
-        )}
-      >
-        {!group.mine && <ConversationAvatar author={group.info} />}
-        <div
-          className={cn("flex flex-col gap-0.5 min-w-0", group.mine ? "items-end" : "items-start")}
-        >
-          {!group.mine && (
-            <span className="font-mono text-[9.5px] tracking-[0.08em] text-walnut-3 mb-0.5 max-w-full truncate">
-              {group.info.displayName}
-            </span>
-          )}
-          {group.messages.map((m, i) => (
-            <ConversationBubble
-              key={m.sid}
-              message={m}
-              mine={group.mine}
-              position={bubblePositionOf(i, group.messages.length)}
-            />
-          ))}
-          {timestamp && (
-            <span className="font-mono text-[9.5px] text-walnut-3 mt-0.5">{timestamp}</span>
-          )}
-        </div>
-      </div>
+    <div className="flex items-center gap-2 -my-1" aria-label={label}>
+      <div className="flex-1 h-px bg-border" />
+      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3">
+        {label}
+      </span>
+      <div className="flex-1 h-px bg-border" />
+    </div>
+  );
+}
+
+function UnreadDivider() {
+  return (
+    <div className="flex items-center gap-2 -my-1" aria-label="New messages">
+      <div className="flex-1 h-px bg-bordeaux/40" />
+      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-bordeaux">
+        New
+      </span>
+      <div className="flex-1 h-px bg-bordeaux/40" />
     </div>
   );
 }

--- a/src/features/invitations/InvitationLinkActions.test.tsx
+++ b/src/features/invitations/InvitationLinkActions.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./invitationsCallable", () => ({
+  callRotateInvitationLink: vi.fn(),
+}));
+
+import { callRotateInvitationLink } from "./invitationsCallable";
+import { InvitationLinkActions } from "./InvitationLinkActions";
+import type { SpeakerInvitation } from "@/lib/types";
+
+const mockFn = vi.mocked(callRotateInvitationLink);
+
+function mkInvitation(overrides: Partial<SpeakerInvitation> = {}): SpeakerInvitation {
+  return {
+    speakerRef: { meetingDate: "2026-05-03", speakerId: "sp1" },
+    assignedDate: "Sunday, May 3, 2026",
+    sentOn: "April 22, 2026",
+    wardName: "Elk River Ward",
+    speakerName: "Sister Jones",
+    inviterName: "Bishop Smith",
+    bodyMarkdown: "body",
+    footerMarkdown: "footer",
+    speakerEmail: "jones@example.com",
+    speakerPhone: "+14165551234",
+    deliveryRecord: [],
+    createdAt: new Date() as unknown as SpeakerInvitation["createdAt"],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockFn.mockReset();
+  Object.assign(navigator, {
+    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("InvitationLinkActions", () => {
+  it("calls rotate with empty channels for Copy link, writes URL to clipboard", async () => {
+    mockFn.mockResolvedValue({
+      mode: "rotate",
+      inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
+      deliveryRecord: [],
+    });
+    render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
+    fireEvent.click(screen.getByText("Copy link"));
+    await waitFor(() => expect(screen.getByText("Copied ✓")).toBeTruthy());
+    expect(mockFn).toHaveBeenCalledWith({
+      mode: "rotate",
+      wardId: "w1",
+      invitationId: "i1",
+      channels: [],
+    });
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://app.example/invite/speaker/w1/i1/tok",
+    );
+  });
+
+  it("resend button includes both channels when invitation has email + phone", () => {
+    render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
+    expect(screen.getByText("Resend EMAIL + SMS")).toBeTruthy();
+  });
+
+  it("resend button is disabled when invitation has no email or phone", () => {
+    const inv = mkInvitation({ speakerEmail: undefined, speakerPhone: undefined });
+    render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
+    const btn = screen.getByTitle("No email or phone on file") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("surfaces a partial-failure message when every delivery failed", async () => {
+    mockFn.mockResolvedValue({
+      mode: "rotate",
+      inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
+      deliveryRecord: [{ channel: "sms", status: "failed", error: "twilio: 21610", at: "now" }],
+    });
+    const inv = mkInvitation({ speakerEmail: undefined });
+    render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
+    fireEvent.click(screen.getByText("Resend SMS"));
+    await waitFor(() => expect(screen.getByText("All delivery attempts failed.")).toBeTruthy());
+  });
+
+  it("reports the channels that actually sent on success", async () => {
+    mockFn.mockResolvedValue({
+      mode: "rotate",
+      inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
+      deliveryRecord: [
+        { channel: "sms", status: "sent", providerId: "SM1", at: "now" },
+        { channel: "email", status: "failed", error: "bounced", at: "now" },
+      ],
+    });
+    render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
+    fireEvent.click(screen.getByText("Resend EMAIL + SMS"));
+    await waitFor(() => expect(screen.getByText("Sent via SMS")).toBeTruthy());
+  });
+});

--- a/src/features/invitations/InvitationLinkActions.test.tsx
+++ b/src/features/invitations/InvitationLinkActions.test.tsx
@@ -29,6 +29,10 @@ function mkInvitation(overrides: Partial<SpeakerInvitation> = {}): SpeakerInvita
   };
 }
 
+function openMenu() {
+  fireEvent.click(screen.getByRole("button", { name: "Invitation link actions" }));
+}
+
 beforeEach(() => {
   mockFn.mockReset();
   Object.assign(navigator, {
@@ -41,15 +45,22 @@ afterEach(() => {
 });
 
 describe("InvitationLinkActions", () => {
-  it("calls rotate with empty channels for Copy link, writes URL to clipboard", async () => {
+  it("renders an overflow menu trigger, not visible action buttons", () => {
+    render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
+    expect(screen.queryByText("Copy link")).toBeNull();
+    expect(screen.getByRole("button", { name: "Invitation link actions" })).toBeTruthy();
+  });
+
+  it("Copy link menu item rotates with empty channels and writes URL to clipboard", async () => {
     mockFn.mockResolvedValue({
       mode: "rotate",
       inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
       deliveryRecord: [],
     });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
-    fireEvent.click(screen.getByText("Copy link"));
-    await waitFor(() => expect(screen.getByText("Copied ✓")).toBeTruthy());
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy link" }));
+    await waitFor(() => expect(screen.getByText("Link copied")).toBeTruthy());
     expect(mockFn).toHaveBeenCalledWith({
       mode: "rotate",
       wardId: "w1",
@@ -61,19 +72,21 @@ describe("InvitationLinkActions", () => {
     );
   });
 
-  it("resend button includes both channels when invitation has email + phone", () => {
+  it("Resend menu item shows both channels when invitation has email + phone", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
-    expect(screen.getByText("Resend EMAIL + SMS")).toBeTruthy();
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" })).toBeTruthy();
   });
 
-  it("resend button is disabled when invitation has no email or phone", () => {
+  it("omits the Resend item entirely when no channel is available", () => {
     const inv = mkInvitation({ speakerEmail: undefined, speakerPhone: undefined });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
-    const btn = screen.getByTitle("No email or phone on file") as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
+    openMenu();
+    expect(screen.getByRole("menuitem", { name: "Copy link" })).toBeTruthy();
+    expect(screen.queryByRole("menuitem", { name: /Resend/ })).toBeNull();
   });
 
-  it("surfaces a partial-failure message when every delivery failed", async () => {
+  it("surfaces a delivery-failed message when every delivery failed", async () => {
     mockFn.mockResolvedValue({
       mode: "rotate",
       inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
@@ -81,8 +94,9 @@ describe("InvitationLinkActions", () => {
     });
     const inv = mkInvitation({ speakerEmail: undefined });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
-    fireEvent.click(screen.getByText("Resend SMS"));
-    await waitFor(() => expect(screen.getByText("All delivery attempts failed.")).toBeTruthy());
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via SMS" }));
+    await waitFor(() => expect(screen.getByText("Delivery failed.")).toBeTruthy());
   });
 
   it("reports the channels that actually sent on success", async () => {
@@ -95,7 +109,8 @@ describe("InvitationLinkActions", () => {
       ],
     });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
-    fireEvent.click(screen.getByText("Resend EMAIL + SMS"));
+    openMenu();
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
     await waitFor(() => expect(screen.getByText("Sent via SMS")).toBeTruthy());
   });
 });

--- a/src/features/invitations/InvitationLinkActions.tsx
+++ b/src/features/invitations/InvitationLinkActions.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import type { SpeakerInvitation } from "@/lib/types";
+import { callRotateInvitationLink } from "./invitationsCallable";
+
+interface Props {
+  wardId: string;
+  invitationId: string;
+  invitation: SpeakerInvitation;
+}
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "working"; verb: "copy" | "resend" }
+  | { kind: "copied" }
+  | { kind: "sent"; channels: readonly ("email" | "sms")[] }
+  | { kind: "error"; message: string };
+
+/** Two-button panel for the bishop viewing an already-sent invitation:
+ *  rotate + copy the URL, or rotate + re-deliver via the same channels
+ *  the invitation originally used. Both actions invalidate any prior
+ *  URL the speaker has — the server-side self-heal path handles any
+ *  concurrent visit to an older link. */
+export function InvitationLinkActions({
+  wardId,
+  invitationId,
+  invitation,
+}: Props): React.ReactElement {
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  const deliverable = availableChannels(invitation);
+
+  async function copy() {
+    setStatus({ kind: "working", verb: "copy" });
+    try {
+      const res = await callRotateInvitationLink({
+        mode: "rotate",
+        wardId,
+        invitationId,
+        channels: [],
+      });
+      await navigator.clipboard.writeText(res.inviteUrl);
+      setStatus({ kind: "copied" });
+    } catch (err) {
+      setStatus({ kind: "error", message: (err as Error).message });
+    }
+  }
+
+  async function resend() {
+    if (deliverable.length === 0) return;
+    setStatus({ kind: "working", verb: "resend" });
+    try {
+      const res = await callRotateInvitationLink({
+        mode: "rotate",
+        wardId,
+        invitationId,
+        channels: deliverable,
+      });
+      const sent = res.deliveryRecord.filter((d) => d.status === "sent").map((d) => d.channel);
+      if (sent.length === 0) {
+        setStatus({ kind: "error", message: "All delivery attempts failed." });
+        return;
+      }
+      setStatus({ kind: "sent", channels: sent });
+    } catch (err) {
+      setStatus({ kind: "error", message: (err as Error).message });
+    }
+  }
+
+  const working = status.kind === "working";
+
+  return (
+    <div className="flex flex-col gap-1 items-end">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={copy}
+          disabled={working}
+          className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-2 hover:text-walnut px-2 py-1 border border-border rounded-md hover:bg-parchment-2 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          {copyLabel(status)}
+        </button>
+        <button
+          type="button"
+          onClick={resend}
+          disabled={working || deliverable.length === 0}
+          title={deliverable.length === 0 ? "No email or phone on file" : undefined}
+          className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment px-2 py-1 border border-bordeaux-deep bg-bordeaux hover:bg-bordeaux-deep rounded-md disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+        >
+          {status.kind === "working" && status.verb === "resend"
+            ? "Sending…"
+            : `Resend ${formatChannels(deliverable)}`}
+        </button>
+      </div>
+      {status.kind === "sent" && (
+        <p className="font-mono text-[10px] text-walnut-3" aria-live="polite">
+          Sent via {formatChannels(status.channels)}
+        </p>
+      )}
+      {status.kind === "error" && (
+        <p className="font-mono text-[10px] text-bordeaux" aria-live="polite">
+          {status.message}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function availableChannels(invitation: SpeakerInvitation): readonly ("email" | "sms")[] {
+  const out: ("email" | "sms")[] = [];
+  if (invitation.speakerEmail) out.push("email");
+  if (invitation.speakerPhone) out.push("sms");
+  return out;
+}
+
+function copyLabel(status: Status): string {
+  if (status.kind === "copied") return "Copied ✓";
+  if (status.kind === "working" && status.verb === "copy") return "Copying…";
+  return "Copy link";
+}
+
+function formatChannels(channels: readonly ("email" | "sms")[]): string {
+  if (channels.length === 0) return "";
+  if (channels.length === 1) return channels[0]!.toUpperCase();
+  return channels.map((c) => c.toUpperCase()).join(" + ");
+}

--- a/src/features/invitations/InvitationLinkActions.tsx
+++ b/src/features/invitations/InvitationLinkActions.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { OverflowMenu, type OverflowMenuItem } from "@/components/ui/OverflowMenu";
 import type { SpeakerInvitation } from "@/lib/types";
 import { callRotateInvitationLink } from "./invitationsCallable";
 
@@ -15,8 +16,10 @@ type Status =
   | { kind: "sent"; channels: readonly ("email" | "sms")[] }
   | { kind: "error"; message: string };
 
-/** Two-button panel for the bishop viewing an already-sent invitation:
- *  rotate + copy the URL, or rotate + re-deliver via the same channels
+const FLASH_MS = 2500;
+
+/** Overflow menu for the bishop viewing an already-sent invitation:
+ *  rotate + copy the URL, or rotate + re-deliver via the channels
  *  the invitation originally used. Both actions invalidate any prior
  *  URL the speaker has — the server-side self-heal path handles any
  *  concurrent visit to an older link. */
@@ -26,8 +29,13 @@ export function InvitationLinkActions({
   invitation,
 }: Props): React.ReactElement {
   const [status, setStatus] = useState<Status>({ kind: "idle" });
-
   const deliverable = availableChannels(invitation);
+
+  useEffect(() => {
+    if (status.kind !== "copied" && status.kind !== "sent") return;
+    const t = setTimeout(() => setStatus({ kind: "idle" }), FLASH_MS);
+    return () => clearTimeout(t);
+  }, [status]);
 
   async function copy() {
     setStatus({ kind: "working", verb: "copy" });
@@ -57,7 +65,7 @@ export function InvitationLinkActions({
       });
       const sent = res.deliveryRecord.filter((d) => d.status === "sent").map((d) => d.channel);
       if (sent.length === 0) {
-        setStatus({ kind: "error", message: "All delivery attempts failed." });
+        setStatus({ kind: "error", message: "Delivery failed." });
         return;
       }
       setStatus({ kind: "sent", channels: sent });
@@ -66,41 +74,30 @@ export function InvitationLinkActions({
     }
   }
 
-  const working = status.kind === "working";
+  const items: OverflowMenuItem[] = [{ label: "Copy link", onSelect: () => void copy() }];
+  if (deliverable.length > 0) {
+    items.push({
+      label: `Resend via ${formatChannels(deliverable)}`,
+      onSelect: () => void resend(),
+    });
+  }
 
   return (
-    <div className="flex flex-col gap-1 items-end">
-      <div className="flex items-center gap-2">
-        <button
-          type="button"
-          onClick={copy}
-          disabled={working}
-          className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-2 hover:text-walnut px-2 py-1 border border-border rounded-md hover:bg-parchment-2 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+    <div className="flex items-center gap-2">
+      {status.kind !== "idle" && (
+        <span
+          role="status"
+          aria-live="polite"
+          className={
+            status.kind === "error"
+              ? "font-mono text-[10px] uppercase tracking-[0.14em] text-bordeaux"
+              : "font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3"
+          }
         >
-          {copyLabel(status)}
-        </button>
-        <button
-          type="button"
-          onClick={resend}
-          disabled={working || deliverable.length === 0}
-          title={deliverable.length === 0 ? "No email or phone on file" : undefined}
-          className="font-mono text-[10px] uppercase tracking-[0.14em] text-parchment px-2 py-1 border border-bordeaux-deep bg-bordeaux hover:bg-bordeaux-deep rounded-md disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
-        >
-          {status.kind === "working" && status.verb === "resend"
-            ? "Sending…"
-            : `Resend ${formatChannels(deliverable)}`}
-        </button>
-      </div>
-      {status.kind === "sent" && (
-        <p className="font-mono text-[10px] text-walnut-3" aria-live="polite">
-          Sent via {formatChannels(status.channels)}
-        </p>
+          {statusLabel(status)}
+        </span>
       )}
-      {status.kind === "error" && (
-        <p className="font-mono text-[10px] text-bordeaux" aria-live="polite">
-          {status.message}
-        </p>
-      )}
+      <OverflowMenu items={items} ariaLabel="Invitation link actions" />
     </div>
   );
 }
@@ -112,10 +109,11 @@ function availableChannels(invitation: SpeakerInvitation): readonly ("email" | "
   return out;
 }
 
-function copyLabel(status: Status): string {
-  if (status.kind === "copied") return "Copied ✓";
-  if (status.kind === "working" && status.verb === "copy") return "Copying…";
-  return "Copy link";
+function statusLabel(status: Status): string {
+  if (status.kind === "working") return status.verb === "copy" ? "Copying…" : "Sending…";
+  if (status.kind === "copied") return "Link copied";
+  if (status.kind === "sent") return `Sent via ${formatChannels(status.channels)}`;
+  return status.message;
 }
 
 function formatChannels(channels: readonly ("email" | "sms")[]): string {

--- a/src/features/invitations/JumpToLatest.tsx
+++ b/src/features/invitations/JumpToLatest.tsx
@@ -1,0 +1,36 @@
+interface Props {
+  unseenCount: number;
+  onJump: () => void;
+}
+
+/** Floating pill over the bottom of the scroll region. Appears when
+ *  the user has scrolled up (parent decides); surfaces the count of
+ *  messages that arrived while they were reading history. Click or
+ *  Enter/Space activates jump-to-bottom. */
+export function JumpToLatest({ unseenCount, onJump }: Props): React.ReactElement {
+  const label = labelFor(unseenCount);
+  return (
+    <button
+      type="button"
+      onClick={onJump}
+      className="absolute left-1/2 -translate-x-1/2 bottom-3 font-sans text-[12px] font-semibold px-3 py-1.5 rounded-full bg-bordeaux text-parchment border border-bordeaux-deep shadow-[0_2px_6px_rgba(35,24,21,0.25)] hover:bg-bordeaux-deep focus:outline-none focus-visible:ring-2 focus-visible:ring-bordeaux/40 transition-colors"
+      aria-label={label}
+    >
+      {unseenCount > 0 && (
+        <span
+          aria-hidden="true"
+          className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-parchment text-bordeaux text-[10.5px] font-bold mr-1.5 align-[-1px]"
+        >
+          {unseenCount > 99 ? "99+" : unseenCount}
+        </span>
+      )}
+      <span aria-hidden="true">↓ Latest</span>
+    </button>
+  );
+}
+
+function labelFor(unseen: number): string {
+  if (unseen === 0) return "Jump to latest";
+  if (unseen === 1) return "1 new · jump to latest";
+  return `${unseen} new · jump to latest`;
+}

--- a/src/features/invitations/ReactionBar.tsx
+++ b/src/features/invitations/ReactionBar.tsx
@@ -1,0 +1,49 @@
+import { cn } from "@/lib/cn";
+import type { Reactions } from "./reactions";
+
+interface Props {
+  reactions: Reactions;
+  selfIdentity: string | null;
+  onToggle: (emoji: string) => void;
+  mine: boolean;
+}
+
+/** Chip row of applied reactions under a bubble. Each chip shows
+ *  the emoji + count; clicking toggles the caller's own identity in
+ *  or out of the set. Chips the caller has reacted with get a
+ *  filled background so they read as "selected". Renders nothing
+ *  when there are no reactions. */
+export function ReactionBar({
+  reactions,
+  selfIdentity,
+  onToggle,
+  mine,
+}: Props): React.ReactElement | null {
+  const entries = Object.entries(reactions).filter(([, ids]) => ids.length > 0);
+  if (entries.length === 0) return null;
+  return (
+    <div className={cn("flex flex-wrap gap-1 mt-0.5", mine ? "justify-end" : "justify-start")}>
+      {entries.map(([emoji, ids]) => {
+        const mineReacted = selfIdentity !== null && ids.includes(selfIdentity);
+        return (
+          <button
+            key={emoji}
+            type="button"
+            onClick={() => onToggle(emoji)}
+            aria-pressed={mineReacted}
+            aria-label={`${emoji} ${ids.length}${mineReacted ? " (you reacted)" : ""}`}
+            className={cn(
+              "inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full border text-[11px] font-medium transition-colors",
+              mineReacted
+                ? "bg-brass-soft border-brass-soft text-brass-deep"
+                : "bg-parchment-2 border-border text-walnut-2 hover:bg-chalk",
+            )}
+          >
+            <span aria-hidden="true">{emoji}</span>
+            <span className="font-mono text-[10px]">{ids.length}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/features/invitations/ReactionPicker.tsx
+++ b/src/features/invitations/ReactionPicker.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/cn";
+import { REACTION_EMOJI } from "./reactions";
+
+interface Props {
+  onPick: (emoji: string) => void;
+  mine: boolean;
+}
+
+/** Small "+" trigger + popover with the fixed reaction emoji set.
+ *  Renders inline beside a bubble; the popover closes on outside
+ *  click or Escape. Kept intentionally minimal — no custom emoji,
+ *  no skin tones — to stay under the component cap and avoid the
+ *  emoji-picker dependency cost on a tiny chat surface. */
+export function ReactionPicker({ onPick, mine }: Props): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDown = (e: MouseEvent) => {
+      if (!rootRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("keydown", onKey);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Add reaction"
+        aria-expanded={open}
+        className="opacity-40 hover:opacity-100 focus-visible:opacity-100 w-6 h-6 rounded-full border border-border bg-chalk text-walnut-3 text-[12px] leading-none flex items-center justify-center hover:bg-parchment-2 transition-opacity"
+      >
+        <span aria-hidden="true">+</span>
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            "absolute z-10 bottom-full mb-1 flex gap-1 bg-chalk border border-border rounded-full px-2 py-1 shadow-elev-1",
+            mine ? "right-0" : "left-0",
+          )}
+        >
+          {REACTION_EMOJI.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                onPick(emoji);
+                setOpen(false);
+              }}
+              className="w-7 h-7 text-[16px] leading-none rounded-full hover:bg-parchment-2 focus-visible:bg-parchment-2 focus:outline-none transition-colors"
+              aria-label={`React with ${emoji}`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -4,8 +4,11 @@ import { inviteAuth } from "@/lib/firebase";
 import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
 import { QuickActionButtons } from "./QuickActionButtons";
+import { TypingIndicator } from "./TypingIndicator";
 import { useConversation, type AuthorInfo, type AuthorMap } from "./useConversation";
 import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
+import { useReadHorizon } from "./useReadHorizon";
+import { useTypingParticipants } from "./useTypingParticipants";
 import { useSpeakerHeartbeat } from "./useSpeakerHeartbeat";
 import { useTwilioChat } from "./twilioClientProvider";
 import { writeSpeakerResponse } from "./invitationActions";
@@ -33,6 +36,8 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
   const twilio = useTwilioChat();
   const { messages, conversation, authors, loading } = useConversation(props.conversationSid);
   const firstUnreadIndex = useFirstUnreadIndex(conversation);
+  const readHorizon = useReadHorizon(conversation, twilio.identity);
+  const typing = useTypingParticipants(conversation, twilio.identity);
 
   useEffect(() => onAuthStateChanged(inviteAuth, setUser), []);
   useSpeakerHeartbeat({
@@ -115,7 +120,10 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         authors={resolvedAuthors}
         loading={loading && twilio.status === "ready"}
         firstUnreadIndex={firstUnreadIndex}
+        readHorizonIndex={readHorizon}
       />
+
+      <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />
 
       {!props.hasResponse && (
         <QuickActionButtons

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -5,6 +5,7 @@ import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
 import { QuickActionButtons } from "./QuickActionButtons";
 import { useConversation, type AuthorInfo, type AuthorMap } from "./useConversation";
+import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
 import { useSpeakerHeartbeat } from "./useSpeakerHeartbeat";
 import { useTwilioChat } from "./twilioClientProvider";
 import { writeSpeakerResponse } from "./invitationActions";
@@ -31,6 +32,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
   const [user, setUser] = useState<User | null>(inviteAuth.currentUser);
   const twilio = useTwilioChat();
   const { messages, conversation, authors, loading } = useConversation(props.conversationSid);
+  const firstUnreadIndex = useFirstUnreadIndex(conversation);
 
   useEffect(() => onAuthStateChanged(inviteAuth, setUser), []);
   useSpeakerHeartbeat({
@@ -112,6 +114,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         currentIdentity={twilio.identity}
         authors={resolvedAuthors}
         loading={loading && twilio.status === "ready"}
+        firstUnreadIndex={firstUnreadIndex}
       />
 
       {!props.hasResponse && (

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -34,7 +34,9 @@ interface Props {
 export function SpeakerInvitationChat(props: Props): React.ReactElement {
   const [user, setUser] = useState<User | null>(inviteAuth.currentUser);
   const twilio = useTwilioChat();
-  const { messages, conversation, authors, loading } = useConversation(props.conversationSid);
+  const { messages, conversation, authors, loading, toggleReaction } = useConversation(
+    props.conversationSid,
+  );
   const firstUnreadIndex = useFirstUnreadIndex(conversation);
   const readHorizon = useReadHorizon(conversation, twilio.identity);
   const typing = useTypingParticipants(conversation, twilio.identity);
@@ -121,6 +123,9 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         loading={loading && twilio.status === "ready"}
         firstUnreadIndex={firstUnreadIndex}
         readHorizonIndex={readHorizon}
+        onReact={(sid, emoji) => {
+          if (twilio.identity) void toggleReaction(sid, emoji, twilio.identity);
+        }}
       />
 
       <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />

--- a/src/features/invitations/ThreadDividers.tsx
+++ b/src/features/invitations/ThreadDividers.tsx
@@ -3,22 +3,40 @@
  *  first message the participant hasn't read in this session. */
 export function DayDivider({ label }: { label: string }): React.ReactElement {
   return (
-    <div className="flex items-center gap-2 -my-1" aria-label={label}>
-      <div className="flex-1 h-px bg-border" />
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3">
+    <div
+      className="flex items-center gap-2 -my-1"
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label={label}
+    >
+      <div aria-hidden="true" className="flex-1 h-px bg-border" />
+      <span
+        aria-hidden="true"
+        className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3"
+      >
         {label}
       </span>
-      <div className="flex-1 h-px bg-border" />
+      <div aria-hidden="true" className="flex-1 h-px bg-border" />
     </div>
   );
 }
 
 export function UnreadDivider(): React.ReactElement {
   return (
-    <div className="flex items-center gap-2 -my-1" aria-label="New messages">
-      <div className="flex-1 h-px bg-bordeaux/40" />
-      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-bordeaux">New</span>
-      <div className="flex-1 h-px bg-bordeaux/40" />
+    <div
+      className="flex items-center gap-2 -my-1"
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label="New messages below"
+    >
+      <div aria-hidden="true" className="flex-1 h-px bg-bordeaux/40" />
+      <span
+        aria-hidden="true"
+        className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-bordeaux"
+      >
+        New
+      </span>
+      <div aria-hidden="true" className="flex-1 h-px bg-bordeaux/40" />
     </div>
   );
 }

--- a/src/features/invitations/ThreadDividers.tsx
+++ b/src/features/invitations/ThreadDividers.tsx
@@ -1,0 +1,24 @@
+/** Slim horizontal rules with a centered eyebrow label. Day dividers
+ *  separate messages by local date; the unread divider marks the
+ *  first message the participant hasn't read in this session. */
+export function DayDivider({ label }: { label: string }): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2 -my-1" aria-label={label}>
+      <div className="flex-1 h-px bg-border" />
+      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3">
+        {label}
+      </span>
+      <div className="flex-1 h-px bg-border" />
+    </div>
+  );
+}
+
+export function UnreadDivider(): React.ReactElement {
+  return (
+    <div className="flex items-center gap-2 -my-1" aria-label="New messages">
+      <div className="flex-1 h-px bg-bordeaux/40" />
+      <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-bordeaux">New</span>
+      <div className="flex-1 h-px bg-bordeaux/40" />
+    </div>
+  );
+}

--- a/src/features/invitations/TypingIndicator.tsx
+++ b/src/features/invitations/TypingIndicator.tsx
@@ -8,10 +8,7 @@ interface Props {
 /** One-line "X is typing…" row with an animated three-dot affordance.
  *  Renders nothing when no one is typing, so the caller doesn't need
  *  to gate on length. */
-export function TypingIndicator({
-  typingIdentities,
-  authors,
-}: Props): React.ReactElement | null {
+export function TypingIndicator({ typingIdentities, authors }: Props): React.ReactElement | null {
   if (typingIdentities.length === 0) return null;
   const names = typingIdentities.map((id) => authors.get(id)?.displayName ?? "Someone");
   const label = formatTypingLabel(names);

--- a/src/features/invitations/TypingIndicator.tsx
+++ b/src/features/invitations/TypingIndicator.tsx
@@ -1,0 +1,47 @@
+import type { AuthorMap } from "./useConversation";
+
+interface Props {
+  typingIdentities: readonly string[];
+  authors: AuthorMap;
+}
+
+/** One-line "X is typing…" row with an animated three-dot affordance.
+ *  Renders nothing when no one is typing, so the caller doesn't need
+ *  to gate on length. */
+export function TypingIndicator({
+  typingIdentities,
+  authors,
+}: Props): React.ReactElement | null {
+  if (typingIdentities.length === 0) return null;
+  const names = typingIdentities.map((id) => authors.get(id)?.displayName ?? "Someone");
+  const label = formatTypingLabel(names);
+  return (
+    <div
+      className="flex items-center gap-2 px-4 py-1.5 border-t border-border bg-parchment"
+      aria-live="polite"
+    >
+      <span className="flex gap-1">
+        <Dot delay={0} />
+        <Dot delay={150} />
+        <Dot delay={300} />
+      </span>
+      <span className="font-serif italic text-[12px] text-walnut-3">{label}</span>
+    </div>
+  );
+}
+
+function Dot({ delay }: { delay: number }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="w-1.5 h-1.5 rounded-full bg-walnut-3 animate-bounce"
+      style={{ animationDelay: `${delay}ms`, animationDuration: "1s" }}
+    />
+  );
+}
+
+function formatTypingLabel(names: readonly string[]): string {
+  if (names.length === 1) return `${names[0]} is typing…`;
+  if (names.length === 2) return `${names[0]} and ${names[1]} are typing…`;
+  return `${names[0]} and ${names.length - 1} others are typing…`;
+}

--- a/src/features/invitations/conversationHelpers.ts
+++ b/src/features/invitations/conversationHelpers.ts
@@ -1,0 +1,29 @@
+import type { Message, Participant } from "@twilio/conversations";
+import type { AuthorInfo, ChatMessage } from "./useConversation";
+
+export function toChatMessage(m: Message): ChatMessage {
+  let attributes: Record<string, unknown> | null = null;
+  const raw = m.attributes;
+  if (raw && typeof raw === "object") attributes = raw as Record<string, unknown>;
+  return {
+    sid: m.sid,
+    index: m.index,
+    author: m.author ?? "",
+    body: m.body ?? "",
+    dateCreated: m.dateCreated ?? null,
+    attributes,
+  };
+}
+
+export function parseAuthorInfo(p: Participant): AuthorInfo | null {
+  const attrs = p.attributes as {
+    displayName?: string;
+    role?: AuthorInfo["role"];
+    email?: string;
+  } | null;
+  if (!attrs?.displayName) return null;
+  const info: AuthorInfo = { displayName: attrs.displayName };
+  if (attrs.role) info.role = attrs.role;
+  if (attrs.email) info.email = attrs.email;
+  return info;
+}

--- a/src/features/invitations/invitationsCallable.ts
+++ b/src/features/invitations/invitationsCallable.ts
@@ -1,7 +1,8 @@
 import { httpsCallable, type Functions } from "firebase/functions";
 import { functions, inviteFunctions } from "@/lib/firebase";
 
-export interface SendSpeakerInvitationRequest {
+export interface FreshInvitationRequest {
+  mode?: "fresh";
   wardId: string;
   speakerId: string;
   meetingDate: string;
@@ -20,6 +21,15 @@ export interface SendSpeakerInvitationRequest {
   expiresAtMillis: number;
 }
 
+export interface RotateInvitationRequest {
+  mode: "rotate";
+  wardId: string;
+  invitationId: string;
+  channels: ("email" | "sms")[];
+}
+
+export type SendSpeakerInvitationRequest = FreshInvitationRequest | RotateInvitationRequest;
+
 export interface DeliveryEntry {
   channel: "email" | "sms";
   status: "sent" | "failed";
@@ -28,16 +38,40 @@ export interface DeliveryEntry {
   at: string;
 }
 
-export interface SendSpeakerInvitationResponse {
+export interface FreshInvitationResponse {
+  mode: "fresh";
   token: string;
   conversationSid: string;
   deliveryRecord: DeliveryEntry[];
 }
 
+export interface RotateInvitationResponse {
+  mode: "rotate";
+  inviteUrl: string;
+  deliveryRecord: DeliveryEntry[];
+}
+
+export type SendSpeakerInvitationResponse = FreshInvitationResponse | RotateInvitationResponse;
+
 export async function callSendSpeakerInvitation(
-  input: SendSpeakerInvitationRequest,
-): Promise<SendSpeakerInvitationResponse> {
-  const fn = httpsCallable<SendSpeakerInvitationRequest, SendSpeakerInvitationResponse>(
+  input: FreshInvitationRequest,
+): Promise<FreshInvitationResponse> {
+  const fn = httpsCallable<FreshInvitationRequest, FreshInvitationResponse>(
+    functions,
+    "sendSpeakerInvitation",
+  );
+  const { data } = await fn(input);
+  return data;
+}
+
+/** Bishop-driven: rotate the capability token on an existing
+ *  invitation and optionally redeliver via email/SMS. Pass
+ *  `channels: []` for a copy-link-only flow that returns the new
+ *  URL without triggering a redelivery. */
+export async function callRotateInvitationLink(
+  input: RotateInvitationRequest,
+): Promise<RotateInvitationResponse> {
+  const fn = httpsCallable<RotateInvitationRequest, RotateInvitationResponse>(
     functions,
     "sendSpeakerInvitation",
   );

--- a/src/features/invitations/reactions.test.ts
+++ b/src/features/invitations/reactions.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { readReactions, toggleReaction } from "./reactions";
+
+describe("readReactions", () => {
+  it("returns an empty object when attributes are null", () => {
+    expect(readReactions(null)).toEqual({});
+  });
+
+  it("returns an empty object when the reactions key is missing", () => {
+    expect(readReactions({ responseType: "yes" })).toEqual({});
+  });
+
+  it("strips non-string entries in a reaction list defensively", () => {
+    const attrs = { reactions: { "👍": ["uid:a", 42, "uid:b", null] } };
+    expect(readReactions(attrs as unknown as Record<string, unknown>)).toEqual({
+      "👍": ["uid:a", "uid:b"],
+    });
+  });
+
+  it("ignores non-array values under an emoji key", () => {
+    const attrs = { reactions: { "👍": "uid:a" } };
+    expect(readReactions(attrs as unknown as Record<string, unknown>)).toEqual({});
+  });
+});
+
+describe("toggleReaction", () => {
+  it("adds the caller's identity when not present", () => {
+    expect(toggleReaction({}, "👍", "uid:me")).toEqual({ "👍": ["uid:me"] });
+  });
+
+  it("removes the caller's identity when already present", () => {
+    expect(toggleReaction({ "👍": ["uid:me"] }, "👍", "uid:me")).toEqual({});
+  });
+
+  it("preserves other reactors when the caller toggles off", () => {
+    expect(toggleReaction({ "👍": ["uid:a", "uid:me"] }, "👍", "uid:me")).toEqual({
+      "👍": ["uid:a"],
+    });
+  });
+
+  it("preserves other emoji entries when toggling one", () => {
+    const current = { "👍": ["uid:a"], "❤️": ["uid:b"] };
+    expect(toggleReaction(current, "👍", "uid:me")).toEqual({
+      "👍": ["uid:a", "uid:me"],
+      "❤️": ["uid:b"],
+    });
+  });
+});

--- a/src/features/invitations/reactions.ts
+++ b/src/features/invitations/reactions.ts
@@ -18,11 +18,7 @@ export function readReactions(attrs: Record<string, unknown> | null): Reactions 
 /** Toggles the caller's identity on a given emoji. Removes the
  *  emoji entry entirely when it ends up empty so the attribute
  *  doesn't accumulate dead keys. */
-export function toggleReaction(
-  current: Reactions,
-  emoji: string,
-  identity: string,
-): Reactions {
+export function toggleReaction(current: Reactions, emoji: string, identity: string): Reactions {
   const existing = current[emoji] ?? [];
   const hasMe = existing.includes(identity);
   const nextList = hasMe ? existing.filter((id) => id !== identity) : [...existing, identity];

--- a/src/features/invitations/reactions.ts
+++ b/src/features/invitations/reactions.ts
@@ -1,0 +1,33 @@
+export const REACTION_EMOJI = ["👍", "❤️", "🙏", "😂", "😮"] as const;
+
+export type Reactions = Record<string, readonly string[]>;
+
+/** Extracts the reactions map from a Twilio message's attributes.
+ *  Defensive against old messages that predate this feature and
+ *  non-record attributes. Always returns a plain object. */
+export function readReactions(attrs: Record<string, unknown> | null): Reactions {
+  const raw = attrs?.reactions;
+  if (!raw || typeof raw !== "object") return {};
+  const out: Record<string, readonly string[]> = {};
+  for (const [emoji, ids] of Object.entries(raw as Record<string, unknown>)) {
+    if (Array.isArray(ids)) out[emoji] = ids.filter((v): v is string => typeof v === "string");
+  }
+  return out;
+}
+
+/** Toggles the caller's identity on a given emoji. Removes the
+ *  emoji entry entirely when it ends up empty so the attribute
+ *  doesn't accumulate dead keys. */
+export function toggleReaction(
+  current: Reactions,
+  emoji: string,
+  identity: string,
+): Reactions {
+  const existing = current[emoji] ?? [];
+  const hasMe = existing.includes(identity);
+  const nextList = hasMe ? existing.filter((id) => id !== identity) : [...existing, identity];
+  const next = { ...current };
+  if (nextList.length === 0) delete next[emoji];
+  else next[emoji] = nextList;
+  return next;
+}

--- a/src/features/invitations/threadItems.test.ts
+++ b/src/features/invitations/threadItems.test.ts
@@ -2,13 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AuthorMap, ChatMessage } from "./useConversation";
 import { buildThreadItems } from "./threadItems";
 
-function mk(
-  sid: string,
-  author: string,
-  body: string,
-  date: Date | null,
-  index = 0,
-): ChatMessage {
+function mk(sid: string, author: string, body: string, date: Date | null, index = 0): ChatMessage {
   return { sid, index, author, body, dateCreated: date, attributes: null };
 }
 

--- a/src/features/invitations/threadItems.test.ts
+++ b/src/features/invitations/threadItems.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import type { AuthorMap, ChatMessage } from "./useConversation";
+import { buildThreadItems } from "./threadItems";
+
+function mk(
+  sid: string,
+  author: string,
+  body: string,
+  date: Date | null,
+  index = 0,
+): ChatMessage {
+  return { sid, index, author, body, dateCreated: date, attributes: null };
+}
+
+const emptyAuthors: AuthorMap = new Map();
+
+describe("buildThreadItems", () => {
+  it("inserts a single day divider before the first message", () => {
+    const d = new Date("2026-04-22T10:00:00");
+    const items = buildThreadItems({
+      messages: [mk("a", "uid:x", "hi", d, 0)],
+      currentIdentity: null,
+      authors: emptyAuthors,
+      now: d,
+    });
+    expect(items.map((i) => i.kind)).toEqual(["day", "group"]);
+    expect(items[0]).toMatchObject({ kind: "day", label: "Today" });
+  });
+
+  it("groups consecutive same-author messages and splits on author change", () => {
+    const d = new Date("2026-04-22T10:00:00");
+    const items = buildThreadItems({
+      messages: [
+        mk("a", "uid:x", "1", d, 0),
+        mk("b", "uid:x", "2", d, 1),
+        mk("c", "uid:y", "3", d, 2),
+      ],
+      currentIdentity: null,
+      authors: emptyAuthors,
+      now: d,
+    });
+    const groups = items.filter((i) => i.kind === "group");
+    expect(groups).toHaveLength(2);
+    expect(groups[0]).toMatchObject({ kind: "group" });
+    if (groups[0]?.kind === "group") expect(groups[0].group.messages).toHaveLength(2);
+  });
+
+  it("labels yesterday and earlier days correctly", () => {
+    const now = new Date("2026-04-22T10:00:00");
+    const yesterday = new Date("2026-04-21T10:00:00");
+    const longAgo = new Date("2026-01-05T10:00:00");
+    const items = buildThreadItems({
+      messages: [mk("a", "u", "y", yesterday, 0), mk("b", "u", "old", longAgo, 1)],
+      currentIdentity: null,
+      authors: emptyAuthors,
+      now,
+    });
+    const days = items.filter((i) => i.kind === "day");
+    expect(days).toHaveLength(2);
+    expect(days[0]).toMatchObject({ label: "Yesterday" });
+    expect(days[1]?.kind === "day" && days[1].label).toMatch(/Jan/);
+  });
+
+  it("inserts an unread divider before the first incoming message at or after firstUnreadIndex", () => {
+    const d = new Date("2026-04-22T10:00:00");
+    const items = buildThreadItems({
+      messages: [
+        mk("a", "uid:me", "sent", d, 0),
+        mk("b", "uid:other", "reply1", d, 1),
+        mk("c", "uid:other", "reply2", d, 2),
+      ],
+      currentIdentity: "uid:me",
+      authors: emptyAuthors,
+      firstUnreadIndex: 1,
+      now: d,
+    });
+    const kinds = items.map((i) => i.kind);
+    expect(kinds).toContain("unread");
+    const unreadIdx = kinds.indexOf("unread");
+    expect(items[unreadIdx - 1]?.kind).toBe("group");
+    expect(items[unreadIdx + 1]?.kind).toBe("group");
+  });
+
+  it("does not insert an unread divider for messages I sent", () => {
+    const d = new Date("2026-04-22T10:00:00");
+    const items = buildThreadItems({
+      messages: [mk("a", "uid:me", "sent", d, 5)],
+      currentIdentity: "uid:me",
+      authors: emptyAuthors,
+      firstUnreadIndex: 5,
+      now: d,
+    });
+    expect(items.map((i) => i.kind)).not.toContain("unread");
+  });
+});

--- a/src/features/invitations/threadItems.ts
+++ b/src/features/invitations/threadItems.ts
@@ -1,0 +1,107 @@
+import type { AuthorInfo, AuthorMap, ChatMessage } from "./useConversation";
+
+export interface MessageGroup {
+  key: string;
+  author: string;
+  mine: boolean;
+  info: AuthorInfo;
+  messages: readonly ChatMessage[];
+}
+
+export type ThreadItem =
+  | { kind: "day"; key: string; label: string }
+  | { kind: "unread"; key: string }
+  | { kind: "group"; key: string; group: MessageGroup };
+
+export interface BuildOpts {
+  messages: readonly ChatMessage[];
+  currentIdentity: string | null;
+  authors: AuthorMap;
+  /** First unread message index (Twilio index, not array index). If
+   *  null, no unread divider is inserted. Messages at or after this
+   *  index that aren't mine get the divider placed just before them. */
+  firstUnreadIndex?: number | null;
+  /** "Now" reference for labelling day headers as Today/Yesterday.
+   *  Accepting it as a param keeps the builder deterministic and
+   *  testable. */
+  now?: Date;
+}
+
+export function buildThreadItems(opts: BuildOpts): ThreadItem[] {
+  const { messages, currentIdentity, authors, firstUnreadIndex, now = new Date() } = opts;
+  const items: ThreadItem[] = [];
+  let lastDay: string | null = null;
+  let unreadInserted = false;
+  let currentGroup: MessageGroup | null = null;
+  const pushGroup = () => {
+    if (currentGroup) items.push({ kind: "group", key: currentGroup.key, group: currentGroup });
+    currentGroup = null;
+  };
+  for (const m of messages) {
+    const day = dayKey(m.dateCreated);
+    if (day !== lastDay) {
+      pushGroup();
+      items.push({ kind: "day", key: `day-${day}`, label: dayLabel(m.dateCreated, now) });
+      lastDay = day;
+    }
+    const mine = m.author === currentIdentity;
+    if (
+      !unreadInserted &&
+      !mine &&
+      typeof firstUnreadIndex === "number" &&
+      m.index >= firstUnreadIndex
+    ) {
+      pushGroup();
+      items.push({ kind: "unread", key: `unread-${m.index}` });
+      unreadInserted = true;
+    }
+    if (currentGroup && currentGroup.author === m.author) {
+      currentGroup = { ...currentGroup, messages: [...currentGroup.messages, m] };
+      continue;
+    }
+    pushGroup();
+    currentGroup = {
+      key: m.sid,
+      author: m.author,
+      mine,
+      info: authors.get(m.author) ?? fallbackAuthor(m.author),
+      messages: [m],
+    };
+  }
+  pushGroup();
+  return items;
+}
+
+function dayKey(d: Date | null): string {
+  if (!d) return "no-date";
+  return `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+}
+
+function dayLabel(d: Date | null, now: Date): string {
+  if (!d) return "Earlier";
+  const today = startOfDay(now);
+  const that = startOfDay(d);
+  const diffDays = Math.round((today.getTime() - that.getTime()) / 86_400_000);
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return d.toLocaleDateString(undefined, { weekday: "long" });
+  const sameYear = d.getFullYear() === now.getFullYear();
+  return d.toLocaleDateString(
+    undefined,
+    sameYear
+      ? { month: "short", day: "numeric" }
+      : { month: "short", day: "numeric", year: "numeric" },
+  );
+}
+
+function startOfDay(d: Date): Date {
+  const c = new Date(d);
+  c.setHours(0, 0, 0, 0);
+  return c;
+}
+
+function fallbackAuthor(identity: string): AuthorInfo {
+  if (identity.startsWith("speaker:")) return { displayName: "Speaker", role: "speaker" };
+  if (identity.startsWith("uid:")) return { displayName: "Bishopric" };
+  return { displayName: "Unknown" };
+}

--- a/src/features/invitations/useBishopAuthors.ts
+++ b/src/features/invitations/useBishopAuthors.ts
@@ -1,0 +1,60 @@
+import { useMemo } from "react";
+import type { User } from "firebase/auth";
+import type { WithId } from "@/hooks/_sub";
+import type { Member, SpeakerInvitation } from "@/lib/types";
+import type { AuthorInfo, AuthorMap } from "./useConversation";
+
+interface Args {
+  members: readonly WithId<Member>[] | undefined;
+  invitation: SpeakerInvitation;
+  invitationId: string;
+  user: User | null;
+  /** Twilio-sourced author info keyed by participant identity. Merged
+   *  last so new conversations with participant attributes override
+   *  the fallback map. */
+  authors: AuthorMap;
+}
+
+/** Builds the author map the bishop-side thread renders with:
+ *  ward-member displayNames + the speaker snapshot from the
+ *  invitation + the current user's Firebase Auth photoURL, then
+ *  Twilio participant attributes overlay. Old conversations without
+ *  attributes still render real names that way. */
+export function useBishopAuthors({
+  members,
+  invitation,
+  invitationId,
+  user,
+  authors,
+}: Args): AuthorMap {
+  return useMemo(() => {
+    const map = new Map<string, AuthorInfo>();
+    for (const m of members ?? []) {
+      if (m.data.role !== "bishopric" && m.data.role !== "clerk") continue;
+      if (!m.data.active) continue;
+      const info: AuthorInfo = { displayName: m.data.displayName, role: m.data.role };
+      if (m.data.email) info.email = m.data.email;
+      map.set(`uid:${m.id}`, info);
+    }
+    const speakerInfo: AuthorInfo = { displayName: invitation.speakerName, role: "speaker" };
+    if (invitation.speakerEmail) speakerInfo.email = invitation.speakerEmail;
+    if (invitation.response?.actorEmail) speakerInfo.email = invitation.response.actorEmail;
+    map.set(`speaker:${invitationId}`, speakerInfo);
+    if (user?.uid) {
+      const existing = map.get(`uid:${user.uid}`);
+      const info: AuthorInfo = {
+        displayName: existing?.displayName ?? user.displayName ?? "You",
+      };
+      if (existing?.role) info.role = existing.role;
+      if (user.photoURL) info.photoURL = user.photoURL;
+      const email = existing?.email ?? user.email;
+      if (email) info.email = email;
+      map.set(`uid:${user.uid}`, info);
+    }
+    for (const [id, info] of authors) {
+      const existing = map.get(id);
+      map.set(id, { ...existing, ...info });
+    }
+    return map;
+  }, [members, invitationId, invitation, user, authors]);
+}

--- a/src/features/invitations/useConversation.ts
+++ b/src/features/invitations/useConversation.ts
@@ -1,5 +1,7 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { Conversation, Message, Participant } from "@twilio/conversations";
+import { parseAuthorInfo, toChatMessage } from "./conversationHelpers";
+import { readReactions, toggleReaction as toggleReactionMap } from "./reactions";
 import { useTwilioChat } from "./twilioClientProvider";
 
 export interface ChatMessage {
@@ -10,28 +12,18 @@ export interface ChatMessage {
   dateCreated: Date | null;
   /** Parsed attributes — `{ responseType: 'yes' | 'no', reason? }`
    *  for the structured quick-action messages, `{ kind: 'invitation' }`
-   *  for the initial letter, else null. */
+   *  for the initial letter, `{ reactions: { emoji: [id...] } }` when
+   *  anyone has reacted, else null. */
   attributes: Record<string, unknown> | null;
 }
 
 export interface AuthorInfo {
   displayName: string;
   role?: "speaker" | "bishopric" | "clerk";
-  /** Optional avatar URL. When present the thread renders it in
-   *  place of initials. Sourced from Firebase Auth's photoURL for
-   *  the current user; other participants fall through to initials
-   *  unless we're fed a URL from somewhere else. */
   photoURL?: string;
-  /** Signed-in Google email — the chat bubble eyebrow renders this
-   *  instead of displayName, and the bishop's identity banner uses
-   *  it to show "speaker verified / mismatch". */
   email?: string;
 }
 
-/** Map keyed by participant identity (e.g. `uid:abc123`,
- *  `speaker:{invitationId}`). Used by the thread to render bubble
- *  labels + avatar initials without knowing individual participants
- *  at the call site. */
 export type AuthorMap = Map<string, AuthorInfo>;
 
 interface ConversationState {
@@ -42,37 +34,17 @@ interface ConversationState {
   error: Error | null;
 }
 
-function toChatMessage(m: Message): ChatMessage {
-  let attributes: Record<string, unknown> | null = null;
-  const raw = m.attributes;
-  if (raw && typeof raw === "object") attributes = raw as Record<string, unknown>;
-  return {
-    sid: m.sid,
-    index: m.index,
-    author: m.author ?? "",
-    body: m.body ?? "",
-    dateCreated: m.dateCreated ?? null,
-    attributes,
-  };
+export interface ConversationHookResult extends ConversationState {
+  /** Toggles the caller's identity on a reaction emoji for a given
+   *  message. Writes the new attributes to Twilio; the messageUpdated
+   *  event then refreshes local state for everyone. */
+  toggleReaction: (sid: string, emoji: string, identity: string) => Promise<void>;
 }
 
-function parseAuthorInfo(p: Participant): AuthorInfo | null {
-  const attrs = p.attributes as {
-    displayName?: string;
-    role?: AuthorInfo["role"];
-    email?: string;
-  } | null;
-  if (!attrs?.displayName) return null;
-  const info: AuthorInfo = { displayName: attrs.displayName };
-  if (attrs.role) info.role = attrs.role;
-  if (attrs.email) info.email = attrs.email;
-  return info;
-}
-
-/** Subscribes to a single conversation's message stream and loads
- *  the participants' display-name map. Client must already be
- *  connected via <TwilioChatProvider>. */
-export function useConversation(conversationSid: string | null): ConversationState {
+/** Subscribes to a single conversation's message stream, participant
+ *  list, and message-attribute updates (so reactions stay live).
+ *  Client must already be connected via <TwilioChatProvider>. */
+export function useConversation(conversationSid: string | null): ConversationHookResult {
   const { client, status } = useTwilioChat();
   const [state, setState] = useState<ConversationState>({
     loading: true,
@@ -81,13 +53,25 @@ export function useConversation(conversationSid: string | null): ConversationSta
     authors: new Map(),
     error: null,
   });
+  const msgRefs = useRef<Map<string, Message>>(new Map());
 
   useEffect(() => {
     if (!client || status !== "ready" || !conversationSid) return;
     let cancelled = false;
     let convo: Conversation | null = null;
+    msgRefs.current = new Map();
+    const replaceMessage = (m: Message) =>
+      setState((s) => ({
+        ...s,
+        messages: s.messages.map((x) => (x.sid === m.sid ? toChatMessage(m) : x)),
+      }));
     const onMessageAdded = (m: Message) => {
+      msgRefs.current.set(m.sid, m);
       setState((s) => ({ ...s, messages: [...s.messages, toChatMessage(m)] }));
+    };
+    const onMessageUpdated = (args: { message: Message }) => {
+      msgRefs.current.set(args.message.sid, args.message);
+      replaceMessage(args.message);
     };
     const onParticipantUpdate = (p: Participant) => {
       setState((s) => {
@@ -99,7 +83,6 @@ export function useConversation(conversationSid: string | null): ConversationSta
         return { ...s, authors: next };
       });
     };
-
     (async () => {
       try {
         convo = await client.getConversationBySid(conversationSid);
@@ -109,6 +92,7 @@ export function useConversation(conversationSid: string | null): ConversationSta
           convo.getParticipants(),
         ]);
         if (cancelled) return;
+        for (const m of page.items) msgRefs.current.set(m.sid, m);
         const authors: AuthorMap = new Map();
         for (const p of participants) {
           if (!p.identity) continue;
@@ -123,6 +107,7 @@ export function useConversation(conversationSid: string | null): ConversationSta
           error: null,
         });
         convo.on("messageAdded", onMessageAdded);
+        convo.on("messageUpdated", onMessageUpdated);
         convo.on("participantJoined", onParticipantUpdate);
         convo.on("participantUpdated", (args) => onParticipantUpdate(args.participant));
       } catch (err) {
@@ -136,16 +121,35 @@ export function useConversation(conversationSid: string | null): ConversationSta
         });
       }
     })();
-
     return () => {
       cancelled = true;
       if (convo) {
         convo.removeAllListeners("messageAdded");
+        convo.removeAllListeners("messageUpdated");
         convo.removeAllListeners("participantJoined");
         convo.removeAllListeners("participantUpdated");
       }
     };
   }, [client, status, conversationSid]);
 
-  return state;
+  const toggleReaction = useCallback(
+    async (sid: string, emoji: string, identity: string): Promise<void> => {
+      const msg = msgRefs.current.get(sid);
+      if (!msg) return;
+      const current = readReactions(
+        msg.attributes && typeof msg.attributes === "object"
+          ? (msg.attributes as Record<string, unknown>)
+          : null,
+      );
+      const nextReactions = toggleReactionMap(current, emoji, identity);
+      const rawAttrs =
+        msg.attributes && typeof msg.attributes === "object"
+          ? (msg.attributes as Record<string, unknown>)
+          : {};
+      await msg.updateAttributes({ ...rawAttrs, reactions: nextReactions });
+    },
+    [],
+  );
+
+  return { ...state, toggleReaction };
 }

--- a/src/features/invitations/useFirstUnreadIndex.ts
+++ b/src/features/invitations/useFirstUnreadIndex.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import type { Conversation } from "@twilio/conversations";
+
+/** Snapshots the first-unread Twilio message index at the moment the
+ *  conversation loads, then pins it for the life of the sid. The
+ *  thread uses this to place a "New" divider that doesn't drift as
+ *  more incoming messages arrive in the same session.
+ *
+ *  Returns null when the participant is caught up (no unread), or
+ *  when the conversation isn't resolved yet. */
+export function useFirstUnreadIndex(conversation: Conversation | null): number | null {
+  const [snapshot, setSnapshot] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!conversation) {
+      setSnapshot(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const lastRead = conversation.lastReadMessageIndex;
+      const lastMsgIdx = conversation.lastMessage?.index;
+      if (typeof lastMsgIdx !== "number") {
+        if (!cancelled) setSnapshot(null);
+        return;
+      }
+      // Never read anything → entire conversation is unread, start at
+      // message index 0. Otherwise start just after the read horizon.
+      const first = lastRead === null ? 0 : lastRead + 1;
+      if (!cancelled) setSnapshot(first <= lastMsgIdx ? first : null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [conversation]);
+
+  return snapshot;
+}

--- a/src/features/invitations/useReadHorizon.ts
+++ b/src/features/invitations/useReadHorizon.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from "react";
+import type { Conversation, Participant } from "@twilio/conversations";
+
+/** Highest message index that any participant other than `self` has
+ *  marked as read. The bishop side uses this to show a "Read" label
+ *  once the speaker has caught up; the speaker side uses it to show
+ *  that at least one bishopric member has seen their reply.
+ *
+ *  Returns null until participants have loaded or when no other
+ *  participant has a read horizon recorded yet. */
+export function useReadHorizon(
+  conversation: Conversation | null,
+  selfIdentity: string | null,
+): number | null {
+  const [horizon, setHorizon] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!conversation) {
+      setHorizon(null);
+      return;
+    }
+    let cancelled = false;
+    const recomputeFrom = (participants: readonly Participant[]) => {
+      let max: number | null = null;
+      for (const p of participants) {
+        if (!p.identity || p.identity === selfIdentity) continue;
+        const idx = p.lastReadMessageIndex;
+        if (typeof idx === "number" && (max === null || idx > max)) max = idx;
+      }
+      if (!cancelled) setHorizon(max);
+    };
+    (async () => {
+      const ps = await conversation.getParticipants();
+      if (!cancelled) recomputeFrom(ps);
+    })();
+    const onUpdate = () => {
+      void conversation.getParticipants().then((ps) => {
+        if (!cancelled) recomputeFrom(ps);
+      });
+    };
+    conversation.on("participantUpdated", onUpdate);
+    conversation.on("participantJoined", onUpdate);
+    return () => {
+      cancelled = true;
+      conversation.off("participantUpdated", onUpdate);
+      conversation.off("participantJoined", onUpdate);
+    };
+  }, [conversation, selfIdentity]);
+
+  return horizon;
+}

--- a/src/features/invitations/useTypingParticipants.ts
+++ b/src/features/invitations/useTypingParticipants.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import type { Conversation, Participant } from "@twilio/conversations";
+
+/** Subscribes to typingStarted / typingEnded events on a Twilio
+ *  conversation and returns the set of currently-typing participant
+ *  identities (excluding the caller's own identity when provided so
+ *  the UI never shows "you are typing"). */
+export function useTypingParticipants(
+  conversation: Conversation | null,
+  selfIdentity: string | null,
+): readonly string[] {
+  const [typing, setTyping] = useState<readonly string[]>([]);
+
+  useEffect(() => {
+    if (!conversation) {
+      setTyping([]);
+      return;
+    }
+    const add = (p: Participant) => {
+      if (!p.identity || p.identity === selfIdentity) return;
+      setTyping((prev) => (prev.includes(p.identity!) ? prev : [...prev, p.identity!]));
+    };
+    const remove = (p: Participant) => {
+      if (!p.identity) return;
+      setTyping((prev) => prev.filter((id) => id !== p.identity));
+    };
+    conversation.on("typingStarted", add);
+    conversation.on("typingEnded", remove);
+    return () => {
+      conversation.off("typingStarted", add);
+      conversation.off("typingEnded", remove);
+    };
+  }, [conversation, selfIdentity]);
+
+  return typing;
+}

--- a/src/features/schedule/SundayCard.tsx
+++ b/src/features/schedule/SundayCard.tsx
@@ -90,12 +90,7 @@ export function SundayCard({
     step === "invite" ? `Send invitations — ${formatShortDate(date)}` : formatShortDate(date);
 
   return (
-    <article
-      className={cn(
-        "rounded-lg border border-border shadow-elev-1 hover:shadow-elev-2 hover:border-border-strong transition-all duration-200",
-        CARD_BG[kind.variant],
-      )}
-    >
+    <article className={cn("rounded-lg border border-border shadow-elev-1", CARD_BG[kind.variant])}>
       <SundayCardHeader
         date={date}
         wardId={wardId}

--- a/src/features/schedule/SundayCardHeader.tsx
+++ b/src/features/schedule/SundayCardHeader.tsx
@@ -38,10 +38,13 @@ export function SundayCardHeader({
   return (
     <div className="flex items-start justify-between gap-3 p-4 pb-2">
       <div className="flex items-start gap-2 flex-1 min-w-0">
-        <Link to={`/week/${date}`} className="flex-1 min-w-0 hover:opacity-80 transition-opacity">
-          <div className="text-2xl font-display font-semibold text-walnut leading-tight">
+        <div className="flex-1 min-w-0">
+          <Link
+            to={`/week/${date}`}
+            className="text-2xl font-display font-semibold text-walnut leading-tight hover:text-bordeaux-deep hover:underline underline-offset-4 decoration-from-font transition-colors"
+          >
             {formatShortDate(date)}
-          </div>
+          </Link>
           <div
             className={cn(
               "text-[11px] font-mono tracking-[0.08em] uppercase mt-1",
@@ -50,7 +53,7 @@ export function SundayCardHeader({
           >
             {formatCountdown(date)}
           </div>
-        </Link>
+        </div>
         {needsApply && (
           <span
             aria-label="Speaker response awaiting your review"

--- a/src/features/templates/sendSpeakerInvitation.ts
+++ b/src/features/templates/sendSpeakerInvitation.ts
@@ -4,7 +4,7 @@ import { wardSchema } from "@/lib/types";
 import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
 import {
   callSendSpeakerInvitation,
-  type SendSpeakerInvitationResponse,
+  type FreshInvitationResponse,
 } from "@/features/invitations/invitationsCallable";
 import { interpolate } from "./interpolate";
 import { formatAssignedDate, formatToday } from "./letterDates";
@@ -43,7 +43,7 @@ export interface SendSpeakerInvitationInput {
  */
 export async function sendSpeakerInvitation(
   input: SendSpeakerInvitationInput,
-): Promise<SendSpeakerInvitationResponse> {
+): Promise<FreshInvitationResponse> {
   reportSaving();
   try {
     const wardSnap = await getDoc(doc(db, "wards", input.wardId));

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -93,6 +93,24 @@
   body {
     @apply bg-parchment text-walnut font-sans text-base leading-relaxed antialiased;
     text-rendering: optimizeLegibility;
+    /* Native-app feel in the installed PWA: no rubber-band bounce on
+       the page, and no double-tap zoom (manipulation still allows
+       pan + pinch on inner scroll containers). Pinch-zoom on the
+       page itself is blocked by the viewport meta. */
+    overscroll-behavior: none;
+    touch-action: manipulation;
+  }
+
+  /* iOS Safari auto-zooms any focused input whose computed font-size
+     is under 16px, and doesn't fully zoom back out. Force a 16px
+     floor on touch devices only — desktop keeps the intended small
+     visual size from Tailwind utilities. */
+  @media (hover: none) and (pointer: coarse) {
+    input,
+    textarea,
+    select {
+      font-size: 16px;
+    }
   }
 
   /* Semantic typography */


### PR DESCRIPTION
## Summary

Chat polish across the bishop ↔ speaker thread, bishop can now
resend or copy an invitation link without starting over, and two
mobile-fit fixes. Full details in the [v0.7.0 changelog entry](./CHANGELOG.md).

### Highlights

- **Chat UI polish** — day separators, unread horizon + jump-to-
  latest, typing indicator, read receipts, auto-grow composer with
  optimistic send, per-message emoji reactions, a11y pass.
- **Full-screen bishop chat on mobile** — `100dvh` layout, page-
  scroll lock, composer stays above the iOS chrome.
- **Resend / copy invite link** — overflow menu in the chat
  header. Rotate-link mode on `sendSpeakerInvitation` generates a
  fresh capability token while preserving `conversationSid` so
  chat history survives.
- **Avatar alignment** — 36px avatar pinned to the last bubble's
  bottom, matching single-line bubble height; name eyebrow +
  timestamp on their own rows indented past the avatar slot.
- **PWA on mobile** — overscroll bounce, pinch/double-tap zoom,
  and iOS input-focus auto-zoom disabled in the installed PWA
  without affecting desktop zoom. (#40)
- **Sunday card click scope** — only the date text navigates to
  the week view; the whole-card hit region is gone. (#38)

### Deploy plan

- **Vercel** auto-deploys the frontend off `main`.
- **Firebase Functions** — `sendSpeakerInvitation` gained
  rotate-link mode; `freshInvitation.ts` and
  `rotateInvitationLink.ts` are new. Deploy manually after merge:
  ```sh
  firebase deploy --only functions --project=prod
  ```
- **Firestore rules / indexes** — unchanged, skip.
- **Twilio role config** — `editAnyMessage` on the `channel user`
  role has been confirmed in place on the prod Twilio Conversations
  service (via `pnpm --filter @steward/functions configure-conversation-roles`),
  so per-message reactions work across all participants.

### Test plan

- [x] CI green on every develop commit in the release window
- [x] 249 unit tests passing on develop
- [ ] Post-merge: Vercel prod build green
- [ ] Post-merge: `firebase deploy --only functions --project=prod`
      completes
- [ ] Sign into prod, open an invitation dialog, verify the chat
      mobile layout + reactions + resend/copy flow
- [ ] Verify Sunday card navigation scopes to the date text only
- [ ] Install the PWA on an iOS device, confirm no overscroll /
      no input-focus zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)