### PR TITLE
feat(invite): full-viewport letter with floating chat drawer

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="theme-color" content="#0f172a" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/src/app/routes/invite-speaker-chat-drawer.tsx
+++ b/src/app/routes/invite-speaker-chat-drawer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from "react";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+import type { CtaVariant } from "./invite-speaker-cta-banner";
 
 interface Props {
   /** Controlled open state so the parent can auto-open when chat
@@ -7,9 +8,9 @@ interface Props {
    *  drawer is collapsed). */
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  /** Tiny badge in the FAB when there's something worth seeing —
-   *  unread replies, a pending Yes/No ask, etc. */
-  hint?: string | undefined;
+  /** When set, the FAB draws attention via a pulse ring, larger size,
+   *  and a variant-specific label. `null` renders the calm FAB. */
+  attention?: CtaVariant | null;
   children: ReactNode;
 }
 
@@ -21,7 +22,7 @@ interface Props {
 export function SpeakerChatFloatingDrawer({
   open,
   onOpenChange,
-  hint,
+  attention,
   children,
 }: Props): React.ReactElement {
   useLockBodyScroll(open);
@@ -38,20 +39,29 @@ export function SpeakerChatFloatingDrawer({
   }, [open, onOpenChange]);
 
   if (!open) {
+    const label =
+      attention === "reply"
+        ? "Reply to the bishopric"
+        : attention === "unread"
+          ? "New message"
+          : "Conversation";
+    const pulseStyle: React.CSSProperties | undefined = attention
+      ? { animation: "fabPulse 1.8s ease-out infinite" }
+      : undefined;
     return (
       <button
         type="button"
         onClick={() => onOpenChange(true)}
-        className="fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-4 py-3 rounded-full bg-bordeaux text-parchment font-sans text-[13.5px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.75rem,env(safe-area-inset-bottom))]"
-        aria-label="Open conversation with the bishopric"
+        style={pulseStyle}
+        className={
+          attention
+            ? "fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-5 py-3.5 rounded-full bg-bordeaux text-parchment font-sans text-[14px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.875rem,env(safe-area-inset-bottom))]"
+            : "fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-4 py-3 rounded-full bg-bordeaux text-parchment font-sans text-[13.5px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.75rem,env(safe-area-inset-bottom))]"
+        }
+        aria-label={`${label} — open the conversation with the bishopric`}
       >
         <ChatIcon />
-        <span>Conversation</span>
-        {hint && (
-          <span className="font-mono text-[10px] uppercase tracking-[0.14em] bg-parchment/20 px-1.5 py-0.5 rounded-full">
-            {hint}
-          </span>
-        )}
+        <span>{label}</span>
       </button>
     );
   }

--- a/src/app/routes/invite-speaker-chat-drawer.tsx
+++ b/src/app/routes/invite-speaker-chat-drawer.tsx
@@ -1,0 +1,92 @@
+import { useEffect, type ReactNode } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+interface Props {
+  /** Controlled open state so the parent can auto-open when chat
+   *  activity demands attention (e.g. a bishop reply lands while the
+   *  drawer is collapsed). */
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Tiny badge in the FAB when there's something worth seeing —
+   *  unread replies, a pending Yes/No ask, etc. */
+  hint?: string | undefined;
+  children: ReactNode;
+}
+
+/** Floating chat drawer for the speaker invite page. Collapsed, it
+ *  shows a pill-shaped FAB bottom-right. Opened, it fills the screen
+ *  on mobile and docks as a ~420px wide panel bottom-right on sm+.
+ *  Body scroll is locked while open to keep the letter behind from
+ *  rubber-banding on iOS. */
+export function SpeakerChatFloatingDrawer({
+  open,
+  onOpenChange,
+  hint,
+  children,
+}: Props): React.ReactElement {
+  useLockBodyScroll(open);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      onOpenChange(false);
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, onOpenChange]);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => onOpenChange(true)}
+        className="fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-4 py-3 rounded-full bg-bordeaux text-parchment font-sans text-[13.5px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.75rem,env(safe-area-inset-bottom))]"
+        aria-label="Open conversation with the bishopric"
+      >
+        <ChatIcon />
+        <span>Conversation</span>
+        {hint && (
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] bg-parchment/20 px-1.5 py-0.5 rounded-full">
+            {hint}
+          </span>
+        )}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Conversation with the bishopric"
+      className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.42)] flex items-stretch sm:items-end justify-end sm:p-4 animate-[fade_160ms_ease-out]"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onOpenChange(false);
+      }}
+    >
+      <div className="bg-chalk flex flex-col w-full h-dvh sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border sm:border-border-strong sm:shadow-elev-3 overflow-hidden">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+function ChatIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}

