### PR TITLE
feat(ui): avatar primitive with Google photo + initials fallback

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -171,13 +171,15 @@ service cloud.firestore {
               && matchesInvite(wardId));
         allow delete: if isActiveBishopric(wardId);
         // Roster updates are bishopric-only OR self-edits limited to a
-        // member's own notification prefs and FCM tokens (so a clerk can
-        // toggle quiet hours / register a device without touching role).
+        // member's own notification prefs, FCM tokens, and the Google
+        // profile fields synced on sign-in (displayName + photoURL) so
+        // a clerk can toggle quiet hours / register a device / refresh
+        // their avatar picture without touching their role.
         allow update: if isActiveBishopric(wardId)
           || (isActiveMember(wardId)
               && request.auth.uid == memberId
               && request.resource.data.diff(resource.data).affectedKeys()
-                  .hasOnly(['notificationPrefs', 'fcmTokens', 'updatedAt']));
+                  .hasOnly(['notificationPrefs', 'fcmTokens', 'displayName', 'photoURL', 'updatedAt']));
       }
 
       // Meetings and their speaker subcollection. Content edits are open to

--- a/src/app/auth-gate.tsx
+++ b/src/app/auth-gate.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Navigate, Outlet } from "react-router";
 import { AppShell } from "@/app/components/AppShell";
 import { WardPicker } from "@/app/components/ward-picker";
+import { useMemberProfileSync } from "@/hooks/useMemberProfileSync";
 import { useWardAccess } from "@/hooks/useWardAccess";
 import { useAuthStore } from "@/stores/authStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
