### PR TITLE
feat(invitations): status provenance, receipts, hygiene fixes

### DIFF
--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -39,18 +39,22 @@ export async function createFreshInvitation(
   const tokenHash = hashInvitationToken(plaintextToken);
   const expiresAt = new Date(input.expiresAtMillis);
 
+  // Admin SDK rejects `undefined` field values by default, so only
+  // include the optional contact/topic fields when the caller actually
+  // provided them. Missing fields read as `undefined` downstream,
+  // which is what the rest of the code already expects.
   const docRef = await db.collection(`wards/${input.wardId}/speakerInvitations`).add({
     speakerRef: { meetingDate: input.meetingDate, speakerId: input.speakerId },
     assignedDate: input.assignedDate,
     sentOn: input.sentOn,
     wardName: input.wardName,
     speakerName: input.speakerName,
-    speakerTopic: input.speakerTopic,
+    ...(input.speakerTopic ? { speakerTopic: input.speakerTopic } : {}),
     inviterName: input.inviterName,
     bodyMarkdown: input.bodyMarkdown,
     footerMarkdown: input.footerMarkdown,
-    speakerEmail: input.speakerEmail,
-    speakerPhone: input.speakerPhone,
+    ...(input.speakerEmail ? { speakerEmail: input.speakerEmail } : {}),
+    ...(input.speakerPhone ? { speakerPhone: input.speakerPhone } : {}),
     expiresAt,
     tokenHash,
     tokenStatus: "active" as const,

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -4,6 +4,7 @@ initializeApp();
 
 export { onCommentCreate } from "./onCommentCreate.js";
 export { onMeetingWrite } from "./onMeetingWrite.js";
+export { onInvitationWrite } from "./onInvitationWrite.js";
 export { drainNotificationQueue } from "./drainNotificationQueue.js";
 export { scheduledNudges } from "./scheduledNudges.js";
 export { sendSpeakerInvitation } from "./sendSpeakerInvitation.js";

--- a/functions/src/invitationChange.test.ts
+++ b/functions/src/invitationChange.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { classifyInvitationChange } from "./invitationChange.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+
+function mk(overrides: Partial<SpeakerInvitationShape> = {}): SpeakerInvitationShape {
+  return {
+    speakerRef: { meetingDate: "2026-05-03", speakerId: "sp1" },
+    assignedDate: "Sunday, May 3, 2026",
+    sentOn: "April 22, 2026",
+    wardName: "Test Ward",
+    speakerName: "Sister Jones",
+    inviterName: "Bishop Smith",
+    bodyMarkdown: "body",
+    footerMarkdown: "footer",
+    ...overrides,
+  };
+}
+
+describe("classifyInvitationChange", () => {
+  it("is a no-op when the document was deleted", () => {
+    const before = mk({ response: { answer: "yes" } });
+    expect(classifyInvitationChange(before, undefined)).toEqual({
+      fireSpeaker: false,
+      fireBishopric: false,
+    });
+  });
+
+  it("fires the speaker receipt when response.answer appears", () => {
+    const after = mk({ response: { answer: "yes" } });
+    expect(classifyInvitationChange(mk(), after)).toEqual({
+      fireSpeaker: true,
+      fireBishopric: false,
+    });
+  });
+
+  it("does not re-fire the speaker receipt when response.answer was already set", () => {
+    const before = mk({ response: { answer: "yes" } });
+    const after = mk({ response: { answer: "yes", reason: "added later" } });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: false,
+      fireBishopric: false,
+    });
+  });
+
+  it("fires the bishopric receipt when acknowledgedAt appears", () => {
+    const before = mk({ response: { answer: "yes" } });
+    const after = mk({
+      response: {
+        answer: "yes",
+        acknowledgedAt: {
+          toMillis: () => 0,
+          toDate: () => new Date(),
+        } as unknown as FirebaseFirestore.Timestamp,
+        acknowledgedBy: "uid:bishop",
+      },
+    });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: false,
+      fireBishopric: true,
+    });
+  });
+
+  it("does not fire either receipt for unrelated writes (e.g., heartbeat)", () => {
+    const before = mk({ response: { answer: "yes", acknowledgedAt: tsFor(0) } });
+    const after = mk({
+      response: { answer: "yes", acknowledgedAt: tsFor(0) },
+      speakerLastSeenAt: tsFor(1000),
+    });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: false,
+      fireBishopric: false,
+    });
+  });
+
+  it("fires the bishopric receipt even if the response was seeded in the same write (rare)", () => {
+    const after = mk({
+      response: { answer: "yes", acknowledgedAt: tsFor(0), acknowledgedBy: "uid:bishop" },
+    });
+    expect(classifyInvitationChange(undefined, after)).toEqual({
+      fireSpeaker: true,
+      fireBishopric: true,
+    });
+  });
+});
+
+function tsFor(ms: number): FirebaseFirestore.Timestamp {
+  return {
+    toMillis: () => ms,
+    toDate: () => new Date(ms),
+  } as unknown as FirebaseFirestore.Timestamp;
+}

--- a/functions/src/invitationChange.ts
+++ b/functions/src/invitationChange.ts
@@ -1,0 +1,34 @@
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+
+export interface InvitationChange {
+  /** Response just went from absent → present. */
+  fireSpeaker: boolean;
+  /** `response.acknowledgedAt` just appeared (Apply was tapped). */
+  fireBishopric: boolean;
+}
+
+/** Returns a pair of booleans describing which receipts should fire
+ *  for a given before/after snapshot of the invitation doc.
+ *
+ *  - Deletions: no receipts.
+ *  - Response newly set (was absent before): speaker receipt.
+ *  - Acknowledgement newly set: bishopric receipt.
+ *  - Other writes (token rotation, heartbeat, delivery record): none.
+ *
+ *  The "appeared" guard deduplicates retried trigger invocations:
+ *  a doc write that already had `response.answer` set will produce
+ *  `fireSpeaker=false` on re-fire. */
+export function classifyInvitationChange(
+  before: SpeakerInvitationShape | undefined,
+  after: SpeakerInvitationShape | undefined,
+): InvitationChange {
+  if (!after) return { fireSpeaker: false, fireBishopric: false };
+  const answerBefore = before?.response?.answer;
+  const answerAfter = after.response?.answer;
+  const ackBefore = before?.response?.acknowledgedAt;
+  const ackAfter = after.response?.acknowledgedAt;
+  return {
+    fireSpeaker: !answerBefore && Boolean(answerAfter),
+    fireBishopric: !ackBefore && Boolean(ackAfter),
+  };
+}