--- a/src/app/routes/invite-speaker-cta-banner.tsx
+++ b/src/app/routes/invite-speaker-cta-banner.tsx
@@ -1,0 +1,88 @@
+export type CtaVariant = "reply" | "unread";
+
+interface Props {
+  variant: CtaVariant;
+  onTap: () => void;
+}
+
+/** Top-of-viewport nudge that tells the speaker they should open the
+ *  chat drawer. Shown only while the drawer is closed and something
+ *  demands attention (no response yet, or an unread bishop message).
+ *  Taps anywhere on the banner open the drawer. */
+export function SpeakerChatCTABanner({ variant, onTap }: Props): React.ReactElement {
+  const copy = variant === "reply" ? REPLY_COPY : UNREAD_COPY;
+  return (
+    <button
+      type="button"
+      onClick={onTap}
+      className="fixed inset-x-0 top-0 z-10 w-full pt-[env(safe-area-inset-top)] bg-bordeaux text-parchment shadow-elev-3 animate-[fade_160ms_ease-out]"
+      aria-label={copy.aria}
+    >
+      <div className="flex items-center justify-between gap-3 px-4 py-3 max-w-3xl mx-auto">
+        <div className="flex items-center gap-2 min-w-0">
+          <span
+            aria-hidden="true"
+            className="inline-flex items-center justify-center w-7 h-7 rounded-full bg-parchment/15"
+          >
+            {variant === "reply" ? <PenIcon /> : <ChatIcon />}
+          </span>
+          <span className="font-sans text-[13.5px] font-semibold text-left truncate">
+            {copy.body}
+          </span>
+        </div>
+        <span className="font-mono text-[10px] uppercase tracking-[0.14em] bg-parchment/15 px-2.5 py-1 rounded-full shrink-0">
+          {copy.action}
+        </span>
+      </div>
+    </button>
+  );
+}
+
+const REPLY_COPY = {
+  body: "Please reply to the speaking invitation",
+  action: "Reply now",
+  aria: "Please reply to the speaking invitation — tap to open the chat",
+};
+
+const UNREAD_COPY = {
+  body: "New message from the bishopric",
+  action: "Open chat",
+  aria: "New message from the bishopric — tap to open the chat",
+};
+
+function PenIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 20h9" />
+      <path d="M16.5 3.5a2.121 2.121 0 013 3L7 19l-4 1 1-4 12.5-12.5z" />
+    </svg>
+  );
+}
+
+function ChatIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}