@@ -31,6 +32,11 @@ export function AuthGate({ appShell = true }: Props) {
   const access = useWardAccess();
   const wardId = useCurrentWardStore((s) => s.wardId);
   const setWardId = useCurrentWardStore((s) => s.setWardId);
+  // Silently back-fill the signed-in user's Google profile fields
+  // (displayName + photoURL) onto their ward membership docs once
+  // access resolves, so avatar bubbles on other screens can render
+  // the real picture instead of initials.
+  useMemberProfileSync();
 
   useEffect(() => {
     if (access.kind === "single") {

--- a/src/app/components/UserMenu.tsx
+++ b/src/app/components/UserMenu.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
+import { Avatar } from "@/components/ui/Avatar";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useAuthStore } from "@/stores/authStore";
 import { cn } from "@/lib/cn";
@@ -46,11 +47,11 @@ export function UserMenu() {
   // add-member script) over the Auth-level displayName, which may only
   // be a first name depending on how the user originally signed in.
   const name = me?.data.displayName || user?.displayName || "User";
-  const initials = name
-    .split(" ")
-    .map((p) => p[0])
-    .slice(0, 2)
-    .join("");
+  const avatarUser = {
+    uid: user?.uid ?? null,
+    displayName: name,
+    photoURL: user?.photoURL ?? me?.data.photoURL ?? null,
+  };
 
   const handleSignOut = async () => {
     await signOut();
@@ -65,9 +66,7 @@ export function UserMenu() {
         aria-haspopup="menu"
         className="inline-flex items-center gap-2.5 rounded-full border border-transparent bg-transparent px-2.5 py-1 text-walnut transition-all hover:border-border hover:bg-chalk"
       >
-        <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-brass to-bordeaux font-display text-xs font-semibold text-chalk">
-          {initials}
-        </span>
+        <Avatar user={avatarUser} size="sm" />
         <span className="hidden text-sm font-medium sm:inline">{name}</span>
         <span className={cn("text-walnut-3 transition-transform", open && "rotate-180")}>
           <ChevronDown size={13} />
@@ -81,9 +80,7 @@ export function UserMenu() {
         >
           {/* Header */}
           <div className="flex items-center gap-3 border-b border-border px-2.5 py-2.5">
-            <span className="flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-brass to-bordeaux font-display text-sm font-semibold text-chalk">
-              {initials}
-            </span>
+            <Avatar user={avatarUser} size="lg" />
             <div className="min-w-0">
               <div className="truncate text-sm font-medium text-walnut">{name}</div>
               <div className="truncate text-xs uppercase tracking-wider text-walnut-3">

--- a/src/app/routes/invitation-view.tsx
+++ b/src/app/routes/invitation-view.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from "react-router";
+import { Avatar } from "@/components/ui/Avatar";
 import { ScaledLetterPreview } from "@/features/templates/ScaledLetterPreview";
 import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation";
 import { useWardMembers } from "@/hooks/useWardMembers";
@@ -27,9 +28,10 @@ export function InvitationViewPage(): React.ReactElement {
 
   const inv = letter.invitation;
   const response = inv.response;
-  const acknowledgedByName = response?.acknowledgedBy
-    ? (members.data.find((m) => m.id === response.acknowledgedBy)?.data.displayName ?? null)
+  const acknowledger = response?.acknowledgedBy
+    ? members.data.find((m) => m.id === response.acknowledgedBy)
     : null;
+  const acknowledgedByName = acknowledger?.data.displayName ?? null;
   const prepareHref = `/week/${inv.speakerRef.meetingDate}/speaker/${inv.speakerRef.speakerId}/prepare`;
 
   return (
@@ -70,9 +72,22 @@ export function InvitationViewPage(): React.ReactElement {
             {formatTimestamp(response.acknowledgedAt) && (
               <>
                 <dt>Applied</dt>
-                <dd>
-                  {formatTimestamp(response.acknowledgedAt)}
-                  {acknowledgedByName ? ` · ${acknowledgedByName}` : ""}
+                <dd className="flex items-center gap-2 flex-wrap">
+                  <span>{formatTimestamp(response.acknowledgedAt)}</span>
+                  {acknowledger && (
+                    <>
+                      <span aria-hidden="true">·</span>
+                      <Avatar
+                        user={{
+                          uid: acknowledger.id,
+                          displayName: acknowledgedByName,
+                          photoURL: acknowledger.data.photoURL ?? null,
+                        }}
+                        size="sm"
+                      />
+                      <span className="normal-case tracking-normal">{acknowledgedByName}</span>
+                    </>
+                  )}
                 </dd>
               </>
             )}

--- a/src/components/ui/Avatar.test.tsx
+++ b/src/components/ui/Avatar.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { Avatar } from "./Avatar";
+
+afterEach(() => cleanup());
+
+describe("Avatar", () => {
+  it("renders the Google photo when photoURL is present", () => {
+    const { container } = render(
+      <Avatar user={{ uid: "u1", displayName: "Bishop Jones", photoURL: "https://g/a.jpg" }} />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("src")).toBe("https://g/a.jpg");
+    expect(img?.getAttribute("alt")).toBe("Bishop Jones");
+    expect(img?.getAttribute("referrerpolicy")).toBe("no-referrer");
+    expect(img?.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("falls back to initials when the image errors", () => {
+    const { container, rerender } = render(
+      <Avatar user={{ uid: "u1", displayName: "Bishop Jones", photoURL: "https://g/a.jpg" }} />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    fireEvent.error(img!);
+    rerender(
+      <Avatar user={{ uid: "u1", displayName: "Bishop Jones", photoURL: "https://g/a.jpg" }} />,
+    );
+    expect(screen.getByText("BJ")).toBeTruthy();
+  });
+
+  it("renders deterministic initials when photoURL is absent", () => {
+    render(<Avatar user={{ uid: "u1", displayName: "Sister Park" }} />);
+    expect(screen.getByText("SP")).toBeTruthy();
+  });
+
+  it("renders the silhouette when both photoURL and displayName are missing", () => {
+    const { container } = render(<Avatar user={{ uid: "u1" }} />);
+    const svg = container.querySelector("svg");
+    expect(svg).not.toBeNull();
+    const root = container.querySelector('[aria-label="Unknown user"]');
+    expect(root).not.toBeNull();
+  });
+
+  it("exposes the display name to assistive tech", () => {
+    render(<Avatar user={{ displayName: "Sister Park" }} />);
+    const bubble = screen.getByLabelText("Sister Park");
+    expect(bubble).toBeTruthy();
+  });
+});

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { cn } from "@/lib/cn";
+import { avatarPaletteFor, initialsOf } from "@/lib/initials";
+
+export type AvatarSize = "sm" | "md" | "lg";
+
+interface User {
+  uid?: string | null;
+  displayName?: string | null;
+  photoURL?: string | null;
+}
+
+interface Props {
+  user: User;
+  size?: AvatarSize;
+  /** Extra class names for the root — used by callers to tweak
+   *  positioning (e.g. `shrink-0`) without owning the avatar's core
+   *  dimensions. */
+  className?: string;
+}
+
+const SIZE_PX: Record<AvatarSize, number> = { sm: 24, md: 32, lg: 40 };
+const SIZE_CLS: Record<AvatarSize, string> = {
+  sm: "w-6 h-6 text-[9.5px]",
+  md: "w-8 h-8 text-[11px]",
+  lg: "w-10 h-10 text-[13px]",
+};
+
+/** Round avatar for a user. Renders, in priority order:
+ *   1. Google profile photo (photoURL) — with `referrerpolicy` set so
+ *      Google's CDN doesn't 403 us, and a silent `onError` swap to
+ *      initials if the image fails.
+ *   2. Two-letter initials on a deterministic-color background so the
+ *      same uid always shows the same color across the app.
+ *   3. A neutral silhouette when both photoURL and displayName are
+ *      missing (rare — only hits if the user has no identity info). */
+export function Avatar({ user, size = "md", className }: Props): React.ReactElement {
+  const [imgFailed, setImgFailed] = useState(false);
+  const showPhoto = Boolean(user.photoURL) && !imgFailed;
+  const name = user.displayName?.trim() || null;
+  const label = name ?? "Unknown user";
+  const dims = SIZE_CLS[size];
+  const pixelSize = SIZE_PX[size];
+
+  if (showPhoto) {
+    return (
+      <img
+        src={user.photoURL ?? ""}
+        alt={label}
+        width={pixelSize}
+        height={pixelSize}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        onError={() => setImgFailed(true)}
+        className={cn("rounded-full object-cover border border-border shrink-0", dims, className)}
+      />
+    );
+  }
+
+  if (!name) {
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        className={cn(
+          "inline-flex items-center justify-center rounded-full border border-border bg-parchment-2 text-walnut-3 shrink-0",
+          dims,
+          className,
+        )}
+      >
+        <SilhouetteIcon />
+      </span>
+    );
+  }
+
+  const palette = avatarPaletteFor(user.uid ?? name);
+  return (
+    <span
+      aria-label={label}
+      className={cn(
+        "inline-flex items-center justify-center rounded-full border font-display font-semibold shrink-0",
+        dims,
+        palette.bg,
+        palette.fg,
+        palette.border,
+        className,
+      )}
+    >
+      <span aria-hidden="true">{initialsOf(name)}</span>
+    </span>
+  );
+}
+
+function SilhouetteIcon() {
+  return (
+    <svg width="55%" height="55%" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <path d="M12 12c2.76 0 5-2.24 5-5s-2.24-5-5-5-5 2.24-5 5 2.24 5 5 5zm0 2c-3.33 0-10 1.67-10 5v3h20v-3c0-3.33-6.67-5-10-5z" />
+    </svg>
+  );
+}

--- a/src/features/comments/CommentItem.tsx
+++ b/src/features/comments/CommentItem.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Avatar } from "@/components/ui/Avatar";
 import type { WithId } from "@/hooks/_sub";
 import { useWardMembers } from "@/hooks/useWardMembers";
 import type { Comment } from "@/lib/types";
@@ -29,6 +30,12 @@ export function CommentItem({ wardId, date, comment }: Props) {
   const isAuthor = user?.uid === comment.data.authorUid;
   const deleted = Boolean(comment.data.deletedAt);
   const edited = Boolean(comment.data.editedAt);
+  const authorMember = members.find((m) => m.id === comment.data.authorUid);
+  const authorAvatar = {
+    uid: comment.data.authorUid,
+    displayName: authorMember?.data.displayName ?? comment.data.authorDisplayName,
+    photoURL: authorMember?.data.photoURL ?? null,
+  };
 
   async function save() {
     const trimmed = draft.trim();
@@ -53,8 +60,9 @@ export function CommentItem({ wardId, date, comment }: Props) {
 
   return (
     <li className="rounded-md border border-border bg-parchment px-3.5 py-2.5">
-      <header className="flex items-baseline justify-between gap-3 mb-1.5">
-        <span className="font-sans text-[13px] font-semibold text-walnut truncate">
+      <header className="flex items-center gap-2.5 mb-1.5">
+        <Avatar user={authorAvatar} size="sm" />
+        <span className="font-sans text-[13px] font-semibold text-walnut truncate flex-1 min-w-0">
           {comment.data.authorDisplayName}
           {isAuthor && <span className="text-walnut-3 font-normal"> (You)</span>}
         </span>

--- a/src/hooks/useMemberProfileSync.ts
+++ b/src/hooks/useMemberProfileSync.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { useAuthStore } from "@/stores/authStore";
+import { useWardAccess } from "./useWardAccess";
+
+/** Pushes the signed-in user's Google profile fields (`displayName`,
+ *  `photoURL`) up to each ward membership doc they own, once per
+ *  session per ward. Other members' avatar bubbles then pick up the
+ *  real face on the next roster snapshot instead of falling back to
+ *  initials.
+ *
+ *  Safe to call unconditionally from inside the auth gate — the hook
+ *  no-ops when the user isn't signed in, or isn't a member of any
+ *  ward, or the fields haven't changed since the last sync. */
+export function useMemberProfileSync(): void {
+  const user = useAuthStore((s) => s.user);
+  const access = useWardAccess();
+  // Track which (wardId, uid, displayName|photoURL) triples we've
+  // already pushed so a rerender doesn't stream extra writes.
+  const syncedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!user) return;
+    if (access.kind !== "single" && access.kind !== "multiple") return;
+    const members = access.kind === "single" ? [access.member] : access.members;
+    const displayName = user.displayName ?? null;
+    const photoURL = user.photoURL ?? null;
+    if (!displayName && !photoURL) return;
+
+    for (const m of members) {
+      const key = `${m.wardId}/${m.uid}/${displayName ?? ""}/${photoURL ?? ""}`;
+      if (syncedRef.current.has(key)) continue;
+      syncedRef.current.add(key);
+      const patch: Record<string, unknown> = { updatedAt: serverTimestamp() };
+      if (displayName) patch.displayName = displayName;
+      if (photoURL) patch.photoURL = photoURL;
+      updateDoc(doc(db, "wards", m.wardId, "members", m.uid), patch).catch((err) => {
+        // Non-fatal — the user can still use the app without a
+        // synced avatar. Clear the synced key so a later retry (e.g.,
+        // network recovery) can try again.
+        console.warn("member profile sync failed", { wardId: m.wardId, err });
+        syncedRef.current.delete(key);
+      });
+    }
+  }, [user, access]);
+}

--- a/src/lib/initials.test.ts
+++ b/src/lib/initials.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { avatarPaletteFor, initialsOf } from "./initials";
+
+describe("initialsOf", () => {
+  it("returns first + last initials for a multi-word name", () => {
+    expect(initialsOf("Bishop Jones")).toBe("BJ");
+    expect(initialsOf("Hannah Marie Reeves")).toBe("HR");
+  });
+
+  it("returns the first two letters for a single-word name", () => {
+    expect(initialsOf("Hannah")).toBe("HA");
+  });
+
+  it("uppercases regardless of input casing", () => {
+    expect(initialsOf("bishop jones")).toBe("BJ");
+  });
+
+  it("tolerates extra whitespace", () => {
+    expect(initialsOf("  Bishop   Jones  ")).toBe("BJ");
+  });
+
+  it("returns '?' for null, undefined, empty, and whitespace-only", () => {
+    expect(initialsOf(null)).toBe("?");
+    expect(initialsOf(undefined)).toBe("?");
+    expect(initialsOf("")).toBe("?");
+    expect(initialsOf("   ")).toBe("?");
+  });
+});
+
+describe("avatarPaletteFor", () => {
+  it("returns the same slot for the same seed across calls", () => {
+    const a = avatarPaletteFor("uid:abc");
+    const b = avatarPaletteFor("uid:abc");
+    expect(a).toEqual(b);
+  });
+
+  it("returns a slot even for empty seeds (no throw)", () => {
+    const p = avatarPaletteFor(null);
+    expect(p.bg).toBeTruthy();
+    expect(p.fg).toBeTruthy();
+  });
+
+  it("distributes uids across multiple slots (probabilistic smoke test)", () => {
+    const seeds = Array.from({ length: 50 }, (_, i) => `uid:${i}`);
+    const slots = new Set(seeds.map((s) => avatarPaletteFor(s).bg));
+    // Palette has 6 slots; 50 uids should land in more than 2 of them.
+    expect(slots.size).toBeGreaterThan(2);
+  });
+});

--- a/src/lib/initials.ts
+++ b/src/lib/initials.ts
@@ -1,0 +1,43 @@
+/** Two-letter initials from a display name. "Firstname Lastname"
+ *  → "FL"; a single-word name falls back to the first two characters
+ *  of that word. Empty or falsy input returns "?". */
+export function initialsOf(displayName: string | null | undefined): string {
+  if (!displayName) return "?";
+  const parts = displayName.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return (parts[0]!.slice(0, 2) || "?").toUpperCase();
+  return `${parts[0]!.charAt(0)}${parts.at(-1)!.charAt(0)}`.toUpperCase();
+}
+
+/** Palette of background + text pairs used for the initials-fallback
+ *  avatar. Colors come from the app's parchment/bordeaux palette so
+ *  they sit naturally next to other UI; we only need *enough* colors
+ *  that members of the same ward don't routinely collide. */
+const AVATAR_PALETTE: readonly { bg: string; fg: string; border: string }[] = [
+  { bg: "bg-bordeaux", fg: "text-parchment", border: "border-bordeaux-deep" },
+  { bg: "bg-brass-soft", fg: "text-brass-deep", border: "border-brass-soft" },
+  { bg: "bg-walnut", fg: "text-parchment", border: "border-walnut-2" },
+  { bg: "bg-success-soft", fg: "text-success", border: "border-success-soft" },
+  { bg: "bg-parchment-2", fg: "text-walnut-2", border: "border-border-strong" },
+  { bg: "bg-danger-soft", fg: "text-bordeaux", border: "border-danger-soft" },
+];
+
+/** Deterministic palette pick for a given seed (typically a uid).
+ *  Same seed → same slot on every render, every device, every
+ *  session. Uses a tiny FNV-1a variant — good enough for bucketing
+ *  a few dozen uids across six slots. Empty seeds land on slot 0
+ *  rather than throwing. */
+export function avatarPaletteFor(seed: string | null | undefined): {
+  bg: string;
+  fg: string;
+  border: string;
+} {
+  if (!seed) return AVATAR_PALETTE[0]!;
+  let h = 2166136261;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  const idx = Math.abs(h) % AVATAR_PALETTE.length;
+  return AVATAR_PALETTE[idx]!;
+}

--- a/src/lib/types/member.ts
+++ b/src/lib/types/member.ts
@@ -44,6 +44,11 @@ export type NotificationPrefs = z.infer<typeof notificationPrefsSchema>;
 export const memberSchema = z.object({
   email: z.email(),
   displayName: z.string().min(1),
+  /** Google profile picture URL captured at sign-in; refreshed on each
+   *  subsequent sign-in so avatar bubbles everywhere else in the app
+   *  can show the real face instead of initials. Optional — speakers
+   *  invited via the public link may not have one on file yet. */
+  photoURL: z.string().optional(),
   calling: callingSchema,
   role: roleSchema,
   active: z.boolean().default(true),


### PR DESCRIPTION
Closes #18.

## Summary

Reusable `<Avatar>` primitive that renders, in priority order:

1. **Google profile photo** — `<img>` with `referrerpolicy=\"no-referrer\"` (Google's CDN 403s without it), `loading=\"lazy\"`, and a silent `onError` swap to initials if the URL fails.
2. **Two-letter initials** on a deterministic-color background. Color is picked via a small FNV-1a-style hash over the uid → one of six palette slots from the app's parchment/bordeaux theme. Same uid always lands in the same slot across sessions + devices.
3. **Silhouette icon** when both `photoURL` and `displayName` are missing.

Three sizes: `sm` (24px), `md` (32px), `lg` (40px). Root element carries `aria-label` = display name; the initials span is `aria-hidden` so assistive tech announces identity rather than letters.

Initials derivation lives in the shared `src/lib/initials.ts` alongside the palette — reusable for any future avatar-adjacent surface.

## Integration sites

| Site | Before | After |
|---|---|---|
| Header `UserMenu` trigger + menu header | Ad-hoc brass→bordeaux gradient with manually-derived initials | `<Avatar>` (sm in the trigger, lg in the menu header) |
| `CommentItem` | Text-only author name | Avatar + name, `photoURL` resolved from the ward roster |
| `invitation-view.tsx` read-only bishopric view | Text-only acknowledger name | Avatar + name inline on the \"Applied\" line |
| `ConversationAvatar` (chat) | Role-keyed palette | **Left alone** — the chat surface's role color-coding is intentional and product-distinct |
| Mention autocomplete, meeting approval/audit list | No UI exists yet | No change — will adopt the primitive when those surfaces land |

## Plumbing

- `memberSchema` in `src/lib/types/member.ts` gains an optional `photoURL` field.
- New `useMemberProfileSync` hook back-fills `displayName` + `photoURL` from the signed-in user onto each ward membership doc once per session. Called from `AuthGate` so it fires unconditionally after the access check resolves. No writes when nothing to sync.
- `firestore.rules` — self-edit allowlist on `wards/{wardId}/members/{uid}` extended from `['notificationPrefs', 'fcmTokens', 'updatedAt']` to also include `['displayName', 'photoURL']`. A member can refresh their own Google profile fields; still can't touch role/calling/etc.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 254 passing (13 new: initials derivation, palette stability, image→initials fallback on error, silhouette fallback when no identity)
- [ ] Rules + e2e run in CI (will exercise the new allowlist)
- [ ] Manual: sign in with a Google account that has a profile photo — user menu top-right shows the photo. Sign out, sign in as a member whose photo CDN 403s — menu shows initials without a flash.
- [ ] Manual: comment on a week — your avatar appears next to your name; reload the page and it persists (via the member-doc photoURL back-fill).
- [ ] Manual: speaker submits Yes → bishop Apply → open the bishopric receipt link `/ward/:wardId/invitations/:id/view` → the \"Applied\" line shows the bishop's avatar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)