--- a/functions/src/invitationReceiptContent.test.ts
+++ b/functions/src/invitationReceiptContent.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+
+function mk(overrides: Partial<SpeakerInvitationShape> = {}): SpeakerInvitationShape {
+  return {
+    speakerRef: { meetingDate: "2026-05-03", speakerId: "sp1" },
+    assignedDate: "Sunday, May 3, 2026",
+    sentOn: "April 22, 2026",
+    wardName: "Test Ward",
+    speakerName: "Sister Jones",
+    inviterName: "Bishop Smith",
+    bodyMarkdown: "We invite you to speak.\n\nTopic: faith.",
+    footerMarkdown: '"Let thy speech be alway with grace..."',
+    ...overrides,
+  };
+}
+
+describe("buildSpeakerReceipt", () => {
+  it("throws when the invitation has no recorded response", () => {
+    expect(() => buildSpeakerReceipt({ invitation: mk() })).toThrow();
+  });
+
+  it("phrases the Yes case as 'accepted' and includes the letter inline", () => {
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+    });
+    expect(content.subject).toMatch(/accepted/);
+    expect(content.subject).toMatch(/Sunday, May 3, 2026/);
+    expect(content.text).toMatch(/You accepted the invitation/);
+    expect(content.text).toMatch(/We invite you to speak\./);
+    expect(content.html).toMatch(/You accepted the invitation/);
+  });
+
+  it("phrases the No case as 'declined'", () => {
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "no" } }),
+    });
+    expect(content.subject).toMatch(/declined/);
+    expect(content.text).toMatch(/You declined the invitation/);
+  });
+
+  it("surfaces the speaker's reason when provided", () => {
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "no", reason: "I'm out of town." } }),
+    });
+    expect(content.text).toMatch(/Your note: I'm out of town/);
+    expect(content.html).toMatch(/I&#39;m out of town/);
+  });
+});
+
+describe("buildBishopricReceipt", () => {
+  it("throws when the invitation has no recorded response", () => {
+    expect(() => buildBishopricReceipt({ invitation: mk() })).toThrow();
+  });
+
+  it("names the speaker in the subject and includes a view URL when provided", () => {
+    const content = buildBishopricReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+      bishopricViewUrl: "https://steward-app.ca/ward/w1/invitations/i1/view",
+      acknowledgedByName: "Bishop Smith",
+    });
+    expect(content.subject).toMatch(/Sister Jones accepted/);
+    expect(content.text).toMatch(/Applied by: Bishop Smith/);
+    expect(content.text).toMatch(/View this invitation in Steward: https:\/\/steward-app\.ca/);
+    expect(content.html).toMatch(/href="https:\/\/steward-app\.ca/);
+  });
+
+  it("declined variant lands under 'declined' phrasing", () => {
+    const content = buildBishopricReceipt({
+      invitation: mk({ response: { answer: "no" } }),
+    });
+    expect(content.subject).toMatch(/Sister Jones declined/);
+  });
+
+  it("omits the view-URL block when not provided", () => {
+    const content = buildBishopricReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+    });
+    expect(content.text).not.toMatch(/View this invitation in Steward/);
+    expect(content.html).not.toMatch(/href="/);
+  });
+});

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -1,0 +1,145 @@
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+
+export interface ReceiptBuildArgs {
+  invitation: SpeakerInvitationShape;
+  bishopricViewUrl?: string;
+  acknowledgedByName?: string | undefined;
+  respondedAt?: Date | undefined;
+}
+
+export interface ReceiptContent {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+function letterHtml(invitation: SpeakerInvitationShape): string {
+  return [
+    `<p style="color:#4a3a30;">${escapeHtml(invitation.sentOn)}</p>`,
+    `<p>Dear ${escapeHtml(invitation.speakerName)},</p>`,
+    // Invitation bodies are authored as Markdown. We render as
+    // paragraphs preserving newlines — full Markdown-to-HTML is not
+    // worth pulling into Functions for the receipt path; the raw body
+    // reads cleanly enough.
+    ...invitation.bodyMarkdown
+      .split(/\n{2,}/)
+      .filter((p) => p.trim().length > 0)
+      .map((p) => `<p>${escapeHtml(p).replace(/\n/g, "<br>")}</p>`),
+    `<p style="color:#4a3a30;font-size:13px;">${escapeHtml(invitation.footerMarkdown)}</p>`,
+    `<p style="color:#666;font-size:12px;">— ${escapeHtml(invitation.wardName)}</p>`,
+  ].join("\n");
+}
+
+function letterText(invitation: SpeakerInvitationShape): string {
+  return [
+    invitation.sentOn,
+    "",
+    `Dear ${invitation.speakerName},`,
+    "",
+    invitation.bodyMarkdown,
+    "",
+    invitation.footerMarkdown,
+    "",
+    `— ${invitation.wardName}`,
+  ].join("\n");
+}
+
+/** Email sent to the speaker when their Yes/No first lands on the
+ *  invitation doc. Confirms exactly what was recorded; the original
+ *  letter is rendered inline for reference. No link is included —
+ *  the speaker already has the invite URL in their inbox/SMS, and
+ *  rotating a fresh token per receipt would be gratuitous. */
+export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
+  const { invitation } = args;
+  const answer = invitation.response?.answer;
+  if (!answer) throw new Error("speaker receipt requires a recorded response");
+  const verb = answer === "yes" ? "accepted" : "declined";
+
+  const subject = `You ${verb} the speaking invitation — ${invitation.assignedDate}`;
+  const headerText =
+    answer === "yes"
+      ? `You accepted the invitation to speak on ${invitation.assignedDate}. Thank you.`
+      : `You declined the invitation to speak on ${invitation.assignedDate}. Thank you for letting us know.`;
+  const text = [
+    headerText,
+    "",
+    invitation.response?.reason ? `Your note: ${invitation.response.reason}` : null,
+    invitation.response?.reason ? "" : null,
+    "For reference, the original letter you received:",
+    "",
+    letterText(invitation),
+    "",
+    "If this wasn't you, please contact the bishopric right away.",
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+  const html = `
+<p>${escapeHtml(headerText)}</p>
+${
+  invitation.response?.reason
+    ? `<blockquote style="margin:0 0 16px 0;padding-left:10px;border-left:3px solid #bca788;color:#4a3a30;"><em>${escapeHtml(invitation.response.reason)}</em></blockquote>`
+    : ""
+}
+<hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
+<p style="color:#666;font-size:12px;margin:0 0 6px 0;">For reference, the original letter you received:</p>
+${letterHtml(invitation)}
+<hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
+<p style="color:#a00;font-size:12px;">If this wasn't you, please contact the bishopric right away.</p>
+`.trim();
+
+  return { subject, text, html };
+}
+
+/** Email sent to every active bishopric/clerk when the Apply action
+ *  mirrors a response to `speaker.status`. Includes the letter inline
+ *  for archival + a link to the read-only invitation view. */
+export function buildBishopricReceipt(args: ReceiptBuildArgs): ReceiptContent {
+  const { invitation, bishopricViewUrl, acknowledgedByName, respondedAt } = args;
+  const answer = invitation.response?.answer;
+  if (!answer) throw new Error("bishopric receipt requires a recorded response");
+  const verb = answer === "yes" ? "accepted" : "declined";
+
+  const subject = `${invitation.speakerName} ${verb} the speaking invitation — ${invitation.assignedDate}`;
+  const responseLine = `${invitation.speakerName} ${verb} the invitation to speak on ${invitation.assignedDate}.`;
+  const metaLines: string[] = [];
+  if (respondedAt) metaLines.push(`Responded: ${respondedAt.toLocaleString()}`);
+  if (acknowledgedByName) metaLines.push(`Applied by: ${acknowledgedByName}`);
+  if (invitation.response?.reason)
+    metaLines.push(`Note from speaker: ${invitation.response.reason}`);
+
+  const text = [
+    responseLine,
+    "",
+    ...metaLines,
+    metaLines.length > 0 ? "" : null,
+    "Original letter sent:",
+    "",
+    letterText(invitation),
+    "",
+    bishopricViewUrl ? `View this invitation in Steward: ${bishopricViewUrl}` : null,
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+
+  const html = `
+<p><strong>${escapeHtml(responseLine)}</strong></p>
+${metaLines.length > 0 ? `<p style="color:#4a3a30;font-size:13px;margin:0 0 12px 0;">${metaLines.map(escapeHtml).join("<br>")}</p>` : ""}
+<hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
+<p style="color:#666;font-size:12px;margin:0 0 6px 0;">Original letter sent:</p>
+${letterHtml(invitation)}
+${
+  bishopricViewUrl
+    ? `<hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
+<p><a href="${bishopricViewUrl}">View this invitation in Steward</a></p>`
+    : ""
+}
+`.trim();
+
+  return { subject, text, html };
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => {
+    return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] ?? c;
+  });
+}

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -1,0 +1,127 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { onDocumentWritten } from "firebase-functions/v2/firestore";
+import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
+import { classifyInvitationChange } from "./invitationChange.js";
+import { STEWARD_ORIGIN } from "./secrets.js";
+import { sendEmail } from "./sendgrid/client.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import type { MemberDoc } from "./types.js";
+
+/** Fires receipt emails on authoritative response transitions:
+ *   - `response.answer` appears → speaker receipt (to speaker, CC bishopric)
+ *   - `response.acknowledgedAt` appears → bishopric receipt (to bishopric)
+ *
+ *  Other writes (token rotation, delivery-record updates, heartbeats)
+ *  are classified as no-ops and return early. The receipts contain the
+ *  original letter inline so the email itself is the archive — no
+ *  external dependency on the invite URL or the app being reachable. */
+export const onInvitationWrite = onDocumentWritten(
+  "wards/{wardId}/speakerInvitations/{invitationId}",
+  async (event) => {
+    const before = event.data?.before.data() as SpeakerInvitationShape | undefined;
+    const after = event.data?.after.data() as SpeakerInvitationShape | undefined;
+    const change = classifyInvitationChange(before, after);
+    if (!change.fireSpeaker && !change.fireBishopric) return;
+    if (!after) return;
+
+    const { wardId, invitationId } = event.params;
+    const db = getFirestore();
+    try {
+      const bishopric = await fetchActiveBishopricEmails(db, wardId);
+      if (change.fireSpeaker) {
+        await sendSpeakerReceipt(after, bishopric);
+      }
+      if (change.fireBishopric) {
+        const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
+        await sendBishopricReceipt(after, bishopric, { wardId, invitationId, origin });
+      }
+    } catch (err) {
+      logger.error("invitation receipt dispatch failed", {
+        wardId,
+        invitationId,
+        err: (err as Error).message,
+      });
+    }
+  },
+);
+
+interface BishopricContact {
+  uid: string;
+  email: string;
+  displayName: string;
+}
+
+async function fetchActiveBishopricEmails(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+): Promise<BishopricContact[]> {
+  const snap = await db.collection(`wards/${wardId}/members`).get();
+  const out: BishopricContact[] = [];
+  for (const d of snap.docs) {
+    const m = d.data() as MemberDoc;
+    if (!m.active) continue;
+    if (m.role !== "bishopric" && m.role !== "clerk") continue;
+    if (!m.email) continue;
+    out.push({ uid: d.id, email: m.email, displayName: m.displayName });
+  }
+  return out;
+}
+
+async function sendSpeakerReceipt(
+  invitation: SpeakerInvitationShape,
+  bishopric: BishopricContact[],
+): Promise<void> {
+  if (!invitation.speakerEmail) {
+    logger.info("speaker receipt skipped — no speakerEmail on invitation", {
+      speakerName: invitation.speakerName,
+    });
+    return;
+  }
+  const content = buildSpeakerReceipt({ invitation });
+  await sendEmail({
+    to: invitation.speakerEmail,
+    fromDisplayName: `${invitation.wardName} (via Steward)`,
+    subject: content.subject,
+    text: content.text,
+    html: content.html,
+    ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
+  });
+}
+
+async function sendBishopricReceipt(
+  invitation: SpeakerInvitationShape,
+  bishopric: BishopricContact[],
+  ctx: { wardId: string; invitationId: string; origin: string },
+): Promise<void> {
+  if (bishopric.length === 0) {
+    logger.warn("bishopric receipt skipped — no bishopric emails found", { wardId: ctx.wardId });
+    return;
+  }
+  const acknowledgedByName = bishopric.find(
+    (b) => b.uid === invitation.response?.acknowledgedBy,
+  )?.displayName;
+  const respondedAt = invitation.response?.respondedAt?.toDate();
+  const origin = ctx.origin.replace(/\/+$/, "");
+  const bishopricViewUrl = `${origin}/ward/${ctx.wardId}/invitations/${ctx.invitationId}/view`;
+  const content = buildBishopricReceipt({
+    invitation,
+    bishopricViewUrl,
+    acknowledgedByName,
+    respondedAt,
+  });
+  // Send individually rather than via CC: the bishopric list can be 3-7
+  // people and individual sends give SendGrid cleaner bounce handling
+  // per recipient.
+  await Promise.all(
+    bishopric.map((b) =>
+      sendEmail({
+        to: b.email,
+        fromDisplayName: `Steward`,
+        subject: content.subject,
+        text: content.text,
+        html: content.html,
+      }),
+    ),
+  );
+}