--- a/src/app/routes/invite-speaker-session-gate.tsx
+++ b/src/app/routes/invite-speaker-session-gate.tsx
@@ -10,7 +10,9 @@ interface SessionStatus {
  *  Renders a "Tap to continue" prompt on idle (so SMS-app link
  *  prefetchers can't consume the token on a bare GET), delegates to
  *  the chat only once the session reaches `"ready"`, and renders
- *  recovery copy for each non-ready branch. */
+ *  recovery copy for each non-ready branch. Lives inside the invite
+ *  page's floating drawer, so the non-ready states fill the drawer
+ *  and center their content rather than floating as a card. */
 export function SessionGate({
   status,
   onStart,
@@ -21,7 +23,9 @@ export function SessionGate({
   children: ReactNode;
 }): ReactElement {
   if (status.kind === "ready") return <>{children}</>;
-  if (status.kind === "loading") return <StateCard>Signing you in…</StateCard>;
+  if (status.kind === "loading") {
+    return <StateCard>Signing you in…</StateCard>;
+  }
   if (status.kind === "rotated") {
     const tail = status.phoneLast4 ? `ending in ••${status.phoneLast4}` : "on file";
     return (
@@ -53,32 +57,41 @@ export function SessionGate({
     );
   }
   return (
-    <div className="bg-chalk border border-border rounded-lg shadow-elev-1 p-5 flex flex-col gap-3">
-      <div>
-        <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
-          Continue to the conversation
-        </div>
-        <p className="font-serif text-[13px] text-walnut-2 mt-1 leading-relaxed">
-          Tap below to open the thread with the bishopric. You'll stay signed in on this device for
-          the rest of the invitation window.
-        </p>
+    <Frame>
+      <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+        Continue to the conversation
       </div>
+      <p className="font-serif text-[14px] text-walnut-2 mt-2 leading-relaxed max-w-sm">
+        Tap below to open the thread with the bishopric. You'll stay signed in on this device for
+        the rest of the invitation window.
+      </p>
       <button
         type="button"
         onClick={onStart}
-        className="self-start font-sans text-[13px] font-semibold px-4 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep"
+        className="mt-5 w-full max-w-xs font-sans text-[14px] font-semibold px-4 py-3 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep"
       >
         Continue
       </button>
+    </Frame>
+  );
+}
+
+/** Fills the drawer and centers its child vertically + horizontally.
+ *  The drawer already provides the chalk background + rounded border,
+ *  so non-ready states render flush (no card-in-card chrome). */
+function Frame({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center text-center p-6 gap-0">
+      {children}
     </div>
   );
 }
 
 function StateCard({ title, children }: { title?: string; children: ReactNode }): ReactElement {
   return (
-    <div className="bg-chalk border border-border rounded-lg shadow-elev-1 p-5">
-      {title && <p className="font-display text-[18px] text-walnut mb-2">{title}</p>}
-      <p className="font-serif text-[13px] text-walnut-2 leading-relaxed">{children}</p>
-    </div>
+    <Frame>
+      {title && <p className="font-display text-[20px] text-walnut mb-3">{title}</p>}
+      <p className="font-serif text-[14px] text-walnut-2 leading-relaxed max-w-sm">{children}</p>
+    </Frame>
   );
 }

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useParams } from "react-router";
 import { SpeakerInvitationChat } from "@/features/invitations/SpeakerInvitationChat";
 import { TwilioChatProvider } from "@/features/invitations/twilioClientProvider";
@@ -6,13 +7,14 @@ import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
 import { ScaledLetterPreview } from "@/features/templates/ScaledLetterPreview";
 import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation";
 import type { SpeakerInvitation } from "@/lib/types";
+import { SpeakerChatFloatingDrawer } from "./invite-speaker-chat-drawer";
 import { ExpiredState, NonReadyState, PrintToolbar, SessionGate } from "./invite-speaker-states";
 
 /**
- * Public landing page for an invitation link. Speakers open this URL
- * from the text message we sent them; they see the frozen letter
- * first, a conversation pane below, and can reply via Yes/No quick
- * actions + free-text chat. The page itself is auth-less; the
+ * Public landing page for an invitation link. The letter fills the
+ * viewport; the print toolbar floats top-right, and the conversation
+ * with the bishopric lives in a floating drawer (FAB when collapsed,
+ * sheet/panel when open). The page itself is auth-less; the
  * <SessionGate> component kicks off capability-token exchange on
  * user tap (not automatically on GET, so SMS-app prefetchers can't
  * burn the token). All Firebase reads on this page route through
@@ -31,6 +33,7 @@ export function SpeakerInvitationLandingPage(): React.ReactElement {
     invitationId,
     invitationToken: token,
   });
+  const [chatOpen, setChatOpen] = useState(false);
 
   if (letter.kind !== "ready") return <NonReadyState state={letter} />;
   if (isExpired(letter.invitation)) return <ExpiredState invitation={letter.invitation} />;
@@ -38,27 +41,31 @@ export function SpeakerInvitationLandingPage(): React.ReactElement {
 
   return (
     <TwilioChatProvider>
-      <main className="min-h-dvh bg-[#e6ddc7]">
-        <div className="max-w-3xl mx-auto flex flex-col gap-4 py-6 px-4">
-          <PrintToolbar />
-          <PrintOnlyLetter
+      <main className="fixed inset-0 bg-[#e6ddc7] overflow-hidden">
+        <PrintOnlyLetter
+          wardName={invitation.wardName}
+          assignedDate={invitation.assignedDate}
+          today={invitation.sentOn}
+          bodyMarkdown={invitation.bodyMarkdown}
+          footerMarkdown={invitation.footerMarkdown}
+        />
+        <div className="absolute inset-0">
+          <ScaledLetterPreview
+            naked
+            height="100dvh"
             wardName={invitation.wardName}
             assignedDate={invitation.assignedDate}
             today={invitation.sentOn}
             bodyMarkdown={invitation.bodyMarkdown}
             footerMarkdown={invitation.footerMarkdown}
           />
-          <div className="bg-chalk border border-border rounded-lg shadow-elev-1 overflow-hidden">
-            <ScaledLetterPreview
-              naked
-              height="50vh"
-              wardName={invitation.wardName}
-              assignedDate={invitation.assignedDate}
-              today={invitation.sentOn}
-              bodyMarkdown={invitation.bodyMarkdown}
-              footerMarkdown={invitation.footerMarkdown}
-            />
-          </div>
+        </div>
+
+        <div className="absolute top-4 right-4 z-10 pt-[env(safe-area-inset-top)]">
+          <PrintToolbar />
+        </div>
+
+        <SpeakerChatFloatingDrawer open={chatOpen} onOpenChange={setChatOpen}>
           <SessionGate status={session.status} onStart={session.start}>
             {invitation.conversationSid && wardId && invitationId && (
               <SpeakerInvitationChat
@@ -68,10 +75,12 @@ export function SpeakerInvitationLandingPage(): React.ReactElement {
                 speakerName={invitation.speakerName}
                 bishopricParticipants={invitation.bishopricParticipants}
                 hasResponse={!!invitation.response}
+                onClose={() => setChatOpen(false)}
+                fillHeight
               />
             )}
           </SessionGate>
-        </div>
+        </SpeakerChatFloatingDrawer>
       </main>
     </TwilioChatProvider>
   );

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -2,12 +2,14 @@ import { useState } from "react";
 import { useParams } from "react-router";
 import { SpeakerInvitationChat } from "@/features/invitations/SpeakerInvitationChat";
 import { TwilioChatProvider } from "@/features/invitations/twilioClientProvider";
+import { useConversationUnread } from "@/features/invitations/useConversationUnread";
 import { useInvitationSession } from "@/features/invitations/useInvitationSession";
 import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
 import { ScaledLetterPreview } from "@/features/templates/ScaledLetterPreview";
 import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation";
 import type { SpeakerInvitation } from "@/lib/types";
 import { SpeakerChatFloatingDrawer } from "./invite-speaker-chat-drawer";
+import { SpeakerChatCTABanner, type CtaVariant } from "./invite-speaker-cta-banner";
 import { ExpiredState, NonReadyState, PrintToolbar, SessionGate } from "./invite-speaker-states";
 
 /**
@@ -33,56 +35,100 @@ export function SpeakerInvitationLandingPage(): React.ReactElement {
     invitationId,
     invitationToken: token,
   });
-  const [chatOpen, setChatOpen] = useState(false);
 
   if (letter.kind !== "ready") return <NonReadyState state={letter} />;
   if (isExpired(letter.invitation)) return <ExpiredState invitation={letter.invitation} />;
-  const { invitation } = letter;
 
   return (
     <TwilioChatProvider>
-      <main className="fixed inset-0 bg-[#e6ddc7] overflow-hidden">
-        <PrintOnlyLetter
+      <InviteLandingContent
+        invitation={letter.invitation}
+        session={session}
+        wardId={wardId}
+        invitationId={invitationId}
+      />
+    </TwilioChatProvider>
+  );
+}
+
+interface ContentProps {
+  invitation: SpeakerInvitation;
+  session: ReturnType<typeof useInvitationSession>;
+  wardId: string | undefined;
+  invitationId: string | undefined;
+}
+
+function InviteLandingContent({
+  invitation,
+  session,
+  wardId,
+  invitationId,
+}: ContentProps): React.ReactElement {
+  const [chatOpen, setChatOpen] = useState(false);
+  const unread = useConversationUnread(invitation.conversationSid);
+  const hasUnread = typeof unread === "number" && unread > 0;
+  // Derived attention state: what, if anything, should nudge the
+  // speaker toward the chat right now. Banner + FAB both key off this
+  // so they emerge and vanish together. When the drawer is open the
+  // chat is already visible — no nudge needed.
+  const promptVariant: CtaVariant | null = chatOpen
+    ? null
+    : !invitation.response
+      ? "reply"
+      : hasUnread
+        ? "unread"
+        : null;
+
+  return (
+    <main className="fixed inset-0 bg-[#e6ddc7] overflow-hidden">
+      <PrintOnlyLetter
+        wardName={invitation.wardName}
+        assignedDate={invitation.assignedDate}
+        today={invitation.sentOn}
+        bodyMarkdown={invitation.bodyMarkdown}
+        footerMarkdown={invitation.footerMarkdown}
+      />
+      <div className="absolute inset-0">
+        <ScaledLetterPreview
+          naked
+          height="100dvh"
           wardName={invitation.wardName}
           assignedDate={invitation.assignedDate}
           today={invitation.sentOn}
           bodyMarkdown={invitation.bodyMarkdown}
           footerMarkdown={invitation.footerMarkdown}
         />
-        <div className="absolute inset-0">
-          <ScaledLetterPreview
-            naked
-            height="100dvh"
-            wardName={invitation.wardName}
-            assignedDate={invitation.assignedDate}
-            today={invitation.sentOn}
-            bodyMarkdown={invitation.bodyMarkdown}
-            footerMarkdown={invitation.footerMarkdown}
-          />
-        </div>
+      </div>
 
-        <div className="absolute top-4 right-4 z-10 pt-[env(safe-area-inset-top)]">
-          <PrintToolbar />
-        </div>
+      {promptVariant && (
+        <SpeakerChatCTABanner variant={promptVariant} onTap={() => setChatOpen(true)} />
+      )}
 
-        <SpeakerChatFloatingDrawer open={chatOpen} onOpenChange={setChatOpen}>
-          <SessionGate status={session.status} onStart={session.start}>
-            {invitation.conversationSid && wardId && invitationId && (
-              <SpeakerInvitationChat
-                wardId={wardId}
-                invitationId={invitationId}
-                conversationSid={invitation.conversationSid}
-                speakerName={invitation.speakerName}
-                bishopricParticipants={invitation.bishopricParticipants}
-                hasResponse={!!invitation.response}
-                onClose={() => setChatOpen(false)}
-                fillHeight
-              />
-            )}
-          </SessionGate>
-        </SpeakerChatFloatingDrawer>
-      </main>
-    </TwilioChatProvider>
+      <div className="absolute top-4 right-4 z-10 pt-[env(safe-area-inset-top)]">
+        <PrintToolbar />
+      </div>
+
+      <SpeakerChatFloatingDrawer
+        open={chatOpen}
+        onOpenChange={setChatOpen}
+        attention={promptVariant}
+      >
+        <SessionGate status={session.status} onStart={session.start}>
+          {invitation.conversationSid && wardId && invitationId && (
+            <SpeakerInvitationChat
+              wardId={wardId}
+              invitationId={invitationId}
+              conversationSid={invitation.conversationSid}
+              speakerName={invitation.speakerName}
+              bishopricParticipants={invitation.bishopricParticipants}
+              hasResponse={!!invitation.response}
+              onClose={() => setChatOpen(false)}
+              fillHeight
+            />
+          )}
+        </SessionGate>
+      </SpeakerChatFloatingDrawer>
+    </main>
   );
 }
 

--- a/src/features/invitations/ConversationComposer.tsx
+++ b/src/features/invitations/ConversationComposer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import type { Conversation } from "@twilio/conversations";
 
 interface Props {
@@ -17,11 +17,11 @@ interface Props {
   showSmsHint?: boolean;
 }
 
-const MAX_ROWS_PX = 132;
 const SMS_SEGMENT = 160;
 
-/** Auto-growing composer with an optimistic pending bubble. Sends
- *  plain-text messages via the Twilio conversation. Quick-action
+/** Multi-row composer with an optimistic pending bubble. Default
+ *  height is three rows; drag the bottom-right corner to expand.
+ *  Sends plain-text messages via the Twilio conversation. Quick-action
  *  (Yes/No) posts go through QuickActionButtons instead — those
  *  carry structured attributes. */
 export function ConversationComposer({
@@ -35,14 +35,6 @@ export function ConversationComposer({
   const [sending, setSending] = useState(false);
   const [pendingText, setPendingText] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const taRef = useRef<HTMLTextAreaElement>(null);
-
-  useEffect(() => {
-    const t = taRef.current;
-    if (!t) return;
-    t.style.height = "auto";
-    t.style.height = `${Math.min(t.scrollHeight, MAX_ROWS_PX)}px`;
-  }, [value]);
 
   async function handleSend() {
     const text = value.trim();
@@ -74,7 +66,6 @@ export function ConversationComposer({
         {error && <p className="font-sans text-[11.5px] text-bordeaux">{error}</p>}
         <div className="flex gap-2 items-end">
           <textarea
-            ref={taRef}
             value={value}
             onChange={(e) => {
               setValue(e.target.value);
@@ -88,9 +79,9 @@ export function ConversationComposer({
             }}
             placeholder={placeholder}
             disabled={disabled || sending}
-            rows={1}
+            rows={3}
             aria-label={placeholder}
-            className="flex-1 font-sans text-[13.5px] px-3 py-2 bg-chalk border border-border-strong rounded-md text-walnut placeholder:text-walnut-3 focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 resize-none disabled:bg-parchment-2"
+            className="flex-1 font-sans text-[13.5px] px-3 py-2 bg-chalk border border-border-strong rounded-md text-walnut placeholder:text-walnut-3 focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 resize-y min-h-18 disabled:bg-parchment-2"
           />
           <button
             type="button"

--- a/src/features/invitations/ConversationComposer.tsx
+++ b/src/features/invitations/ConversationComposer.tsx
@@ -60,7 +60,7 @@ export function ConversationComposer({
   }
 
   return (
-    <div className="flex flex-col bg-chalk border-t border-border">
+    <div className="mt-auto shrink-0 flex flex-col bg-chalk border-t border-border pb-[env(safe-area-inset-bottom)]">
       {pendingText && <PendingBubble text={pendingText} />}
       <div className="flex flex-col gap-1.5 p-3">
         {error && <p className="font-sans text-[11.5px] text-bordeaux">{error}</p>}

--- a/src/features/invitations/ConversationComposer.tsx
+++ b/src/features/invitations/ConversationComposer.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Conversation } from "@twilio/conversations";
 
 interface Props {
@@ -18,6 +18,22 @@ interface Props {
 }
 
 const SMS_SEGMENT = 160;
+const CONNECT_WAIT_MS = 5000;
+const CONNECT_POLL_MS = 100;
+
+/** Poll the conversation ref until Twilio populates it. `connect()`
+ *  returns before the client's first `stateChanged` event, so the
+ *  conversation prop can still be null immediately after the caller
+ *  awaited ensureReady. */
+async function waitForConversation(
+  ref: React.RefObject<Conversation | null>,
+): Promise<Conversation | null> {
+  const deadline = Date.now() + CONNECT_WAIT_MS;
+  while (!ref.current && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, CONNECT_POLL_MS));
+  }
+  return ref.current;
+}
 
 /** Multi-row composer with an optimistic pending bubble. Default
  *  height is three rows; drag the bottom-right corner to expand.
@@ -35,6 +51,15 @@ export function ConversationComposer({
   const [sending, setSending] = useState(false);
   const [pendingText, setPendingText] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // Mirror the conversation prop in a ref so the async send path can
+  // poll for it without re-capturing a stale closure. Twilio's client
+  // finishes initializing a beat after `ensureReady` resolves, so the
+  // first tap can arrive before useConversation has populated the
+  // `conversation` prop.
+  const conversationRef = useRef(conversation);
+  useEffect(() => {
+    conversationRef.current = conversation;
+  }, [conversation]);
 
   async function handleSend() {
     const text = value.trim();
@@ -48,8 +73,9 @@ export function ConversationComposer({
         const ok = await ensureReady();
         if (!ok) throw new Error("Sign-in required.");
       }
-      if (!conversation) throw new Error("Not connected.");
-      await conversation.sendMessage(text);
+      const ready = await waitForConversation(conversationRef);
+      if (!ready) throw new Error("Still connecting — try again in a moment.");
+      await ready.sendMessage(text);
     } catch (err) {
       setError((err as Error).message);
       setValue(text);

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -25,6 +25,14 @@ interface Props {
     email?: string | undefined;
   }[];
   hasResponse: boolean;
+  /** When present, the chat's header renders a small close affordance
+   *  that invokes this callback. Used by the invite page's floating
+   *  drawer so the speaker can dismiss the chat back over the letter. */
+  onClose?: () => void;
+  /** When true, the chat fills its flex parent (used inside the
+   *  floating drawer on the invite page). Default layout stays inline
+   *  for other callsites. */
+  fillHeight?: boolean;
 }
 
 /** Speaker-side chat pane. By the time this renders the parent
@@ -104,14 +112,32 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
   }
 
   return (
-    <section className="bg-chalk border border-border rounded-lg shadow-elev-1 flex flex-col overflow-hidden">
-      <header className="px-4 py-3 border-b border-border bg-parchment">
-        <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
-          Conversation with the bishopric
+    <section
+      className={
+        props.fillHeight
+          ? "bg-chalk flex flex-col overflow-hidden h-full min-h-0"
+          : "bg-chalk border border-border rounded-lg shadow-elev-1 flex flex-col overflow-hidden"
+      }
+    >
+      <header className="flex items-start gap-3 px-4 py-3 border-b border-border bg-parchment">
+        <div className="flex-1 min-w-0">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+            Conversation with the bishopric
+          </div>
+          <p className="font-serif text-[12.5px] text-walnut-2 mt-0.5">
+            This is a group conversation — the bishop, counselors, and clerks can all see and reply.
+          </p>
         </div>
-        <p className="font-serif text-[12.5px] text-walnut-2 mt-0.5">
-          This is a group conversation — the bishop, counselors, and clerks can all see and reply.
-        </p>
+        {props.onClose && (
+          <button
+            type="button"
+            onClick={props.onClose}
+            className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
+            aria-label="Close conversation"
+          >
+            Close
+          </button>
+        )}
       </header>
 
       <ConversationThread
@@ -121,6 +147,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         loading={loading && twilio.status === "ready"}
         firstUnreadIndex={firstUnreadIndex}
         readHorizonIndex={readHorizon}
+        {...(props.fillHeight ? { fillHeight: true } : {})}
       />
 
       <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -79,7 +79,14 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         twilioIdentity: twilio.identity,
         liveAuthors: authors,
       }),
-    [props.invitationId, props.speakerName, props.bishopricParticipants, twilio.identity, user, authors],
+    [
+      props.invitationId,
+      props.speakerName,
+      props.bishopricParticipants,
+      twilio.identity,
+      user,
+      authors,
+    ],
   );
 
   async function ensureReady(): Promise<boolean> {

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -69,6 +69,16 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
     });
   }, [twilio, props.wardId, props.invitationId]);
 
+  // Clear the speaker's unread horizon whenever they're viewing the
+  // chat and new messages land. Drives the page-level "New message"
+  // banner down to quiet once the speaker has actually seen the
+  // bishopric's reply — without this, the banner stays lit even
+  // after the drawer has been opened.
+  useEffect(() => {
+    if (!conversation || messages.length === 0) return;
+    void conversation.setAllMessagesRead();
+  }, [conversation, messages.length]);
+
   const resolvedAuthors = useMemo(
     () =>
       buildSpeakerAuthorMap({

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -115,7 +115,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
     <section
       className={
         props.fillHeight
-          ? "bg-chalk flex flex-col overflow-hidden h-full min-h-0"
+          ? "bg-chalk flex flex-col overflow-hidden flex-1 min-h-0"
           : "bg-chalk border border-border rounded-lg shadow-elev-1 flex flex-col overflow-hidden"
       }
     >

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -5,13 +5,14 @@ import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
 import { QuickActionButtons } from "./QuickActionButtons";
 import { TypingIndicator } from "./TypingIndicator";
-import { useConversation, type AuthorInfo, type AuthorMap } from "./useConversation";
+import { useConversation } from "./useConversation";
 import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
 import { useReadHorizon } from "./useReadHorizon";
 import { useTypingParticipants } from "./useTypingParticipants";
 import { useSpeakerHeartbeat } from "./useSpeakerHeartbeat";
 import { useTwilioChat } from "./twilioClientProvider";
 import { writeSpeakerResponse } from "./invitationActions";
+import { buildSpeakerAuthorMap } from "./speakerAuthorMap";
 
 interface Props {
   wardId: string;
@@ -54,39 +55,32 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
     enabled: Boolean(user),
   });
 
-  const resolvedAuthors: AuthorMap = useMemo(() => {
-    const map = new Map<string, AuthorInfo>();
-    map.set(`speaker:${props.invitationId}`, {
-      displayName: props.speakerName,
-      role: "speaker",
+  // Kick off the Twilio client as soon as the chat mounts so prior
+  // messages load before the speaker taps Send. Without this, the
+  // conversation pane would stay empty until the first interaction
+  // and the first send attempt would race the connect and throw
+  // "Not connected."
+  useEffect(() => {
+    if (twilio.status !== "idle") return;
+    void twilio.connect({
+      wardId: props.wardId,
+      invitationId: props.invitationId,
+      useInviteApp: true,
     });
-    for (const m of props.bishopricParticipants) {
-      const info: AuthorInfo = { displayName: m.displayName, role: m.role };
-      if (m.email) info.email = m.email;
-      map.set(`uid:${m.uid}`, info);
-    }
-    if (user && twilio.identity) {
-      const existing = map.get(twilio.identity);
-      const info: AuthorInfo = {
-        displayName: existing?.displayName ?? user.displayName ?? props.speakerName,
-      };
-      if (existing?.role) info.role = existing.role;
-      if (user.photoURL) info.photoURL = user.photoURL;
-      map.set(twilio.identity, info);
-    }
-    for (const [id, info] of authors) {
-      const existing = map.get(id);
-      map.set(id, { ...existing, ...info });
-    }
-    return map;
-  }, [
-    props.invitationId,
-    props.speakerName,
-    props.bishopricParticipants,
-    twilio.identity,
-    user,
-    authors,
-  ]);
+  }, [twilio, props.wardId, props.invitationId]);
+
+  const resolvedAuthors = useMemo(
+    () =>
+      buildSpeakerAuthorMap({
+        invitationId: props.invitationId,
+        speakerName: props.speakerName,
+        bishopricParticipants: props.bishopricParticipants,
+        user,
+        twilioIdentity: twilio.identity,
+        liveAuthors: authors,
+      }),
+    [props.invitationId, props.speakerName, props.bishopricParticipants, twilio.identity, user, authors],
+  );
 
   async function ensureReady(): Promise<boolean> {
     if (twilio.status === "idle" || twilio.status === "error") {

--- a/src/features/invitations/speakerAuthorMap.ts
+++ b/src/features/invitations/speakerAuthorMap.ts
@@ -1,0 +1,50 @@
+import type { User } from "firebase/auth";
+import type { AuthorInfo, AuthorMap } from "./useConversation";
+
+interface BishopricParticipant {
+  uid: string;
+  displayName: string;
+  role: "bishopric" | "clerk";
+  email?: string | undefined;
+}
+
+interface Args {
+  invitationId: string;
+  speakerName: string;
+  bishopricParticipants: readonly BishopricParticipant[];
+  user: User | null;
+  twilioIdentity: string | null;
+  liveAuthors: AuthorMap;
+}
+
+/** Composes the author directory the speaker-side chat uses to label
+ *  bubbles. Seeds the map from the invitation snapshot
+ *  (bishopricParticipants) so names render even before Twilio streams
+ *  participant attributes, then overlays the signed-in speaker's own
+ *  photo/name, and finally merges in whatever Twilio actually sees. */
+export function buildSpeakerAuthorMap(args: Args): AuthorMap {
+  const map = new Map<string, AuthorInfo>();
+  map.set(`speaker:${args.invitationId}`, {
+    displayName: args.speakerName,
+    role: "speaker",
+  });
+  for (const m of args.bishopricParticipants) {
+    const info: AuthorInfo = { displayName: m.displayName, role: m.role };
+    if (m.email) info.email = m.email;
+    map.set(`uid:${m.uid}`, info);
+  }
+  if (args.user && args.twilioIdentity) {
+    const existing = map.get(args.twilioIdentity);
+    const info: AuthorInfo = {
+      displayName: existing?.displayName ?? args.user.displayName ?? args.speakerName,
+    };
+    if (existing?.role) info.role = existing.role;
+    if (args.user.photoURL) info.photoURL = args.user.photoURL;
+    map.set(args.twilioIdentity, info);
+  }
+  for (const [id, info] of args.liveAuthors) {
+    const existing = map.get(id);
+    map.set(id, { ...existing, ...info });
+  }
+  return map;
+}

--- a/src/features/invitations/useConversation.ts
+++ b/src/features/invitations/useConversation.ts
@@ -64,6 +64,8 @@ export function useConversation(conversationSid: string | null): ConversationHoo
         return { ...s, authors: next };
       });
     };
+    const onParticipantUpdatedEvent = (args: { participant: Participant }) =>
+      onParticipantUpdate(args.participant);
     (async () => {
       try {
         convo = await client.getConversationBySid(conversationSid);
@@ -88,7 +90,7 @@ export function useConversation(conversationSid: string | null): ConversationHoo
         });
         convo.on("messageAdded", onMessageAdded);
         convo.on("participantJoined", onParticipantUpdate);
-        convo.on("participantUpdated", (args) => onParticipantUpdate(args.participant));
+        convo.on("participantUpdated", onParticipantUpdatedEvent);
       } catch (err) {
         if (cancelled) return;
         setState({
@@ -100,12 +102,16 @@ export function useConversation(conversationSid: string | null): ConversationHoo
         });
       }
     })();
+    // Remove *only* the listeners we added. `removeAllListeners` on a
+    // shared conversation would blow away other subscribers'
+    // listeners (e.g., the page-level useConversationUnread hook) and
+    // silently break the unread banner on drawer close.
     return () => {
       cancelled = true;
       if (convo) {
-        convo.removeAllListeners("messageAdded");
-        convo.removeAllListeners("participantJoined");
-        convo.removeAllListeners("participantUpdated");
+        convo.off("messageAdded", onMessageAdded);
+        convo.off("participantJoined", onParticipantUpdate);
+        convo.off("participantUpdated", onParticipantUpdatedEvent);
       }
     };
   }, [client, status, conversationSid]);

--- a/src/features/invitations/useConversationUnread.ts
+++ b/src/features/invitations/useConversationUnread.ts
@@ -4,11 +4,12 @@ import { useTwilioChat } from "./twilioClientProvider";
 
 /** Per-conversation unread badge signal. Returns the unread
  *  message count for `conversationSid` as seen by the currently-
- *  connected Twilio participant (i.e., the bishop). null when the
- *  client isn't connected yet, when the sid is missing, or when
- *  Twilio doesn't have a read horizon recorded for the participant
- *  yet. Re-fetches on messageAdded so the badge reacts live to new
- *  speaker replies arriving. */
+ *  connected Twilio participant. null when the client isn't
+ *  connected yet, when the sid is missing, or when Twilio doesn't
+ *  have a read horizon recorded for the participant yet. Re-fetches
+ *  on messageAdded / updatedLastReadMessageIndex so the badge reacts
+ *  live to fresh replies arriving and to the local participant
+ *  advancing their read horizon. */
 export function useConversationUnread(conversationSid: string | null | undefined): number | null {
   const { client, status } = useTwilioChat();
   const [unread, setUnread] = useState<number | null>(null);
@@ -20,6 +21,7 @@ export function useConversationUnread(conversationSid: string | null | undefined
     }
     let cancelled = false;
     let convoRef: Conversation | null = null;
+    let handlerRef: (() => void) | null = null;
 
     async function refetch(convo: Conversation) {
       const count = await convo.getUnreadMessagesCount();
@@ -27,9 +29,8 @@ export function useConversationUnread(conversationSid: string | null | undefined
       // Twilio returns null when the participant has never marked
       // anything read (no read horizon set). In that case, every
       // message in the conversation is effectively unread — derive
-      // the count from lastMessage.index. Without this, badge never
-      // lights up on a brand-new conversation the bishop hasn't
-      // opened yet.
+      // the count from lastMessage.index. Without this, the badge
+      // never lights up on a brand-new conversation.
       if (count !== null) {
         setUnread(count);
         return;
@@ -47,6 +48,7 @@ export function useConversationUnread(conversationSid: string | null | undefined
         const handler = () => {
           void refetch(convo);
         };
+        handlerRef = handler;
         convo.on("messageAdded", handler);
         convo.on("updatedLastReadMessageIndex", handler);
       } catch {
@@ -54,11 +56,15 @@ export function useConversationUnread(conversationSid: string | null | undefined
       }
     })();
 
+    // Detach ONLY the handler this hook added. Using
+    // removeAllListeners on a shared conversation would clobber other
+    // subscribers (e.g. useConversation's own messageAdded hookup)
+    // and silently break them on drawer close.
     return () => {
       cancelled = true;
-      if (convoRef) {
-        convoRef.removeAllListeners("messageAdded");
-        convoRef.removeAllListeners("updatedLastReadMessageIndex");
+      if (convoRef && handlerRef) {
+        convoRef.off("messageAdded", handlerRef);
+        convoRef.off("updatedLastReadMessageIndex", handlerRef);
       }
     };
   }, [client, status, conversationSid]);

--- a/src/features/invitations/useConversationUnread.ts
+++ b/src/features/invitations/useConversationUnread.ts
@@ -49,8 +49,14 @@ export function useConversationUnread(conversationSid: string | null | undefined
           void refetch(convo);
         };
         handlerRef = handler;
+        // participantUpdated fires reliably when the LOCAL participant
+        // advances their own last-read index (setAllMessagesRead).
+        // updatedLastReadMessageIndex is inconsistent about self-fire
+        // across SDK versions, so we depend on participantUpdated for
+        // the read-horizon signal and keep messageAdded for fresh
+        // incoming messages.
         convo.on("messageAdded", handler);
-        convo.on("updatedLastReadMessageIndex", handler);
+        convo.on("participantUpdated", handler);
       } catch {
         if (!cancelled) setUnread(null);
       }
@@ -64,7 +70,7 @@ export function useConversationUnread(conversationSid: string | null | undefined
       cancelled = true;
       if (convoRef && handlerRef) {
         convoRef.off("messageAdded", handlerRef);
-        convoRef.off("updatedLastReadMessageIndex", handlerRef);
+        convoRef.off("participantUpdated", handlerRef);
       }
     };
   }, [client, status, conversationSid]);

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -246,6 +246,21 @@
   }
 }
 
+/* Soft pulse ring for attention-worthy FABs. Used on the speaker
+   invite page to draw the eye to the chat drawer when the speaker
+   hasn't responded yet or the bishop has replied. */
+@keyframes fabPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(139, 46, 42, 0.55);
+  }
+  75% {
+    box-shadow: 0 0 0 14px rgba(139, 46, 42, 0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(139, 46, 42, 0);
+  }
+}
+
 /* --------------------------------------------------------------------
    Speaker-letter print rules. A `<PrintOnlyLetter>` portal mounts a
    copy of the letter at `document.body` level; on screen it stays


### PR DESCRIPTION
## Summary

Rebuild of the public speaker-invitation page so the letter is the primary surface and the conversation with the bishopric lives in a floating drawer that actively nudges the speaker when attention is needed.

### Layout
- **Letter fills the viewport.** `ScaledLetterPreview` now renders at `100dvh` inside a `fixed inset-0` main. Zoom + pan still work via the existing TransformWrapper.
- **Floating print toolbar** docks top-right with safe-area padding.
- **Floating chat drawer** (new `SpeakerChatFloatingDrawer`):
  - Collapsed: pill FAB bottom-right.
  - Open on mobile: full-screen sheet (`h-dvh`), body scroll locked so the letter behind doesn't rubber-band on iOS.
  - Open on sm+: ~420px-wide panel docked bottom-right.
  - ESC or backdrop tap closes.
- `SpeakerInvitationChat` gains `onClose` and `fillHeight` props — the legacy inline layout still works when both are omitted.
- Session-gate states (idle, loading, rotated, rate-limited, invalid, error) now fill the drawer and center their content; the old card-in-card chrome is gone and the Continue CTA stretches full-width.

### Composer
- Multi-row textarea by default (`rows=3`, `min-h-18`) with `resize-y` so speakers can drag to expand.
- Pinned to the bottom of the drawer via `mt-auto shrink-0` + `env(safe-area-inset-bottom)` + `ConversationThread`'s `flex-1 min-h-0`.
- `interactive-widget=resizes-content` on the viewport meta so the mobile keyboard shrinks the layout viewport instead of overlapping the composer.
- Send path now awaits Twilio's conversation via a ref + 5s poll instead of throwing "Not connected" the moment after `ensureReady` when the client is still coming up.

### Chat discoverability
- **Top CTA banner** (new `SpeakerChatCTABanner`) in bordeaux, safe-area aware. Shows when the drawer is closed AND either:
  - the speaker hasn't responded yet → *"Please reply to the speaking invitation"*
  - a bishop message is unread → *"New message from the bishopric"*
  Tap anywhere → drawer opens.
- **FAB emphasis** mirrors the same attention state: bigger pill, variant-specific label, soft `fabPulse` ring (new `@keyframes` in `styles/index.css`).
- When the speaker has replied and nothing is unread, everything quiets: small calm FAB reading *"Conversation"*.
- Page-level `useConversationUnread` lives in a new inner component inside `TwilioChatProvider` so the unread signal stays live while the drawer is closed.

### Connection + read-horizon hygiene
- `SpeakerInvitationChat` auto-connects Twilio on mount (parity with `BishopInvitationChat`) so prior messages load before the first Send.
- Speaker-side chat calls `conversation.setAllMessagesRead()` whenever the chat is mounted and new messages arrive — clears the unread banner live.
- `useConversation` + `useConversationUnread` now detach only their own handlers via `conversation.off(event, handler)` instead of `removeAllListeners(event)`. Previously, closing the drawer wiped every subscriber's listener on the shared conversation and silently broke the schedule-row badge + the unread banner until a full page refresh.
- `useConversationUnread` listens to `participantUpdated` (the signal `useReadHorizon` already relies on) instead of `updatedLastReadMessageIndex`, which Twilio fires inconsistently for a participant's own `setAllMessagesRead` across SDK versions. Badge on the bishop side + banner on the speaker side now clear the instant the message is viewed.
- Author-map builder extracted into `speakerAuthorMap.ts` so `SpeakerInvitationChat` stays under the 150-LOC ceiling.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 241 passing
- [ ] Manual (preview): open a fresh invite link
  - Letter fills the viewport, FAB pulses, top banner reads "Please reply…" — tap either, drawer opens.
  - Submit Yes → drawer closes (manually), FAB returns to calm state, no banner.
- [ ] Manual: from a second browser as the bishop, post a chat message while the speaker's drawer is closed. Speaker should see the banner switch to "New message from the bishopric" and the FAB pulse within a second.
- [ ] Manual: speaker opens drawer, reads, closes — banner quiets without a refresh.
- [ ] Manual: bishop opens the speaker's chat from the schedule — SpeakerRow badge clears without a refresh.
- [ ] Manual: composer drag-resize works desktop + mobile; keyboard on iOS pushes the composer up, not behind the keyboard.
- [ ] Manual: print toolbar still triggers `window.print()` with the letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)