--- a/functions/src/rotateInvitationLink.ts
+++ b/functions/src/rotateInvitationLink.ts
@@ -1,4 +1,4 @@
-import { getFirestore } from "firebase-admin/firestore";
+import { FieldValue, getFirestore } from "firebase-admin/firestore";
 import { HttpsError } from "firebase-functions/v2/https";
 import { buildInviteUrl, tryEmail, trySms } from "./sendSpeakerInvitation.helpers.js";
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
@@ -11,8 +11,9 @@ import type {
 
 /** Bishop-driven link rotation. Generates a new capability token on
  *  an existing invitation, preserving conversationSid + chat history
- *  + bishopricParticipants snapshot + any prior response. Returns the
- *  plaintext URL once; Firestore keeps only the new hash.
+ *  + bishopricParticipants snapshot + any prior response. The
+ *  plaintext URL is embedded in the SMS/email body and never returned
+ *  to the caller — only the delivery outcome travels back.
  *
  *  Bishop-driven rotations don't count against ROTATION_DAILY_CAP —
  *  that cap exists to limit SMS-cost exposure from a leaked link,
@@ -36,17 +37,68 @@ export async function rotateInvitationLink(
 
   const plaintextToken = generateInvitationToken();
   const tokenHash = hashInvitationToken(plaintextToken);
-  await ref.update({ tokenHash, tokenStatus: "active" as const });
+
+  // Refresh the speakerEmail + speakerPhone snapshot from the live
+  // speaker doc before we build the delivery payload. Without this,
+  // a bishop correcting a typo in the speaker's phone number and then
+  // hitting Resend would still deliver to the stale number on the
+  // invitation doc. The rest of the letter (name, date, wardName,
+  // inviterName) stays frozen — only delivery channels refresh.
+  const liveContact =
+    input.channels.length > 0 ? await readLiveContactInfo(db, input.wardId, invitation) : null;
+  const writePatch = liveContact ? contactWritePatch(liveContact) : {};
+  const effectiveContact: Pick<SpeakerInvitationShape, "speakerEmail" | "speakerPhone"> =
+    liveContact ?? {
+      ...(invitation.speakerEmail ? { speakerEmail: invitation.speakerEmail } : {}),
+      ...(invitation.speakerPhone ? { speakerPhone: invitation.speakerPhone } : {}),
+    };
+
+  await ref.update({ tokenHash, tokenStatus: "active" as const, ...writePatch });
 
   const inviteUrl = buildInviteUrl(origin, input.wardId, input.invitationId, plaintextToken);
-  const deliveryRecord = await deliverIfRequested(input, invitation, inviteUrl);
+  const freshInvitation: SpeakerInvitationShape = { ...invitation, ...effectiveContact };
+  const deliveryRecord = await deliverIfRequested(input, freshInvitation, inviteUrl);
   if (deliveryRecord.length > 0) {
     await ref.update({
       deliveryRecord: [...(invitation.deliveryRecord ?? []), ...deliveryRecord],
     });
   }
 
-  return { mode: "rotate", inviteUrl, deliveryRecord };
+  return { mode: "rotate", deliveryRecord };
+}
+
+interface LiveContact {
+  speakerEmail?: string;
+  speakerPhone?: string;
+}
+
+async function readLiveContactInfo(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+  invitation: SpeakerInvitationShape,
+): Promise<LiveContact | null> {
+  const { meetingDate, speakerId } = invitation.speakerRef;
+  const speakerRef = db.doc(`wards/${wardId}/meetings/${meetingDate}/speakers/${speakerId}`);
+  const snap = await speakerRef.get();
+  if (!snap.exists) return null;
+  const speaker = snap.data() as { email?: string; phone?: string };
+  const out: LiveContact = {};
+  if (speaker.email) out.speakerEmail = speaker.email;
+  if (speaker.phone) out.speakerPhone = speaker.phone;
+  return out;
+}
+
+/** Convert the live contact into a Firestore update patch: set the
+ *  field when present, mark it for deletion when the speaker no
+ *  longer has that channel. Keeps the invitation snapshot honest so a
+ *  subsequent resend doesn't fall back to a removed channel. */
+function contactWritePatch(
+  live: LiveContact,
+): Record<string, string | FirebaseFirestore.FieldValue> {
+  return {
+    speakerEmail: live.speakerEmail ?? FieldValue.delete(),
+    speakerPhone: live.speakerPhone ?? FieldValue.delete(),
+  };
 }
 
 async function deliverIfRequested(

--- a/functions/src/sendSpeakerInvitation.types.ts
+++ b/functions/src/sendSpeakerInvitation.types.ts
@@ -30,8 +30,9 @@ export interface FreshInvitationRequest {
 
 /** Rotate-link path: generates a fresh capability token on an
  *  existing invitation, preserving the conversationSid + chat
- *  history. `channels` may be empty — the bishop may want to copy
- *  the URL to their clipboard without triggering another SMS/email. */
+ *  history. `channels` lists the delivery channels to re-deliver on;
+ *  the plaintext URL is never returned to the caller — it only ever
+ *  reaches the speaker via SMS/email. */
 export interface RotateInvitationRequest {
   mode: "rotate";
   wardId: string;
@@ -52,10 +53,6 @@ export interface FreshInvitationResponse {
 
 export interface RotateInvitationResponse {
   mode: "rotate";
-  /** Freshly-rotated URL carrying a new capability token. Plaintext
-   *  leaves the server here exactly once; Firestore stores only the
-   *  new hash. */
-  inviteUrl: string;
   deliveryRecord: DeliveryEntry[];
 }
 

--- a/functions/src/sendgrid/client.ts
+++ b/functions/src/sendgrid/client.ts
@@ -1,4 +1,14 @@
 import sgMail from "@sendgrid/mail";
+import { logger } from "firebase-functions/v2";
+
+/** In local dev the Firebase emulator sets `FUNCTIONS_EMULATOR=true`.
+ *  We use that as the single signal to stub SendGrid delivery — real
+ *  sends would need a live API key that dev machines shouldn't carry
+ *  anyway. Outside the emulator a missing key still throws, so a
+ *  prod mis-config fails loud. */
+function isStubbed(): boolean {
+  return process.env.FUNCTIONS_EMULATOR === "true";
+}
 
 let configured = false;
 function ensureConfigured(): void {
@@ -24,6 +34,17 @@ export interface EmailInput {
 }
 
 export async function sendEmail(input: EmailInput): Promise<string | null> {
+  if (isStubbed()) {
+    logger.info("[sendgrid:stub] email captured (not sent)", {
+      to: input.to,
+      cc: input.cc,
+      replyTo: input.replyTo,
+      fromDisplayName: input.fromDisplayName,
+      subject: input.subject,
+      textPreview: input.text.slice(0, 400),
+    });
+    return `stub-${Date.now()}`;
+  }
   ensureConfigured();
   const fromAddress = process.env.INVITATION_FROM_EMAIL;
   if (!fromAddress) throw new Error("INVITATION_FROM_EMAIL missing.");

--- a/functions/src/sendgrid/client.ts
+++ b/functions/src/sendgrid/client.ts
@@ -15,6 +15,9 @@ export interface EmailInput {
    *  `"Bishop Haymond (via Steward) <bishopric@mail.steward-app.ca>"`. */
   fromDisplayName: string;
   replyTo?: string;
+  /** Optional CC recipients. Used for the speaker's response-receipt
+   *  email so the bishopric sees a copy in the same thread. */
+  cc?: readonly string[];
   subject: string;
   text: string;
   html?: string;
@@ -30,6 +33,7 @@ export async function sendEmail(input: EmailInput): Promise<string | null> {
     subject: input.subject,
     text: input.text,
     ...(input.replyTo ? { replyTo: input.replyTo } : {}),
+    ...(input.cc && input.cc.length > 0 ? { cc: [...input.cc] } : {}),
     ...(input.html ? { html: input.html } : {}),
   });
   return res.headers["x-message-id"] ?? null;

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -4,6 +4,7 @@ import { ConductingProgram } from "@/features/print/ConductingProgram";
 import { ScheduleView } from "@/features/schedule/ScheduleView";
 import { AuthGate } from "./auth-gate";
 import { AcceptInvitePage } from "./routes/accept-invite";
+import { InvitationViewPage } from "./routes/invitation-view";
 import { SpeakerInvitationLandingPage } from "./routes/invite-speaker";
 import { Login } from "./routes/login";
 import { MembersPage } from "./routes/members";
@@ -30,6 +31,10 @@ export const router = createBrowserRouter([
       { path: "settings/notifications", element: <NotificationSettingsPage /> },
       { path: "settings/templates/speaker-email", element: <SpeakerEmailTemplatePage /> },
       { path: "settings/templates/ward-invites", element: <WardInviteTemplatePage /> },
+      {
+        path: "ward/:wardId/invitations/:invitationId/view",
+        element: <InvitationViewPage />,
+      },
     ],
   },
   // Print views + full-screen editors share AuthGate's auth + ward

--- a/src/app/routes/invitation-view.tsx
+++ b/src/app/routes/invitation-view.tsx
@@ -1,0 +1,104 @@
+import { Link, useParams } from "react-router";
+import { ScaledLetterPreview } from "@/features/templates/ScaledLetterPreview";
+import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation";
+import { useWardMembers } from "@/hooks/useWardMembers";
+
+function formatTimestamp(value: unknown): string | null {
+  if (!value) return null;
+  const ts = value as { toDate?: () => Date };
+  if (typeof ts.toDate === "function") return ts.toDate().toLocaleString();
+  if (value instanceof Date) return value.toLocaleString();
+  return null;
+}
+
+/** Read-only view of a speaker invitation for the bishopric. Linked
+ *  from the bishopric receipt email — shows the frozen letter + the
+ *  response's provenance block without the chat pane. For the full
+ *  workspace (chat, Apply, Resend) the bishopric goes to Prepare. */
+export function InvitationViewPage(): React.ReactElement {
+  const { wardId, invitationId } = useParams<{ wardId: string; invitationId: string }>();
+  const letter = useSpeakerInvitation(wardId, invitationId);
+  const members = useWardMembers();
+
+  if (letter.kind === "loading") return <CenteredNote>Loading…</CenteredNote>;
+  if (letter.kind === "not-found") return <CenteredNote>Invitation not found.</CenteredNote>;
+  if (letter.kind === "error")
+    return <CenteredNote>Couldn't load invitation — {letter.message}</CenteredNote>;
+
+  const inv = letter.invitation;
+  const response = inv.response;
+  const acknowledgedByName = response?.acknowledgedBy
+    ? (members.data.find((m) => m.id === response.acknowledgedBy)?.data.displayName ?? null)
+    : null;
+  const prepareHref = `/week/${inv.speakerRef.meetingDate}/speaker/${inv.speakerRef.speakerId}/prepare`;
+
+  return (
+    <main className="max-w-3xl mx-auto flex flex-col gap-4 py-6 px-4">
+      <header>
+        <h1 className="font-sans text-xl font-semibold text-walnut">
+          {inv.speakerName} — {inv.assignedDate}
+        </h1>
+        <p className="font-serif italic text-sm text-walnut-2 mt-0.5">
+          Read-only view. Jump to{" "}
+          <Link to={prepareHref} className="underline decoration-brass-soft">
+            Prepare invitation
+          </Link>{" "}
+          for the full workspace with chat.
+        </p>
+      </header>
+
+      {response && (
+        <section className="bg-chalk border border-border rounded-lg p-4">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+            Response
+          </div>
+          <div className="font-sans text-lg text-walnut mt-1">
+            {response.answer === "yes" ? "Accepted" : "Declined"}
+          </div>
+          {response.reason && (
+            <blockquote className="mt-2 pl-3 border-l-2 border-brass-soft font-serif italic text-[13.5px] text-walnut-2">
+              {response.reason}
+            </blockquote>
+          )}
+          <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 font-mono text-[10px] uppercase tracking-[0.08em] text-walnut-3">
+            {formatTimestamp(response.respondedAt) && (
+              <>
+                <dt>Responded</dt>
+                <dd>{formatTimestamp(response.respondedAt)}</dd>
+              </>
+            )}
+            {formatTimestamp(response.acknowledgedAt) && (
+              <>
+                <dt>Applied</dt>
+                <dd>
+                  {formatTimestamp(response.acknowledgedAt)}
+                  {acknowledgedByName ? ` · ${acknowledgedByName}` : ""}
+                </dd>
+              </>
+            )}
+          </dl>
+        </section>
+      )}
+
+      <div className="bg-chalk border border-border rounded-lg shadow-elev-1 overflow-hidden">
+        <ScaledLetterPreview
+          naked
+          height="60vh"
+          wardName={inv.wardName}
+          assignedDate={inv.assignedDate}
+          today={inv.sentOn}
+          bodyMarkdown={inv.bodyMarkdown}
+          footerMarkdown={inv.footerMarkdown}
+        />
+      </div>
+    </main>
+  );
+}
+
+function CenteredNote({ children }: { children: React.ReactNode }): React.ReactElement {
+  return (
+    <main className="grid min-h-dvh place-items-center">
+      <p className="font-serif italic text-walnut-2">{children}</p>
+    </main>
+  );
+}

--- a/src/features/invitations/InvitationLinkActions.test.tsx
+++ b/src/features/invitations/InvitationLinkActions.test.tsx
@@ -35,9 +35,6 @@ function openMenu() {
 
 beforeEach(() => {
   mockFn.mockReset();
-  Object.assign(navigator, {
-    clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
-  });
 });
 
 afterEach(() => {
@@ -51,25 +48,10 @@ describe("InvitationLinkActions", () => {
     expect(screen.getByRole("button", { name: "Invitation link actions" })).toBeTruthy();
   });
 
-  it("Copy link menu item rotates with empty channels and writes URL to clipboard", async () => {
-    mockFn.mockResolvedValue({
-      mode: "rotate",
-      inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
-      deliveryRecord: [],
-    });
+  it("never exposes a Copy link action — the plaintext URL stays server-side", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Copy link" }));
-    await waitFor(() => expect(screen.getByText("Link copied")).toBeTruthy());
-    expect(mockFn).toHaveBeenCalledWith({
-      mode: "rotate",
-      wardId: "w1",
-      invitationId: "i1",
-      channels: [],
-    });
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
-      "https://app.example/invite/speaker/w1/i1/tok",
-    );
+    expect(screen.queryByRole("menuitem", { name: "Copy link" })).toBeNull();
   });
 
   it("Resend menu item shows both channels when invitation has email + phone", () => {
@@ -78,18 +60,16 @@ describe("InvitationLinkActions", () => {
     expect(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" })).toBeTruthy();
   });
 
-  it("omits the Resend item entirely when no channel is available", () => {
+  it("renders no overflow items when no delivery channel is available", () => {
     const inv = mkInvitation({ speakerEmail: undefined, speakerPhone: undefined });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
     openMenu();
-    expect(screen.getByRole("menuitem", { name: "Copy link" })).toBeTruthy();
     expect(screen.queryByRole("menuitem", { name: /Resend/ })).toBeNull();
   });
 
   it("surfaces a delivery-failed message when every delivery failed", async () => {
     mockFn.mockResolvedValue({
       mode: "rotate",
-      inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
       deliveryRecord: [{ channel: "sms", status: "failed", error: "twilio: 21610", at: "now" }],
     });
     const inv = mkInvitation({ speakerEmail: undefined });
@@ -102,7 +82,6 @@ describe("InvitationLinkActions", () => {
   it("reports the channels that actually sent on success", async () => {
     mockFn.mockResolvedValue({
       mode: "rotate",
-      inviteUrl: "https://app.example/invite/speaker/w1/i1/tok",
       deliveryRecord: [
         { channel: "sms", status: "sent", providerId: "SM1", at: "now" },
         { channel: "email", status: "failed", error: "bounced", at: "now" },

--- a/src/features/invitations/InvitationLinkActions.tsx
+++ b/src/features/invitations/InvitationLinkActions.tsx
@@ -11,18 +11,18 @@ interface Props {
 
 type Status =
   | { kind: "idle" }
-  | { kind: "working"; verb: "copy" | "resend" }
-  | { kind: "copied" }
+  | { kind: "working" }
   | { kind: "sent"; channels: readonly ("email" | "sms")[] }
   | { kind: "error"; message: string };
 
 const FLASH_MS = 2500;
 
-/** Overflow menu for the bishop viewing an already-sent invitation:
- *  rotate + copy the URL, or rotate + re-deliver via the channels
- *  the invitation originally used. Both actions invalidate any prior
- *  URL the speaker has — the server-side self-heal path handles any
- *  concurrent visit to an older link. */
+/** Overflow menu for the bishop viewing an already-sent invitation.
+ *  Rotates + redelivers the URL via the invitation's original
+ *  channels. The plaintext URL never returns to the bishop's client —
+ *  it only ever reaches the speaker's phone/email. Any prior URL the
+ *  speaker has is invalidated (the server-side self-heal path handles
+ *  concurrent visits to an older link). */
 export function InvitationLinkActions({
   wardId,
   invitationId,
@@ -32,30 +32,14 @@ export function InvitationLinkActions({
   const deliverable = availableChannels(invitation);
 
   useEffect(() => {
-    if (status.kind !== "copied" && status.kind !== "sent") return;
+    if (status.kind !== "sent") return;
     const t = setTimeout(() => setStatus({ kind: "idle" }), FLASH_MS);
     return () => clearTimeout(t);
   }, [status]);
 
-  async function copy() {
-    setStatus({ kind: "working", verb: "copy" });
-    try {
-      const res = await callRotateInvitationLink({
-        mode: "rotate",
-        wardId,
-        invitationId,
-        channels: [],
-      });
-      await navigator.clipboard.writeText(res.inviteUrl);
-      setStatus({ kind: "copied" });
-    } catch (err) {
-      setStatus({ kind: "error", message: (err as Error).message });
-    }
-  }
-
   async function resend() {
     if (deliverable.length === 0) return;
-    setStatus({ kind: "working", verb: "resend" });
+    setStatus({ kind: "working" });
     try {
       const res = await callRotateInvitationLink({
         mode: "rotate",
@@ -74,7 +58,7 @@ export function InvitationLinkActions({
     }
   }
 
-  const items: OverflowMenuItem[] = [{ label: "Copy link", onSelect: () => void copy() }];
+  const items: OverflowMenuItem[] = [];
   if (deliverable.length > 0) {
     items.push({
       label: `Resend via ${formatChannels(deliverable)}`,
@@ -110,8 +94,7 @@ function availableChannels(invitation: SpeakerInvitation): readonly ("email" | "
 }
 
 function statusLabel(status: Status): string {
-  if (status.kind === "working") return status.verb === "copy" ? "Copying…" : "Sending…";
-  if (status.kind === "copied") return "Link copied";
+  if (status.kind === "working") return "Sending…";
   if (status.kind === "sent") return `Sent via ${formatChannels(status.channels)}`;
   return status.message;
 }

--- a/src/features/invitations/invitationActions.ts
+++ b/src/features/invitations/invitationActions.ts
@@ -66,6 +66,11 @@ export async function applyResponseToSpeaker(input: ApplyResponseInput): Promise
     "response.acknowledgedAt": serverTimestamp(),
     "response.acknowledgedBy": input.bishopUid,
   });
-  batch.update(speakerRef, { status: newStatus });
+  batch.update(speakerRef, {
+    status: newStatus,
+    statusSource: "speaker-response",
+    statusSetBy: input.bishopUid,
+    statusSetAt: serverTimestamp(),
+  });
   await batch.commit();
 }

--- a/src/features/invitations/invitationsCallable.ts
+++ b/src/features/invitations/invitationsCallable.ts
@@ -47,7 +47,6 @@ export interface FreshInvitationResponse {
 
 export interface RotateInvitationResponse {
   mode: "rotate";
-  inviteUrl: string;
   deliveryRecord: DeliveryEntry[];
 }
 
@@ -65,9 +64,8 @@ export async function callSendSpeakerInvitation(
 }
 
 /** Bishop-driven: rotate the capability token on an existing
- *  invitation and optionally redeliver via email/SMS. Pass
- *  `channels: []` for a copy-link-only flow that returns the new
- *  URL without triggering a redelivery. */
+ *  invitation and redeliver via email/SMS. The fresh plaintext URL
+ *  is embedded in the delivery body and never returned to the caller. */
 export async function callRotateInvitationLink(
   input: RotateInvitationRequest,
 ): Promise<RotateInvitationResponse> {

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -2,9 +2,11 @@ import { useState } from "react";
 import { BishopInvitationDialog } from "@/features/invitations/BishopInvitationDialog";
 import { useConversationUnread } from "@/features/invitations/useConversationUnread";
 import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
+import { useWardMembers } from "@/hooks/useWardMembers";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import type { Speaker, SpeakerStatus } from "@/lib/types";
 import { cn } from "@/lib/cn";
+import { statusProvenanceLabel } from "./statusProvenance";
 
 interface Props {
   number: number;
@@ -34,6 +36,8 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
   const needsApply = Boolean(response && !response.acknowledgedAt);
   const unreadCount = useConversationUnread(invitation?.conversationSid);
   const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
+  const members = useWardMembers();
+  const provenance = statusProvenanceLabel(speaker, members);
 
   return (
     <li className="flex items-center gap-3 py-3 border-b border-border last:border-b-0">
@@ -44,6 +48,11 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
         <div className="font-sans text-sm font-semibold text-walnut truncate">{speaker.name}</div>
         {speaker.topic && (
           <div className="font-serif italic text-sm text-walnut-2 truncate">{speaker.topic}</div>
+        )}
+        {provenance && (
+          <div className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 truncate mt-0.5">
+            {provenance}
+          </div>
         )}
       </div>
       <div

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -50,7 +50,7 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
           <div className="font-serif italic text-sm text-walnut-2 truncate">{speaker.topic}</div>
         )}
         {provenance && (
-          <div className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 truncate mt-0.5">
+          <div className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 mt-0.5">
             {provenance}
           </div>
         )}

--- a/src/features/schedule/statusProvenance.ts
+++ b/src/features/schedule/statusProvenance.ts
@@ -1,0 +1,47 @@
+import type { Speaker, WithId, Member } from "@/lib/types";
+import type { SubState } from "@/hooks/_sub";
+
+interface FirestoreTimestampLike {
+  toDate: () => Date;
+}
+
+function resolveName(uid: string | undefined, members: SubState<WithId<Member>[]>): string | null {
+  if (!uid) return null;
+  const hit = members.data.find((m) => m.id === uid);
+  return hit?.data.displayName ?? null;
+}
+
+function formatShortDate(value: unknown): string | null {
+  if (!value) return null;
+  const ts = value as Partial<FirestoreTimestampLike>;
+  if (typeof ts.toDate === "function") {
+    return ts.toDate().toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  if (value instanceof Date) {
+    return value.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+  }
+  return null;
+}
+
+/** Compact label describing who set the speaker's current status and
+ *  how, for surfaces that want to show provenance next to the status
+ *  badge. Returns null when the status is planned/invited (provenance
+ *  is meaningful only for the terminal states) or when the speaker
+ *  doc is missing the provenance fields (legacy rows pre-rollout). */
+export function statusProvenanceLabel(
+  speaker: Speaker,
+  members: SubState<WithId<Member>[]>,
+): string | null {
+  if (speaker.status !== "confirmed" && speaker.status !== "declined") return null;
+  if (!speaker.statusSource) return null;
+  const who = resolveName(speaker.statusSetBy, members);
+  const when = formatShortDate(speaker.statusSetAt);
+  const source = speaker.statusSource === "speaker-response" ? "from reply" : "set manually";
+  const byPart = who ? ` by ${who}` : "";
+  const whenPart = when ? ` · ${when}` : "";
+  const prefix =
+    speaker.statusSource === "speaker-response"
+      ? `${source} · applied${byPart}`
+      : `${source}${byPart}`;
+  return `${prefix}${whenPart}`;
+}

--- a/src/features/speakers/speakerActions.ts
+++ b/src/features/speakers/speakerActions.ts
@@ -44,20 +44,23 @@ export async function createSpeaker(input: CreateSpeakerInput): Promise<void> {
     // subcollection entry. Ensure the parent meeting is there first.
     await ensureMeetingDoc(input.wardId, input.date, input.nonMeetingSundays);
     const ref = doc(collection(db, "wards", input.wardId, "meetings", input.date, "speakers"));
+    const actor = currentActor();
     const data: Record<string, unknown> = {
       name: input.name,
       status: "planned",
       role: input.role || "Member",
+      statusSource: "manual",
+      statusSetAt: serverTimestamp(),
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     };
+    if (actor) data.statusSetBy = actor.uid;
     if (input.email) data.email = input.email;
     if (input.phone) data.phone = input.phone;
     if (input.topic) data.topic = input.topic;
 
     const batch = writeBatch(db);
     batch.set(ref, data);
-    const actor = currentActor();
     if (actor) {
       const changes: HistoryChange[] = [{ field: "name", new: input.name }];
       if (input.topic) changes.push({ field: "topic", new: input.topic });
@@ -88,11 +91,20 @@ export async function updateSpeaker(
   }>,
 ): Promise<void> {
   return withSaveError(async () => {
+    const actor = currentActor();
     const data: Record<string, unknown> = { updatedAt: serverTimestamp(), ...updates };
+    // Status changes authored here are bishopric-initiated overrides;
+    // speaker-response confirmations flow through applyResponseToSpeaker
+    // and stamp "speaker-response" there. Surfacing the source next to
+    // the badge lets the team audit who changed what.
+    if ("status" in updates) {
+      data.statusSource = "manual";
+      data.statusSetAt = serverTimestamp();
+      if (actor) data.statusSetBy = actor.uid;
+    }
     const batch = writeBatch(db);
     batch.update(speakerRef(wardId, date, speakerId), data);
 
-    const actor = currentActor();
     if (actor) {
       const changes: HistoryChange[] = Object.entries(updates).map(([field, value]) => ({
         field,

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -120,6 +120,16 @@ export const speakerLetterOverrideSchema = z.object({
 });
 export type SpeakerLetterOverride = z.infer<typeof speakerLetterOverrideSchema>;
 
+// Provenance for the last `status` change on a speaker row. "speaker-response"
+// means it was mirrored from a speaker's Yes/No reply on the invite page (via
+// `applyResponseToSpeaker`); "manual" means a bishopric member set it directly
+// in the schedule or speaker form. Surfaced next to the status badge so the
+// team audits itself — the invite flow isn't a security boundary, just a
+// workflow, and the bishopric has ultimate authority on status either way.
+export const STATUS_SOURCES = ["speaker-response", "manual"] as const;
+export const statusSourceSchema = z.enum(STATUS_SOURCES);
+export type StatusSource = z.infer<typeof statusSourceSchema>;
+
 // Tolerate legacy speaker docs that stored a status outside the current
 // enum (e.g. "draft", "sent") — fall back to "planned" rather than failing
 // the whole list parse.
@@ -135,6 +145,9 @@ export const speakerSchema = z.object({
   role: speakerRoleSchema.catch("Member"),
   order: z.number().int().min(0).optional(),
   letterOverride: speakerLetterOverrideSchema.optional(),
+  statusSource: statusSourceSchema.optional(),
+  statusSetBy: z.string().optional(),
+  statusSetAt: z.any().optional(),
   createdAt: z.any().optional(),
   updatedAt: z.any().optional(),
 });


### PR DESCRIPTION
## Summary

Reframes the \"bishop can fake a speaker's response\" thread as a **transparency + audit** problem rather than a prevention one — the bishopric has direct write access to `speaker.status` anyway, so putting OTP on the invite page was locking a door with no wall around it. Plan file: `/Users/oriel/.claude/plans/toasty-chasing-sprout.md`.

**What's in:**

1. **Remove \"Copy link\" overflow action.** The rotate callable no longer returns `inviteUrl` — the freshly-minted plaintext URL stays server-side and reaches the speaker only via SMS / email.
2. **Fix stale-snapshot resend bug.** When a bishop corrected a typo'd phone/email on the speaker form and hit Resend, delivery used the original snapshot on the invitation doc. Rotate now reads the live speaker doc and refreshes `speakerEmail` + `speakerPhone` before building the delivery payload, persisting the refreshed snapshot. Absent channels are cleared with `FieldValue.delete()`.
3. **Status provenance.** Speaker doc gains `statusSource` (`\"speaker-response\" | \"manual\"`), `statusSetBy` (uid), `statusSetAt`. Written by `applyResponseToSpeaker`, `updateSpeaker`, `createSpeaker`. Schedule row shows a compact eyebrow on confirmed/declined rows: _\"from reply · applied by John · Apr 22\"_ or _\"set manually by John · Apr 23\"_.
4. **Receipts.** New `onInvitationWrite` Firestore trigger:
   - `response.answer` newly present → email the speaker (cc'd to active bishopric/clerks) with the original letter rendered inline.
   - `response.acknowledgedAt` newly present → email each active bishopric/clerk individually with the letter inline + a link to the new read-only view.
   - Other writes (heartbeat, delivery record, token rotation) are classified as no-ops by the pure `classifyInvitationChange` helper (unit tested).
5. **Read-only bishopric view** at `/ward/:wardId/invitations/:invitationId/view` — letter + response block (answer, respondedAt, applied-by) without a chat pane. The Apply-receipt CTA lands here.

## Out of scope (intentional)

- OTP / email verification for the speaker's response — ruled out on the merits (bishopric bypass makes it moot).
- Mismatch flags for non-matching verified emails.
- Post-Sunday hard expiry of the speaker invite page.
- Audit log of speaker.email / speaker.phone mutations.

## Test plan

- [x] `pnpm typecheck` (root) — clean
- [x] functions `pnpm run build` — clean
- [x] `pnpm lint` — 61 warnings, 0 errors (baseline +1 from an escapeHtml arrow-body that matches the existing pattern in `invitationReplyNotify.ts`)
- [x] `pnpm format:check` — clean after `pnpm format`
- [x] `pnpm test` — 241 passing (app)
- [x] functions `pnpm test` — 67 passing (including new invitationChange + invitationReceiptContent suites)
- [ ] Rules + e2e will run in CI on push
- [ ] Manual (preview): send an invitation with a wrong phone → correct it in the speaker form → Resend → SMS lands at the corrected number; confirm invitation doc's `speakerPhone` now reflects the new number.
- [ ] Manual: speaker submits Yes on the invite page → speaker receives email with the letter inline + bishopric members in cc.
- [ ] Manual: bishop clicks Apply → all active bishopric members receive email with the letter inline + a View link that loads `/ward/:wardId/invitations/:invitationId/view`.
- [ ] Manual: confirm the overflow no longer exposes \"Copy link\".
- [ ] Manual: provenance eyebrow appears on the schedule row in both \"from reply\" and \"set manually\" flavors.

## Deployment note

This PR adds the 7th Cloud Function (`onInvitationWrite`). CLAUDE.md flags this as a deliberate-scope decision — the receipts need to fire server-side on authoritative Firestore transitions; the trigger pattern matches `onMeetingWrite` + `onCommentCreate`. Requires the existing `SENDGRID_API_KEY` + `INVITATION_FROM_EMAIL` + `STEWARD_ORIGIN` env configs; no new secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)