### PR TITLE
feat(templates): editable server-side email & SMS templates (#55)

### DIFF
--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -94,7 +94,7 @@ export async function createFreshInvitation(
       ),
     );
   }
-  if (wantsSms) deliveryRecord.push(await trySms(input.speakerPhone!, emailArgs));
+  if (wantsSms) deliveryRecord.push(await trySms(input.wardId, input.speakerPhone!, emailArgs));
   await docRef.update({ deliveryRecord });
 
   return { mode: "fresh", token: docRef.id, conversationSid, deliveryRecord };

--- a/functions/src/invitationDelivery.ts
+++ b/functions/src/invitationDelivery.ts
@@ -1,0 +1,81 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { buildEmailHtml, buildEmailText } from "./invitationEmailBody.js";
+import { interpolate, readMessageTemplate } from "./messageTemplates.js";
+import { sendEmail } from "./sendgrid/client.js";
+import { sendSmsDirect } from "./twilio/messaging.js";
+import type { DeliveryEntry } from "./sendSpeakerInvitation.types.js";
+
+type EmailArgs = Parameters<typeof buildEmailText>[0];
+
+export interface EmailDeliveryParams {
+  speakerEmail: string;
+  inviterName: string;
+  assignedDate: string;
+  /** Reply-To used so a speaker replying to the email lands in the
+   *  bishop's inbox naturally. On rotate-mode we don't have it on the
+   *  invitation doc, so callers fall back to the speaker's own email. */
+  replyToEmail: string;
+}
+
+export async function tryEmail(
+  params: EmailDeliveryParams,
+  args: EmailArgs,
+): Promise<DeliveryEntry> {
+  try {
+    const messageId = await sendEmail({
+      to: params.speakerEmail,
+      fromDisplayName: `${params.inviterName} (via Steward)`,
+      replyTo: params.replyToEmail,
+      subject: `Speaking invitation — ${params.assignedDate}`,
+      text: buildEmailText(args),
+      html: buildEmailHtml(args),
+    });
+    const entry: DeliveryEntry = { channel: "email", status: "sent", at: new Date() };
+    if (messageId) entry.providerId = messageId;
+    return entry;
+  } catch (err) {
+    logger.error("email send failed", { err: (err as Error).message });
+    return { channel: "email", status: "failed", error: (err as Error).message, at: new Date() };
+  }
+}
+
+async function buildInitialInvitationSms(
+  wardId: string,
+  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl">,
+): Promise<string> {
+  const template = await readMessageTemplate(getFirestore(), wardId, "initialInvitationSms");
+  return interpolate(template, vars);
+}
+
+export async function trySms(
+  wardId: string,
+  speakerPhone: string,
+  emailArgs: EmailArgs,
+): Promise<DeliveryEntry> {
+  try {
+    const body = await buildInitialInvitationSms(wardId, emailArgs);
+    const sid = await sendSmsDirect({ to: speakerPhone, body });
+    return { channel: "sms", status: "sent", providerId: sid, at: new Date() };
+  } catch (err) {
+    logger.error("initial SMS send failed", { err: (err as Error).message });
+    return { channel: "sms", status: "failed", error: (err as Error).message, at: new Date() };
+  }
+}
+
+/** Send the invitation letter via SMS (Twilio). Used both by the
+ *  initial sendSpeakerInvitation flow and by issueSpeakerSession's
+ *  rotation path when a consumed/expired token is presented. */
+export async function sendInvitationSms(args: {
+  wardId: string;
+  speakerPhone: string;
+  inviterName: string;
+  wardName: string;
+  assignedDate: string;
+  speakerName: string;
+  inviteUrl: string;
+}): Promise<{ providerId: string }> {
+  const body = await buildInitialInvitationSms(args.wardId, args);
+  const sid = await sendSmsDirect({ to: args.speakerPhone, body });
+  return { providerId: sid };
+}

--- a/functions/src/invitationEmailBody.ts
+++ b/functions/src/invitationEmailBody.ts
@@ -26,14 +26,6 @@ export function buildEmailHtml(a: BuildEmailArgs): string {
 <p style="color:#666;font-size:12px;">— ${escapeHtml(a.wardName)}</p>`;
 }
 
-export function buildSmsBody(a: BuildEmailArgs): string {
-  return (
-    `${a.inviterName} (${a.wardName}) has invited you to speak on ${a.assignedDate}. ` +
-    `Read the full invitation: ${a.inviteUrl}. ` +
-    `Reply STOP to unsubscribe.`
-  );
-}
-
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")

--- a/functions/src/invitationReceiptContent.test.ts
+++ b/functions/src/invitationReceiptContent.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
 import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
+import {
+  DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
+  DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+  DEFAULT_SPEAKER_RESPONSE_DECLINED,
+} from "./messageTemplateDefaults.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 function mk(overrides: Partial<SpeakerInvitationShape> = {}): SpeakerInvitationShape {
@@ -18,12 +23,15 @@ function mk(overrides: Partial<SpeakerInvitationShape> = {}): SpeakerInvitationS
 
 describe("buildSpeakerReceipt", () => {
   it("throws when the invitation has no recorded response", () => {
-    expect(() => buildSpeakerReceipt({ invitation: mk() })).toThrow();
+    expect(() =>
+      buildSpeakerReceipt({ invitation: mk(), headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED }),
+    ).toThrow();
   });
 
   it("phrases the Yes case as 'accepted' and includes the letter inline", () => {
     const content = buildSpeakerReceipt({
       invitation: mk({ response: { answer: "yes" } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
     });
     expect(content.subject).toMatch(/accepted/);
     expect(content.subject).toMatch(/Sunday, May 3, 2026/);
@@ -35,6 +43,7 @@ describe("buildSpeakerReceipt", () => {
   it("phrases the No case as 'declined'", () => {
     const content = buildSpeakerReceipt({
       invitation: mk({ response: { answer: "no" } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_DECLINED,
     });
     expect(content.subject).toMatch(/declined/);
     expect(content.text).toMatch(/You declined the invitation/);
@@ -43,6 +52,7 @@ describe("buildSpeakerReceipt", () => {
   it("surfaces the speaker's reason when provided", () => {
     const content = buildSpeakerReceipt({
       invitation: mk({ response: { answer: "no", reason: "I'm out of town." } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_DECLINED,
     });
     expect(content.text).toMatch(/Your note: I'm out of town/);
     expect(content.html).toMatch(/I&#39;m out of town/);
@@ -51,7 +61,12 @@ describe("buildSpeakerReceipt", () => {
 
 describe("buildBishopricReceipt", () => {
   it("throws when the invitation has no recorded response", () => {
-    expect(() => buildBishopricReceipt({ invitation: mk() })).toThrow();
+    expect(() =>
+      buildBishopricReceipt({
+        invitation: mk(),
+        headerTemplate: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
+      }),
+    ).toThrow();
   });
 
   it("names the speaker in the subject and includes a view URL when provided", () => {
@@ -59,6 +74,7 @@ describe("buildBishopricReceipt", () => {
       invitation: mk({ response: { answer: "yes" } }),
       bishopricViewUrl: "https://steward-app.ca/ward/w1/invitations/i1/view",
       acknowledgedByName: "Bishop Smith",
+      headerTemplate: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
     });
     expect(content.subject).toMatch(/Sister Jones accepted/);
     expect(content.text).toMatch(/Applied by: Bishop Smith/);
@@ -69,6 +85,7 @@ describe("buildBishopricReceipt", () => {
   it("declined variant lands under 'declined' phrasing", () => {
     const content = buildBishopricReceipt({
       invitation: mk({ response: { answer: "no" } }),
+      headerTemplate: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
     });
     expect(content.subject).toMatch(/Sister Jones declined/);
   });
@@ -76,6 +93,7 @@ describe("buildBishopricReceipt", () => {
   it("omits the view-URL block when not provided", () => {
     const content = buildBishopricReceipt({
       invitation: mk({ response: { answer: "yes" } }),
+      headerTemplate: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
     });
     expect(content.text).not.toMatch(/View this invitation in Steward/);
     expect(content.html).not.toMatch(/href="/);

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -1,3 +1,4 @@
+import { interpolate } from "./messageTemplates.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ReceiptBuildArgs {
@@ -5,6 +6,12 @@ export interface ReceiptBuildArgs {
   bishopricViewUrl?: string;
   acknowledgedByName?: string | undefined;
   respondedAt?: Date | undefined;
+  /** Body of the matching server-side message template —
+   *  `speakerResponseAccepted` / `speakerResponseDeclined` for
+   *  `buildSpeakerReceipt`, `bishopricResponseReceipt` for
+   *  `buildBishopricReceipt`. Caller loads the template via
+   *  `readMessageTemplate` so builders stay pure. */
+  headerTemplate: string;
 }
 
 export interface ReceiptContent {
@@ -50,16 +57,17 @@ function letterText(invitation: SpeakerInvitationShape): string {
  *  the speaker already has the invite URL in their inbox/SMS, and
  *  rotating a fresh token per receipt would be gratuitous. */
 export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
-  const { invitation } = args;
+  const { invitation, headerTemplate } = args;
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("speaker receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
 
   const subject = `You ${verb} the speaking invitation — ${invitation.assignedDate}`;
-  const headerText =
-    answer === "yes"
-      ? `You accepted the invitation to speak on ${invitation.assignedDate}. Thank you.`
-      : `You declined the invitation to speak on ${invitation.assignedDate}. Thank you for letting us know.`;
+  const headerText = interpolate(headerTemplate, {
+    speakerName: invitation.speakerName,
+    assignedDate: invitation.assignedDate,
+    reason: invitation.response?.reason ?? "",
+  });
   const text = [
     headerText,
     "",
@@ -94,13 +102,17 @@ ${letterHtml(invitation)}
  *  mirrors a response to `speaker.status`. Includes the letter inline
  *  for archival + a link to the read-only invitation view. */
 export function buildBishopricReceipt(args: ReceiptBuildArgs): ReceiptContent {
-  const { invitation, bishopricViewUrl, acknowledgedByName, respondedAt } = args;
+  const { invitation, bishopricViewUrl, acknowledgedByName, respondedAt, headerTemplate } = args;
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("bishopric receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
 
   const subject = `${invitation.speakerName} ${verb} the speaking invitation — ${invitation.assignedDate}`;
-  const responseLine = `${invitation.speakerName} ${verb} the invitation to speak on ${invitation.assignedDate}.`;
+  const responseLine = interpolate(headerTemplate, {
+    speakerName: invitation.speakerName,
+    verb,
+    assignedDate: invitation.assignedDate,
+  });
   const metaLines: string[] = [];
   if (respondedAt) metaLines.push(`Responded: ${respondedAt.toLocaleString()}`);
   if (acknowledgedByName) metaLines.push(`Applied by: ${acknowledgedByName}`);

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -2,6 +2,7 @@ import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { sendAndPrune } from "./fcm.js";
 import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
+import { interpolate, readMessageTemplate } from "./messageTemplates.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
 import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
@@ -70,9 +71,16 @@ export async function smsSpeaker(inv: ResolvedInvitation, body: string): Promise
     });
   }
   const preview = truncate(body, 240);
-  const text = inviteUrl
-    ? `${inv.wardName}: new message from the bishopric about your speaking assignment — "${preview}". Open: ${inviteUrl}`
-    : `${inv.inviterName} (Steward): ${preview}`;
+  // Rotation-failed path stays hardcoded: it's an error fallback, not
+  // a user-authored message — we don't want a bishopric-edited template
+  // to leak a placeholder `{{inviteUrl}}` token into an SMS.
+  let text: string;
+  if (inviteUrl) {
+    const template = await readMessageTemplate(getFirestore(), inv.wardId, "bishopReplySms");
+    text = interpolate(template, { wardName: inv.wardName, preview, inviteUrl });
+  } else {
+    text = `${inv.inviterName} (Steward): ${preview}`;
+  }
   try {
     await sendSmsDirect({ to: inv.speakerPhone, body: text });
   } catch (err) {
@@ -99,21 +107,14 @@ function isSpeakerOnline(inv: ResolvedInvitation): boolean {
 export async function emailSpeaker(inv: ResolvedInvitation, body: string): Promise<void> {
   if (!inv.speakerEmail) return;
   const preview = truncate(body, 180);
-  const text = [
-    `${inv.inviterName} replied to your invitation for ${inv.assignedDate}:`,
-    "",
+  const template = await readMessageTemplate(getFirestore(), inv.wardId, "bishopReplyEmail");
+  const text = interpolate(template, {
+    inviterName: inv.inviterName,
+    assignedDate: inv.assignedDate,
     preview,
-    "",
-    "To reply back, open the invitation link in the text message we sent you.",
-    "",
-    `— ${inv.wardName}`,
-  ].join("\n");
-  const html = `<p>${escapeHtml(inv.inviterName)} replied to your invitation for <strong>${escapeHtml(
-    inv.assignedDate,
-  )}</strong>:</p>
-<blockquote style="margin:0 0 12px 0;padding-left:10px;border-left:3px solid #bca788;color:#4a3a30;"><em>${escapeHtml(preview)}</em></blockquote>
-<p style="color:#666;font-size:13px;">To reply back, open the invitation link in the text message we sent you.</p>
-<p style="color:#666;font-size:12px;">— ${escapeHtml(inv.wardName)}</p>`;
+    wardName: inv.wardName,
+  });
+  const html = textToParagraphHtml(text);
   try {
     await sendEmail({
       to: inv.speakerEmail,
@@ -125,6 +126,18 @@ export async function emailSpeaker(inv: ResolvedInvitation, body: string): Promi
   } catch (err) {
     logger.error("reply email failed", { err: (err as Error).message, token: inv.token });
   }
+}
+
+/** Render an author-editable plain-text email body into HTML: split
+ *  on blank lines for paragraphs, `<br>` for single newlines, escape
+ *  everything. Bishoprics author in text; we don't ask them to reason
+ *  about HTML. */
+function textToParagraphHtml(text: string): string {
+  return text
+    .split(/\n{2,}/)
+    .filter((p) => p.trim().length > 0)
+    .map((p) => `<p>${escapeHtml(p).replace(/\n/g, "<br>")}</p>`)
+    .join("\n");
 }
 
 function truncate(s: string, max: number): string {

--- a/functions/src/issueSpeakerSession.ts
+++ b/functions/src/issueSpeakerSession.ts
@@ -108,6 +108,7 @@ async function handleSpeakerTokenExchange(
     try {
       const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
       await sendInvitationSms({
+        wardId,
         speakerPhone: decision.speakerPhone,
         inviterName: decision.inviterName,
         wardName: decision.wardName,

--- a/functions/src/messageTemplateDefaults.ts
+++ b/functions/src/messageTemplateDefaults.ts
@@ -1,0 +1,56 @@
+/**
+ * Server-side defaults for the six editable messaging templates.
+ * Each string reproduces the copy the Cloud Function sent before the
+ * template became editable — so wards without a Firestore override
+ * see identical behavior.
+ *
+ * **Keep in sync with `src/features/templates/serverTemplateDefaults.ts`.**
+ * The two files can't share a module (separate pnpm workspaces); a
+ * drift test in `messageTemplates.test.ts` asserts they stay aligned.
+ *
+ * Variables use the `{{name}}` syntax — see `interpolate` in
+ * `messageTemplates.ts`.
+ */
+
+export const DEFAULT_INITIAL_INVITATION_SMS =
+  "{{inviterName}} ({{wardName}}) has invited you to speak on {{assignedDate}}. " +
+  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+
+export const DEFAULT_SPEAKER_RESPONSE_ACCEPTED =
+  "You accepted the invitation to speak on {{assignedDate}}. Thank you.";
+
+export const DEFAULT_SPEAKER_RESPONSE_DECLINED =
+  "You declined the invitation to speak on {{assignedDate}}. Thank you for letting us know.";
+
+export const DEFAULT_BISHOPRIC_RESPONSE_RECEIPT =
+  "{{speakerName}} {{verb}} the invitation to speak on {{assignedDate}}.";
+
+export const DEFAULT_BISHOP_REPLY_SMS =
+  '{{wardName}}: new message from the bishopric about your speaking assignment — "{{preview}}". Open: {{inviteUrl}}';
+
+export const DEFAULT_BISHOP_REPLY_EMAIL = [
+  "{{inviterName}} replied to your invitation for {{assignedDate}}:",
+  "",
+  "{{preview}}",
+  "",
+  "To reply back, open the invitation link in the text message we sent you.",
+  "",
+  "— {{wardName}}",
+].join("\n");
+
+export type MessageTemplateKey =
+  | "initialInvitationSms"
+  | "speakerResponseAccepted"
+  | "speakerResponseDeclined"
+  | "bishopricResponseReceipt"
+  | "bishopReplySms"
+  | "bishopReplyEmail";
+
+export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
+  initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
+  speakerResponseAccepted: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+  speakerResponseDeclined: DEFAULT_SPEAKER_RESPONSE_DECLINED,
+  bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
+  bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
+  bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
+};

--- a/functions/src/messageTemplates.test.ts
+++ b/functions/src/messageTemplates.test.ts
@@ -1,0 +1,131 @@
+import { promises as fs } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MESSAGE_TEMPLATES } from "./messageTemplateDefaults.js";
+import { interpolate, readMessageTemplate } from "./messageTemplates.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLIENT_DEFAULTS_PATH = resolve(
+  __dirname,
+  "../../src/features/templates/serverTemplateDefaults.ts",
+);
+
+describe("interpolate", () => {
+  it("replaces known tokens from the vars map", () => {
+    expect(interpolate("Hello {{name}}", { name: "Paul" })).toBe("Hello Paul");
+  });
+
+  it("leaves unknown tokens literal so authoring typos stay visible", () => {
+    expect(interpolate("{{missing}} and {{name}}", { name: "Paul" })).toBe("{{missing}} and Paul");
+  });
+
+  it("tolerates whitespace inside the braces", () => {
+    expect(interpolate("{{  name  }}", { name: "Paul" })).toBe("Paul");
+  });
+
+  it("preserves multi-line bodies", () => {
+    const template = "line 1: {{a}}\n\nline 3: {{b}}";
+    expect(interpolate(template, { a: "x", b: "y" })).toBe("line 1: x\n\nline 3: y");
+  });
+});
+
+function makeDb(
+  docs: Record<string, { bodyMarkdown?: unknown } | null>,
+): FirebaseFirestore.Firestore {
+  return {
+    doc(path: string) {
+      return {
+        async get() {
+          const entry = docs[path];
+          if (entry === null || entry === undefined) {
+            return { exists: false, get() {} };
+          }
+          return {
+            exists: true,
+            get(field: string) {
+              return (entry as Record<string, unknown>)[field];
+            },
+          };
+        },
+      };
+    },
+  } as unknown as FirebaseFirestore.Firestore;
+}
+
+describe("readMessageTemplate", () => {
+  it("falls back to the default when the doc is missing", async () => {
+    const db = makeDb({});
+    const body = await readMessageTemplate(db, "w1", "initialInvitationSms");
+    expect(body).toBe(DEFAULT_MESSAGE_TEMPLATES.initialInvitationSms);
+  });
+
+  it("returns bodyMarkdown from the Firestore doc when present", async () => {
+    const db = makeDb({
+      "wards/w1/templates/initialInvitationSms": { bodyMarkdown: "custom body" },
+    });
+    const body = await readMessageTemplate(db, "w1", "initialInvitationSms");
+    expect(body).toBe("custom body");
+  });
+
+  it("falls back when bodyMarkdown is empty or the wrong type", async () => {
+    const emptyDb = makeDb({ "wards/w1/templates/bishopReplyEmail": { bodyMarkdown: "" } });
+    expect(await readMessageTemplate(emptyDb, "w1", "bishopReplyEmail")).toBe(
+      DEFAULT_MESSAGE_TEMPLATES.bishopReplyEmail,
+    );
+    const wrongTypeDb = makeDb({
+      "wards/w1/templates/bishopReplyEmail": { bodyMarkdown: 42 },
+    });
+    expect(await readMessageTemplate(wrongTypeDb, "w1", "bishopReplyEmail")).toBe(
+      DEFAULT_MESSAGE_TEMPLATES.bishopReplyEmail,
+    );
+  });
+
+  it("swallows unexpected errors and returns the fallback", async () => {
+    const db = {
+      doc() {
+        return {
+          async get() {
+            throw new Error("network");
+          },
+        };
+      },
+    } as unknown as FirebaseFirestore.Firestore;
+    const body = await readMessageTemplate(db, "w1", "speakerResponseAccepted");
+    expect(body).toBe(DEFAULT_MESSAGE_TEMPLATES.speakerResponseAccepted);
+  });
+});
+
+describe("default templates drift check (client vs server)", () => {
+  it("client-side serverTemplateDefaults.ts matches server-side messageTemplateDefaults.ts", async () => {
+    const source = await fs.readFile(CLIENT_DEFAULTS_PATH, "utf8");
+    const clientValues: Record<string, string> = {};
+    for (const key of Object.keys(DEFAULT_MESSAGE_TEMPLATES)) {
+      const constName = `DEFAULT_${camelToUpperSnake(key)}`;
+      clientValues[key] = evalConstant(source, constName);
+    }
+    expect(clientValues).toEqual(DEFAULT_MESSAGE_TEMPLATES);
+  });
+});
+
+/**
+ * Extract the RHS of `export const <name> = <expr>;` from a TS source
+ * file and evaluate it as plain JS. The RHS for every DEFAULT_* in
+ * `serverTemplateDefaults.ts` is a valid JS expression (string literal,
+ * string concat, or array-join) — no TS-only syntax — so the Function
+ * constructor handles it without a TS compiler step.
+ */
+function evalConstant(source: string, name: string): string {
+  const re = new RegExp(`export const ${name}\\s*=\\s*([\\s\\S]*?);\\s*$`, "m");
+  const match = re.exec(source);
+  if (!match || !match[1]) throw new Error(`constant ${name} not found in client defaults`);
+  const result = new Function(`return (${match[1]})`)();
+  if (typeof result !== "string") {
+    throw new Error(`constant ${name} did not evaluate to a string`);
+  }
+  return result;
+}
+
+function camelToUpperSnake(camel: string): string {
+  return camel.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toUpperCase();
+}

--- a/functions/src/messageTemplates.ts
+++ b/functions/src/messageTemplates.ts
@@ -1,0 +1,38 @@
+import type { MessageTemplateKey } from "./messageTemplateDefaults.js";
+import { DEFAULT_MESSAGE_TEMPLATES } from "./messageTemplateDefaults.js";
+
+/**
+ * Replace `{{name}}` tokens in `template` with values from `vars`.
+ * Unknown keys stay literal (mirrors the client helper at
+ * `src/features/templates/interpolate.ts`) so authoring typos are
+ * visible in the delivered message rather than silently dropped.
+ * Whitespace inside the braces is tolerated.
+ */
+export function interpolate(template: string, vars: Readonly<Record<string, string>>): string {
+  return template.replace(/\{\{\s*(\w+)\s*\}\}/g, (match, key: string) =>
+    Object.hasOwn(vars, key) ? vars[key]! : match,
+  );
+}
+
+/**
+ * Fetches the body of a ward's server-side messaging template from
+ * Firestore. Falls back to the hardcoded default when no doc has
+ * been written yet (or when the doc is malformed). Never throws —
+ * downstream sends should always succeed even when the template
+ * collection is empty.
+ */
+export async function readMessageTemplate(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+  key: MessageTemplateKey,
+): Promise<string> {
+  const fallback = DEFAULT_MESSAGE_TEMPLATES[key];
+  try {
+    const snap = await db.doc(`wards/${wardId}/templates/${key}`).get();
+    if (!snap.exists) return fallback;
+    const body = snap.get("bodyMarkdown");
+    return typeof body === "string" && body.length > 0 ? body : fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -3,6 +3,7 @@ import { logger } from "firebase-functions/v2";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
 import { classifyInvitationChange } from "./invitationChange.js";
+import { readMessageTemplate } from "./messageTemplates.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
 import { sendEmail } from "./sendgrid/client.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
@@ -30,11 +31,20 @@ export const onInvitationWrite = onDocumentWritten(
     try {
       const bishopric = await fetchActiveBishopricEmails(db, wardId);
       if (change.fireSpeaker) {
-        await sendSpeakerReceipt(after, bishopric);
+        const answer = after.response?.answer;
+        const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
+        const headerTemplate = await readMessageTemplate(db, wardId, key);
+        await sendSpeakerReceipt(after, bishopric, headerTemplate);
       }
       if (change.fireBishopric) {
         const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
-        await sendBishopricReceipt(after, bishopric, { wardId, invitationId, origin });
+        const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");
+        await sendBishopricReceipt(after, bishopric, {
+          wardId,
+          invitationId,
+          origin,
+          headerTemplate,
+        });
       }
     } catch (err) {
       logger.error("invitation receipt dispatch failed", {
@@ -75,6 +85,7 @@ async function fetchActiveBishopricEmails(
 async function sendSpeakerReceipt(
   invitation: SpeakerInvitationShape,
   bishopric: BishopricContact[],
+  headerTemplate: string,
 ): Promise<void> {
   if (!invitation.speakerEmail) {
     logger.info("speaker receipt skipped — no speakerEmail on invitation", {
@@ -82,7 +93,7 @@ async function sendSpeakerReceipt(
     });
     return;
   }
-  const content = buildSpeakerReceipt({ invitation });
+  const content = buildSpeakerReceipt({ invitation, headerTemplate });
   await sendEmail({
     to: invitation.speakerEmail,
     fromDisplayName: `${invitation.wardName} (via Steward)`,
@@ -96,7 +107,7 @@ async function sendSpeakerReceipt(
 async function sendBishopricReceipt(
   invitation: SpeakerInvitationShape,
   bishopric: BishopricContact[],
-  ctx: { wardId: string; invitationId: string; origin: string },
+  ctx: { wardId: string; invitationId: string; origin: string; headerTemplate: string },
 ): Promise<void> {
   if (bishopric.length === 0) {
     logger.warn("bishopric receipt skipped — no bishopric emails found", { wardId: ctx.wardId });
@@ -113,6 +124,7 @@ async function sendBishopricReceipt(
     bishopricViewUrl,
     acknowledgedByName,
     respondedAt,
+    headerTemplate: ctx.headerTemplate,
   });
   // Send individually rather than via CC: the bishopric list can be 3-7
   // people and individual sends give SendGrid cleaner bounce handling

--- a/functions/src/rotateInvitationLink.ts
+++ b/functions/src/rotateInvitationLink.ts
@@ -132,7 +132,7 @@ async function deliverIfRequested(
     );
   }
   if (input.channels.includes("sms") && invitation.speakerPhone) {
-    out.push(await trySms(invitation.speakerPhone, emailArgs));
+    out.push(await trySms(input.wardId, invitation.speakerPhone, emailArgs));
   }
   return out;
 }

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -1,13 +1,12 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { HttpsError } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
-import { sendEmail } from "./sendgrid/client.js";
 import { addChatParticipant, deleteConversation } from "./twilio/conversations.js";
-import { sendSmsDirect } from "./twilio/messaging.js";
-import { buildEmailHtml, buildEmailText, buildSmsBody } from "./invitationEmailBody.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
-import type { DeliveryEntry } from "./sendSpeakerInvitation.types.js";
 import type { MemberDoc } from "./types.js";
+
+export { tryEmail, trySms, sendInvitationSms } from "./invitationDelivery.js";
+export type { EmailDeliveryParams } from "./invitationDelivery.js";
 
 export async function assertActiveMember(wardId: string, uid: string): Promise<void> {
   const snap = await getFirestore().doc(`wards/${wardId}/members/${uid}`).get();
@@ -28,15 +27,11 @@ export interface BishopricSnapshot {
   email: string;
 }
 
-/** Pulls every active bishopric + clerk member from the ward and
- *  adds them to the new conversation with displayName + role
- *  attributes. Returns the list of successfully-added members so
- *  the caller can snapshot it onto the invitation doc — the
- *  speaker's public invite page uses that snapshot to label chat
- *  bubbles when Twilio attributes aren't available (e.g. older
- *  conversations, or while the client is still loading).
- *  Per-add failures are logged and swallowed; the conversation
- *  stays usable with whichever participants succeeded. */
+/** Adds every active bishopric/clerk member to the conversation and
+ *  returns the snapshot the caller pins on the invitation doc — the
+ *  invite page uses that list to label chat bubbles when Twilio
+ *  attributes aren't available. Per-add failures are swallowed so the
+ *  conversation stays usable with whichever adds succeeded. */
 export async function addBishopricParticipants(
   wardId: string,
   conversationSid: string,
@@ -91,50 +86,6 @@ export async function cleanupPriorConversations(
   }
 }
 
-type EmailArgs = Parameters<typeof buildEmailText>[0];
-
-export interface EmailDeliveryParams {
-  speakerEmail: string;
-  inviterName: string;
-  assignedDate: string;
-  /** Reply-To used so a speaker replying to the email lands in the
-   *  bishop's inbox naturally. On rotate-mode we don't have it on the
-   *  invitation doc, so callers fall back to the speaker's own email. */
-  replyToEmail: string;
-}
-
-export async function tryEmail(
-  params: EmailDeliveryParams,
-  args: EmailArgs,
-): Promise<DeliveryEntry> {
-  try {
-    const messageId = await sendEmail({
-      to: params.speakerEmail,
-      fromDisplayName: `${params.inviterName} (via Steward)`,
-      replyTo: params.replyToEmail,
-      subject: `Speaking invitation — ${params.assignedDate}`,
-      text: buildEmailText(args),
-      html: buildEmailHtml(args),
-    });
-    const entry: DeliveryEntry = { channel: "email", status: "sent", at: new Date() };
-    if (messageId) entry.providerId = messageId;
-    return entry;
-  } catch (err) {
-    logger.error("email send failed", { err: (err as Error).message });
-    return { channel: "email", status: "failed", error: (err as Error).message, at: new Date() };
-  }
-}
-
-export async function trySms(speakerPhone: string, emailArgs: EmailArgs): Promise<DeliveryEntry> {
-  try {
-    const sid = await sendSmsDirect({ to: speakerPhone, body: buildSmsBody(emailArgs) });
-    return { channel: "sms", status: "sent", providerId: sid, at: new Date() };
-  } catch (err) {
-    logger.error("initial SMS send failed", { err: (err as Error).message });
-    return { channel: "sms", status: "failed", error: (err as Error).message, at: new Date() };
-  }
-}
-
 /** Build a speaker invite URL from its three parts. The `:invitationId`
  *  path segment is the stable Firestore doc ID; `:token` is the
  *  rotating capability value. Keeping them separate lets the landing
@@ -148,28 +99,4 @@ export function buildInviteUrl(
 ): string {
   const trimmed = origin.replace(/\/+$/, "");
   return `${trimmed}/invite/speaker/${wardId}/${invitationId}/${token}`;
-}
-
-/** Send the invitation letter via SMS (Twilio). Used both by the
- *  initial sendSpeakerInvitation flow and by issueSpeakerSession's
- *  rotation path when a consumed/expired token is presented. */
-export async function sendInvitationSms(args: {
-  speakerPhone: string;
-  inviterName: string;
-  wardName: string;
-  assignedDate: string;
-  speakerName: string;
-  inviteUrl: string;
-}): Promise<{ providerId: string }> {
-  const sid = await sendSmsDirect({
-    to: args.speakerPhone,
-    body: buildSmsBody({
-      speakerName: args.speakerName,
-      inviterName: args.inviterName,
-      assignedDate: args.assignedDate,
-      wardName: args.wardName,
-      inviteUrl: args.inviteUrl,
-    }),
-  });
-  return { providerId: sid };
 }

--- a/src/app/routes/templates.tsx
+++ b/src/app/routes/templates.tsx
@@ -1,13 +1,25 @@
 import { Link } from "react-router";
 import { PageRail } from "@/components/ui/PageRail";
+import { BishopReplyEmailSection } from "@/features/templates/BishopReplyEmailSection";
+import { BishopReplySmsSection } from "@/features/templates/BishopReplySmsSection";
+import { BishopricResponseReceiptSection } from "@/features/templates/BishopricResponseReceiptSection";
+import { InitialSmsSection } from "@/features/templates/InitialSmsSection";
 import { SpeakerEmailSection } from "@/features/templates/SpeakerEmailSection";
 import { SpeakerLetterSection } from "@/features/templates/SpeakerLetterSection";
+import { SpeakerResponseAcceptedSection } from "@/features/templates/SpeakerResponseAcceptedSection";
+import { SpeakerResponseDeclinedSection } from "@/features/templates/SpeakerResponseDeclinedSection";
 import { WardInviteSection } from "@/features/templates/WardInviteSection";
 
 const RAIL_ITEMS = [
-  { id: "sec-speaker-letter", label: "Speaker invitation letter" },
-  { id: "sec-speaker-email", label: "Speaker invitation email" },
-  { id: "sec-ward-invite", label: "Ward invitation message" },
+  { id: "sec-speaker-letter", label: "Letter", group: "Speaker invitation" },
+  { id: "sec-speaker-email", label: "Email", group: "Speaker invitation" },
+  { id: "sec-initial-sms", label: "SMS", group: "Speaker invitation" },
+  { id: "sec-response-accepted", label: "Accepted", group: "Response receipts" },
+  { id: "sec-response-declined", label: "Declined", group: "Response receipts" },
+  { id: "sec-bishopric-receipt", label: "Bishopric notice", group: "Response receipts" },
+  { id: "sec-reply-sms", label: "Reply SMS", group: "Conversation" },
+  { id: "sec-reply-email", label: "Reply email", group: "Conversation" },
+  { id: "sec-ward-invite", label: "Invitation message", group: "Ward members" },
 ];
 
 const RAIL_ELSEWHERE = [
@@ -36,14 +48,20 @@ export function TemplatesPage(): React.ReactElement {
           Templates
         </h1>
         <p className="font-serif italic text-[16px] text-walnut-2 mt-1">
-          The messages Steward sends on your behalf — invitations, emails, and on-page letters.
+          The messages Steward sends on your behalf — invitations, receipts, and chat notifications.
         </p>
       </header>
 
-      <div className="grid grid-cols-1 sm:grid-cols-[1fr_200px] gap-8 items-start">
+      <div className="grid grid-cols-1 sm:grid-cols-[1fr_220px] gap-8 items-start">
         <div>
           <SpeakerLetterSection />
           <SpeakerEmailSection />
+          <InitialSmsSection />
+          <SpeakerResponseAcceptedSection />
+          <SpeakerResponseDeclinedSection />
+          <BishopricResponseReceiptSection />
+          <BishopReplySmsSection />
+          <BishopReplyEmailSection />
           <WardInviteSection />
         </div>
 

--- a/src/components/ui/PageRail.tsx
+++ b/src/components/ui/PageRail.tsx
@@ -8,6 +8,10 @@ interface RailItem {
   /** Optional numeric badge rendered at the end of the row — used on
    *  the Ward settings rail for the member count. */
   count?: number;
+  /** Optional group label. When two consecutive items carry different
+   *  group strings, a brass-deep header renders between them. Used on
+   *  the Templates page to separate invitation / receipts / replies. */
+  group?: string;
 }
 
 interface Props {
@@ -50,23 +54,35 @@ export function PageRail({ items, elsewhere, label = "Page sections" }: Props): 
       <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep px-2.5 pt-1 pb-2">
         On this page
       </div>
-      {items.map((s) => (
-        <a
-          key={s.id}
-          href={`#${s.id}`}
-          className={cn(
-            "flex items-center gap-2 px-3 py-2 rounded-md border-l-2 -ml-0.5 text-[13.5px] transition-colors",
-            active === s.id
-              ? "border-bordeaux text-bordeaux-deep font-semibold bg-parchment-2/40"
-              : "border-transparent text-walnut-2 hover:bg-parchment-2 hover:text-walnut",
-          )}
-        >
-          <span className="flex-1">{s.label}</span>
-          {typeof s.count === "number" && (
-            <span className="font-mono text-[10px] tracking-[0.08em] text-walnut-3">{s.count}</span>
-          )}
-        </a>
-      ))}
+      {items.map((s, idx) => {
+        const prevGroup = idx > 0 ? items[idx - 1]?.group : undefined;
+        const showGroupHeader = s.group !== undefined && s.group !== prevGroup;
+        return (
+          <div key={s.id} className="contents">
+            {showGroupHeader && (
+              <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-walnut-3 px-2.5 pt-3 pb-1">
+                {s.group}
+              </div>
+            )}
+            <a
+              href={`#${s.id}`}
+              className={cn(
+                "flex items-center gap-2 px-3 py-2 rounded-md border-l-2 -ml-0.5 text-[13.5px] transition-colors",
+                active === s.id
+                  ? "border-bordeaux text-bordeaux-deep font-semibold bg-parchment-2/40"
+                  : "border-transparent text-walnut-2 hover:bg-parchment-2 hover:text-walnut",
+              )}
+            >
+              <span className="flex-1">{s.label}</span>
+              {typeof s.count === "number" && (
+                <span className="font-mono text-[10px] tracking-[0.08em] text-walnut-3">
+                  {s.count}
+                </span>
+              )}
+            </a>
+          </div>
+        );
+      })}
       {elsewhere && elsewhere.length > 0 && (
         <>
           <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep px-2.5 pt-4 pb-2">

--- a/src/features/templates/BishopReplyEmailSection.tsx
+++ b/src/features/templates/BishopReplyEmailSection.tsx
@@ -1,0 +1,33 @@
+import { MessageTemplateCard } from "./MessageTemplateCard";
+import { DEFAULT_BISHOP_REPLY_EMAIL } from "./serverTemplateDefaults";
+
+export function BishopReplyEmailSection(): React.ReactElement {
+  return (
+    <MessageTemplateCard
+      sectionId="sec-reply-email"
+      eyebrow="Email"
+      title="Bishop reply → speaker email"
+      description={
+        <>
+          SendGrid email sent alongside the reply SMS (or on its own if the speaker has email but no
+          phone). Author in plain text; the HTML version is rendered paragraph-by-paragraph.
+        </>
+      }
+      templateKey="bishopReplyEmail"
+      defaultBody={DEFAULT_BISHOP_REPLY_EMAIL}
+      kind="email"
+      variables={[
+        { name: "inviterName", hint: "Bishopric member who posted the message" },
+        { name: "assignedDate", hint: "Pre-formatted Sunday" },
+        { name: "preview", hint: "First ~180 chars of the bishopric message" },
+        { name: "wardName", hint: "Your ward name" },
+      ]}
+      sampleVars={{
+        inviterName: "Bishop Paul",
+        assignedDate: "Sunday, April 26, 2026",
+        preview: "Thanks for agreeing to speak! Any topic in mind yet?",
+        wardName: "Elk River Ward",
+      }}
+    />
+  );
+}

--- a/src/features/templates/BishopReplySmsSection.tsx
+++ b/src/features/templates/BishopReplySmsSection.tsx
@@ -1,0 +1,33 @@
+import { MessageTemplateCard } from "./MessageTemplateCard";
+import { DEFAULT_BISHOP_REPLY_SMS } from "./serverTemplateDefaults";
+
+const SAMPLE_INVITE_URL = "https://example.com/invite/speaker/your-ward/sample-token";
+
+export function BishopReplySmsSection(): React.ReactElement {
+  return (
+    <MessageTemplateCard
+      sectionId="sec-reply-sms"
+      eyebrow="SMS"
+      title="Bishop reply → speaker SMS"
+      description={
+        <>
+          Sent to the speaker's phone when a member of the bishopric posts a reply in the chat and
+          the speaker's web session isn't presumed open.
+        </>
+      }
+      templateKey="bishopReplySms"
+      defaultBody={DEFAULT_BISHOP_REPLY_SMS}
+      kind="sms"
+      variables={[
+        { name: "wardName", hint: "Your ward name" },
+        { name: "preview", hint: "First ~240 chars of the bishopric message" },
+        { name: "inviteUrl", hint: "Fresh invite-page link (rotated at send time)" },
+      ]}
+      sampleVars={{
+        wardName: "Elk River Ward",
+        preview: "Thanks for agreeing to speak! Any topic in mind yet?",
+        inviteUrl: SAMPLE_INVITE_URL,
+      }}
+    />
+  );
+}

--- a/src/features/templates/BishopricResponseReceiptSection.tsx
+++ b/src/features/templates/BishopricResponseReceiptSection.tsx
@@ -1,0 +1,31 @@
+import { MessageTemplateCard } from "./MessageTemplateCard";
+import { DEFAULT_BISHOPRIC_RESPONSE_RECEIPT } from "./serverTemplateDefaults";
+
+export function BishopricResponseReceiptSection(): React.ReactElement {
+  return (
+    <MessageTemplateCard
+      sectionId="sec-bishopric-receipt"
+      eyebrow="Receipt"
+      title="Bishopric notice — response applied"
+      description={
+        <>
+          Opening line of the email the bishopric receives after a response is applied. Responded-
+          at, applied-by, and the original letter render structurally below.
+        </>
+      }
+      templateKey="bishopricResponseReceipt"
+      defaultBody={DEFAULT_BISHOPRIC_RESPONSE_RECEIPT}
+      kind="email"
+      variables={[
+        { name: "speakerName", hint: "Speaker who replied" },
+        { name: "verb", hint: "Literal 'accepted' or 'declined' — use exactly as written" },
+        { name: "assignedDate", hint: "Pre-formatted Sunday" },
+      ]}
+      sampleVars={{
+        speakerName: "Sebastian Tan",
+        verb: "accepted",
+        assignedDate: "Sunday, April 26, 2026",
+      }}
+    />
+  );
+}

--- a/src/features/templates/InitialSmsSection.tsx
+++ b/src/features/templates/InitialSmsSection.tsx
@@ -1,0 +1,35 @@
+import { MessageTemplateCard } from "./MessageTemplateCard";
+import { DEFAULT_INITIAL_INVITATION_SMS } from "./serverTemplateDefaults";
+
+const SAMPLE_INVITE_URL = "https://example.com/invite/speaker/your-ward/sample-token";
+
+export function InitialSmsSection(): React.ReactElement {
+  return (
+    <MessageTemplateCard
+      sectionId="sec-initial-sms"
+      eyebrow="SMS"
+      title="Speaker invitation — SMS"
+      description={
+        <>
+          The first text message the speaker receives when you send an invitation. Delivered by
+          Twilio.
+        </>
+      }
+      templateKey="initialInvitationSms"
+      defaultBody={DEFAULT_INITIAL_INVITATION_SMS}
+      kind="sms"
+      variables={[
+        { name: "inviterName", hint: "Bishop or counselor sending the invitation" },
+        { name: "wardName", hint: "Your ward name" },
+        { name: "assignedDate", hint: "Pre-formatted Sunday, e.g. 'Sunday, April 26, 2026'" },
+        { name: "inviteUrl", hint: "Personal invite-page link for the speaker" },
+      ]}
+      sampleVars={{
+        inviterName: "Bishop Paul",
+        wardName: "Elk River Ward",
+        assignedDate: "Sunday, April 26, 2026",
+        inviteUrl: SAMPLE_INVITE_URL,
+      }}
+    />
+  );
+}

--- a/src/features/templates/MessageTemplateCard.tsx
+++ b/src/features/templates/MessageTemplateCard.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useMemo, useState } from "react";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import type { MessageTemplateKey } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { interpolate } from "./interpolate";
+import { EditorSection } from "./SpeakerLetterEditor";
+import { TemplateVariableList, type TemplateVariableDoc } from "./TemplateVariableList";
+import { useMessageTemplate } from "./useMessageTemplate";
+import { writeMessageTemplate } from "./writeMessageTemplate";
+
+const SMS_SEGMENT = 160;
+
+interface Props {
+  sectionId: string;
+  eyebrow: string;
+  title: string;
+  description: React.ReactNode;
+  templateKey: MessageTemplateKey;
+  defaultBody: string;
+  kind: "sms" | "email";
+  variables: readonly TemplateVariableDoc[];
+  sampleVars: Readonly<Record<string, string>>;
+  editorLabel?: string;
+}
+
+/** Shared card for every server-side messaging template section on
+ *  /settings/templates. Editor on the left, interpolated preview on
+ *  the right; SMS-kind cards add a character + segment counter. Each
+ *  card writes its own Firestore doc so there's no page-level savebar
+ *  to coordinate. */
+export function MessageTemplateCard({
+  sectionId,
+  eyebrow,
+  title,
+  description,
+  templateKey,
+  defaultBody,
+  kind,
+  variables,
+  sampleVars,
+  editorLabel,
+}: Props): React.ReactElement {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const me = useCurrentMember();
+  const { data: template, loading } = useMessageTemplate(templateKey);
+
+  const [body, setBody] = useState(defaultBody);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (loading || seeded) return;
+    if (template) setBody(template.bodyMarkdown);
+    setSeeded(true);
+  }, [loading, seeded, template]);
+
+  const canEdit = Boolean(me?.data.active);
+  const preview = useMemo(() => interpolate(body, sampleVars), [body, sampleVars]);
+
+  async function handleSave() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMessageTemplate(wardId, templateKey, { bodyMarkdown: body });
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section
+      id={sectionId}
+      className="bg-chalk border border-border rounded-lg p-6 mb-4 scroll-mt-24"
+    >
+      <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1">
+        {eyebrow}
+      </div>
+      <h2 className="font-display text-[22px] font-semibold text-walnut mb-1">{title}</h2>
+      <div className="font-serif italic text-[14px] text-walnut-2 mb-4">{description}</div>
+
+      <TemplateVariableList variables={variables} />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] mt-4">
+        <div className="flex flex-col gap-3">
+          <EditorSection
+            label={editorLabel ?? (kind === "sms" ? "Message body" : "Body")}
+            initialMarkdown={body}
+            onChange={setBody}
+            disabled={!canEdit}
+          />
+          {error && <p className="font-sans text-[12.5px] text-bordeaux">{error}</p>}
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => void handleSave()}
+              disabled={!canEdit || saving}
+              className="font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-walnut bg-walnut text-parchment hover:bg-ink shadow-[0_1px_0_rgba(35,24,21,0.18)] disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              {saving ? "Saving…" : "Save template"}
+            </button>
+            <button
+              type="button"
+              onClick={() => setBody(defaultBody)}
+              disabled={!canEdit || saving}
+              className="font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-border-strong bg-chalk text-walnut hover:bg-parchment-2 disabled:opacity-60"
+            >
+              Reset to default
+            </button>
+          </div>
+        </div>
+        <PreviewPane preview={preview} kind={kind} />
+      </div>
+    </section>
+  );
+}
+
+function PreviewPane({ preview, kind }: { preview: string; kind: "sms" | "email" }) {
+  const segments = kind === "sms" ? Math.max(1, Math.ceil(preview.length / SMS_SEGMENT)) : null;
+  return (
+    <aside className="flex flex-col gap-2 min-w-0">
+      <div className="flex items-center justify-between font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
+        <span>Preview — sample data</span>
+        {kind === "sms" && (
+          <span>
+            {preview.length} chars · {segments === 1 ? "1 segment" : `${segments} segments`}
+          </span>
+        )}
+      </div>
+      <pre className="rounded-md border border-border bg-parchment-2/60 p-4 font-serif text-[13px] text-walnut-2 leading-relaxed whitespace-pre-wrap break-words min-h-24">
+        {preview}
+      </pre>
+    </aside>
+  );
+}

--- a/src/features/templates/SpeakerEmailSection.tsx
+++ b/src/features/templates/SpeakerEmailSection.tsx
@@ -6,8 +6,18 @@ import { friendlyWriteError } from "@/stores/saveStatusStore";
 import { renderSpeakerEmailBody } from "./renderSpeakerEmailBody";
 import { DEFAULT_SPEAKER_EMAIL_BODY } from "./speakerEmailDefaults";
 import { EditorSection } from "./SpeakerLetterEditor";
+import { TemplateVariableList } from "./TemplateVariableList";
 import { useSpeakerEmailTemplate } from "./useSpeakerEmailTemplate";
 import { writeSpeakerEmailTemplate } from "./writeSpeakerEmailTemplate";
+
+const VARIABLES = [
+  { name: "speakerName", hint: "Display name from the speaker form" },
+  { name: "date", hint: "Pre-formatted Sunday, e.g. 'Sunday, April 26, 2026'" },
+  { name: "wardName", hint: "Your ward name" },
+  { name: "inviterName", hint: "Bishop or counselor sending the invitation" },
+  { name: "topic", hint: "Assigned topic (blank if absent)" },
+  { name: "inviteUrl", hint: "Personal invite-page link for the speaker" },
+] as const;
 
 const SAMPLE_URL = "https://example.com/invite/speaker/your-ward/sample-token";
 
@@ -69,19 +79,19 @@ export function SpeakerEmailSection(): React.ReactElement {
       className="bg-chalk border border-border rounded-lg p-6 mb-4 scroll-mt-24"
     >
       <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1">
-        Template
+        Email
       </div>
       <h2 className="font-display text-[22px] font-semibold text-walnut mb-1">
         Speaker invitation email
       </h2>
-      <p className="font-serif italic text-[14px] text-walnut-2 mb-5">
-        The plain-text message your email client sends when you click "Send email" on a planned
-        speaker. Variables: <code>{"{{speakerName}}"}</code>, <code>{"{{date}}"}</code>,{" "}
-        <code>{"{{wardName}}"}</code>, <code>{"{{inviterName}}"}</code>, <code>{"{{topic}}"}</code>,{" "}
-        <code>{"{{inviteUrl}}"}</code>.
-      </p>
+      <div className="font-serif italic text-[14px] text-walnut-2 mb-4">
+        The plain-text message your email client opens when you click "Send email" on a planned
+        speaker.
+      </div>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <TemplateVariableList variables={VARIABLES} />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] mt-4">
         <div className="flex flex-col gap-4">
           <EditorSection
             label="Email body"

--- a/src/features/templates/SpeakerResponseAcceptedSection.tsx
+++ b/src/features/templates/SpeakerResponseAcceptedSection.tsx
@@ -1,0 +1,31 @@
+import { MessageTemplateCard } from "./MessageTemplateCard";
+import { DEFAULT_SPEAKER_RESPONSE_ACCEPTED } from "./serverTemplateDefaults";
+
+export function SpeakerResponseAcceptedSection(): React.ReactElement {
+  return (
+    <MessageTemplateCard
+      sectionId="sec-response-accepted"
+      eyebrow="Receipt"
+      title="Speaker response — accepted"
+      description={
+        <>
+          Header of the email the speaker gets when they tap Yes. The original letter and a
+          safety-check line are appended automatically below this body.
+        </>
+      }
+      templateKey="speakerResponseAccepted"
+      defaultBody={DEFAULT_SPEAKER_RESPONSE_ACCEPTED}
+      kind="email"
+      variables={[
+        { name: "speakerName", hint: "Display name from the speaker form" },
+        { name: "assignedDate", hint: "Pre-formatted Sunday" },
+        { name: "reason", hint: "Optional note the speaker typed (blank if absent)" },
+      ]}
+      sampleVars={{
+        speakerName: "Sebastian Tan",
+        assignedDate: "Sunday, April 26, 2026",
+        reason: "",
+      }}
+    />
+  );
+}

--- a/src/features/templates/SpeakerResponseDeclinedSection.tsx
+++ b/src/features/templates/SpeakerResponseDeclinedSection.tsx
@@ -1,0 +1,31 @@
+import { MessageTemplateCard } from "./MessageTemplateCard";
+import { DEFAULT_SPEAKER_RESPONSE_DECLINED } from "./serverTemplateDefaults";
+
+export function SpeakerResponseDeclinedSection(): React.ReactElement {
+  return (
+    <MessageTemplateCard
+      sectionId="sec-response-declined"
+      eyebrow="Receipt"
+      title="Speaker response — declined"
+      description={
+        <>
+          Header of the email the speaker gets when they tap No. The letter excerpt and safety note
+          stay structural below this text.
+        </>
+      }
+      templateKey="speakerResponseDeclined"
+      defaultBody={DEFAULT_SPEAKER_RESPONSE_DECLINED}
+      kind="email"
+      variables={[
+        { name: "speakerName", hint: "Display name from the speaker form" },
+        { name: "assignedDate", hint: "Pre-formatted Sunday" },
+        { name: "reason", hint: "Optional note the speaker typed (blank if absent)" },
+      ]}
+      sampleVars={{
+        speakerName: "Sebastian Tan",
+        assignedDate: "Sunday, April 26, 2026",
+        reason: "Out of town that weekend",
+      }}
+    />
+  );
+}

--- a/src/features/templates/TemplateVariableList.tsx
+++ b/src/features/templates/TemplateVariableList.tsx
@@ -1,0 +1,25 @@
+export interface TemplateVariableDoc {
+  name: string;
+  hint: string;
+}
+
+/** Shared `{{var}} — hint` table rendered above the editor for every
+ *  template section. Keeping the list structural (rather than inlined
+ *  into prose) lets each variable own its own line and keeps the
+ *  layout predictable when the list grows. */
+export function TemplateVariableList({
+  variables,
+}: {
+  variables: readonly TemplateVariableDoc[];
+}): React.ReactElement {
+  return (
+    <dl className="grid sm:grid-cols-[max-content_1fr] gap-x-3 gap-y-0.5 font-serif text-[12.5px] text-walnut-3">
+      {variables.map((v) => (
+        <div key={v.name} className="contents">
+          <dt className="font-mono text-[11px] text-walnut-2">{`{{${v.name}}}`}</dt>
+          <dd className="italic">{v.hint}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/src/features/templates/WardInviteSection.tsx
+++ b/src/features/templates/WardInviteSection.tsx
@@ -1,14 +1,22 @@
 import { useEffect, useMemo, useState } from "react";
-import Markdown from "react-markdown";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
 import { renderWardInviteMessage } from "./renderWardInviteMessage";
 import { EditorSection } from "./SpeakerLetterEditor";
+import { TemplateVariableList } from "./TemplateVariableList";
 import { useWardInviteTemplate } from "./useWardInviteTemplate";
 import { DEFAULT_WARD_INVITE_BODY } from "./wardInviteDefaults";
 import { writeWardInviteTemplate } from "./writeWardInviteTemplate";
+
+const VARIABLES = [
+  { name: "inviteeName", hint: "Member being invited" },
+  { name: "wardName", hint: "Your ward name" },
+  { name: "inviterName", hint: "Bishop or counselor sending the invite" },
+  { name: "calling", hint: "Their calling (e.g. 'executive secretary')" },
+  { name: "role", hint: "App role — 'bishopric' or 'clerk'" },
+] as const;
 
 /** Templates → Ward invitation message section. Greeting shown at
  *  the top of the accept-invite page and used as the mailto body. */
@@ -66,20 +74,20 @@ export function WardInviteSection(): React.ReactElement {
       className="bg-chalk border border-border rounded-lg p-6 mb-4 scroll-mt-24"
     >
       <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1">
-        Template
+        Ward
       </div>
       <h2 className="font-display text-[22px] font-semibold text-walnut mb-1">
         Ward invitation message
       </h2>
-      <p className="font-serif italic text-[14px] text-walnut-2 mb-5">
-        The greeting shown at the top of the accept-invite page and used as the <code>mailto:</code>{" "}
-        body when you invite a new bishopric or clerk member. The sign-in link and footer are
-        appended automatically. Variables: <code>{"{{inviteeName}}"}</code>,{" "}
-        <code>{"{{wardName}}"}</code>, <code>{"{{inviterName}}"}</code>,{" "}
-        <code>{"{{calling}}"}</code>, <code>{"{{role}}"}</code>.
-      </p>
+      <div className="font-serif italic text-[14px] text-walnut-2 mb-4">
+        The greeting shown at the top of the accept-invite page and used as the mailto body when you
+        invite a new bishopric or clerk member. The sign-in link and footer are appended
+        automatically below.
+      </div>
 
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+      <TemplateVariableList variables={VARIABLES} />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)] mt-4">
         <div className="flex flex-col gap-4">
           <EditorSection
             label="Invitation greeting"
@@ -111,17 +119,9 @@ export function WardInviteSection(): React.ReactElement {
           <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
             Preview — sample data
           </div>
-          <div className="rounded-md border border-border bg-parchment-2/60 p-4">
-            <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep mb-2">
-              Ward invitation
-            </div>
-            <div className="prose prose-sm max-w-none font-serif text-[13.5px] text-walnut-2 leading-relaxed mb-3">
-              <Markdown>{preview}</Markdown>
-            </div>
-            <div className="rounded-md border border-border bg-chalk p-2.5 text-center font-sans text-[12px] italic text-walnut-3">
-              [ Accept invite button appears here ]
-            </div>
-          </div>
+          <pre className="rounded-md border border-border bg-parchment-2/60 p-4 font-serif text-[13px] text-walnut-2 leading-relaxed whitespace-pre-wrap break-words min-h-24">
+            {preview}
+          </pre>
         </aside>
       </div>
     </section>

--- a/src/features/templates/serverTemplateDefaults.ts
+++ b/src/features/templates/serverTemplateDefaults.ts
@@ -1,0 +1,65 @@
+import type { MessageTemplateKey } from "@/lib/types";
+
+/**
+ * Defaults for the six server-side messaging templates. Strings here
+ * match the current hardcoded copy in the Cloud Functions so wards
+ * without a Firestore override see identical behavior.
+ *
+ * **Keep in sync with `functions/src/messageTemplateDefaults.ts`.**
+ * The two files can't share a module (separate pnpm workspaces), so a
+ * test asserts the values match — see `functions/src/messageTemplates.test.ts`.
+ *
+ * Variables use the `{{name}}` syntax that `interpolate()` understands.
+ * See src/features/templates/interpolate.ts.
+ */
+
+/** Twilio SMS body sent when a bishop first invites a speaker. */
+export const DEFAULT_INITIAL_INVITATION_SMS =
+  "{{inviterName}} ({{wardName}}) has invited you to speak on {{assignedDate}}. " +
+  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+
+/** Narrative header of the SendGrid email the speaker receives when
+ *  they submit Yes on the invitation page. The letter excerpt and
+ *  safety warning are structural and stay hardcoded around this
+ *  string. */
+export const DEFAULT_SPEAKER_RESPONSE_ACCEPTED =
+  "You accepted the invitation to speak on {{assignedDate}}. Thank you.";
+
+/** Same shape for the declined branch. */
+export const DEFAULT_SPEAKER_RESPONSE_DECLINED =
+  "You declined the invitation to speak on {{assignedDate}}. Thank you for letting us know.";
+
+/** Opening line of the bishopric receipt when the Apply action mirrors
+ *  a response to `speaker.status`. The meta lines (responded-at,
+ *  applied-by, reason) and the inline letter rendering are structural. */
+export const DEFAULT_BISHOPRIC_RESPONSE_RECEIPT =
+  "{{speakerName}} {{verb}} the invitation to speak on {{assignedDate}}.";
+
+/** Twilio SMS the speaker gets when the bishopric replies in chat and
+ *  the speaker's web session isn't presumed online. The `{{inviteUrl}}`
+ *  may be absent (rotation failure) — the Cloud Function's hardcoded
+ *  fallback kicks in for that edge case. */
+export const DEFAULT_BISHOP_REPLY_SMS =
+  '{{wardName}}: new message from the bishopric about your speaking assignment — "{{preview}}". Open: {{inviteUrl}}';
+
+/** SendGrid email sent alongside the reply SMS (or on its own when
+ *  the speaker has email but no phone on file). Text body — the HTML
+ *  variant is derived paragraph-by-paragraph server-side. */
+export const DEFAULT_BISHOP_REPLY_EMAIL = [
+  "{{inviterName}} replied to your invitation for {{assignedDate}}:",
+  "",
+  "{{preview}}",
+  "",
+  "To reply back, open the invitation link in the text message we sent you.",
+  "",
+  "— {{wardName}}",
+].join("\n");
+
+export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
+  initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
+  speakerResponseAccepted: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+  speakerResponseDeclined: DEFAULT_SPEAKER_RESPONSE_DECLINED,
+  bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
+  bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
+  bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
+};

--- a/src/features/templates/useMessageTemplate.ts
+++ b/src/features/templates/useMessageTemplate.ts
@@ -1,0 +1,14 @@
+import { useDocSnapshot } from "@/hooks/_sub";
+import { type MessageTemplateKey, messageTemplateSchema } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+
+/**
+ * Subscribes to one of the ward's server-side messaging templates at
+ * `wards/{wardId}/templates/{key}`. Returns `data: null` when no
+ * template has been written yet — callers should fall back to the
+ * default from `serverTemplateDefaults.ts`.
+ */
+export function useMessageTemplate(key: MessageTemplateKey) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  return useDocSnapshot(["wards", wardId, "templates", key], messageTemplateSchema);
+}

--- a/src/features/templates/writeMessageTemplate.ts
+++ b/src/features/templates/writeMessageTemplate.ts
@@ -1,0 +1,27 @@
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { MessageTemplateKey } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/**
+ * Write one of the six server-side messaging templates to
+ * `wards/{wardId}/templates/{key}`. Any active bishopric or clerk
+ * member can edit per the shared template rule.
+ */
+export async function writeMessageTemplate(
+  wardId: string,
+  key: MessageTemplateKey,
+  input: { bodyMarkdown: string },
+): Promise<void> {
+  reportSaving();
+  try {
+    await setDoc(doc(db, "wards", wardId, "templates", key), {
+      bodyMarkdown: input.bodyMarkdown,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -57,3 +57,32 @@ export const speakerEmailTemplateSchema = z.object({
   updatedAt: z.any().optional(),
 });
 export type SpeakerEmailTemplate = z.infer<typeof speakerEmailTemplateSchema>;
+
+/**
+ * Shared shape for server-side messaging templates (SMS + email
+ * bodies sent by Cloud Functions). Each template lives at
+ * `wards/{wardId}/templates/{key}` and exposes the same
+ * `bodyMarkdown` + `updatedAt` pair the letter / email / invite
+ * templates already use. Six keys — see `MESSAGE_TEMPLATE_KEYS`.
+ *
+ * Templates govern only the authored narrative text; the structural
+ * framing around response-receipt emails (the inline letter excerpt,
+ * the divider rules, the "View in Steward" link, the warning text)
+ * stays hardcoded in the Cloud Function so bishoprics don't have to
+ * author HTML wrappers.
+ */
+export const messageTemplateSchema = z.object({
+  bodyMarkdown: z.string(),
+  updatedAt: z.any().optional(),
+});
+export type MessageTemplate = z.infer<typeof messageTemplateSchema>;
+
+export const MESSAGE_TEMPLATE_KEYS = [
+  "initialInvitationSms",
+  "speakerResponseAccepted",
+  "speakerResponseDeclined",
+  "bishopricResponseReceipt",
+  "bishopReplySms",
+  "bishopReplyEmail",
+] as const;
+export type MessageTemplateKey = (typeof MESSAGE_TEMPLATE_KEYS)[number];


### PR DESCRIPTION
## Summary
- Extends `/settings/templates` to cover six more messages that Cloud Functions send on the bishopric's behalf — initial invitation SMS, speaker accepted/declined receipts, bishopric notice, and the reply SMS/email pair. Each writes to `wards/{wardId}/templates/{key}` with defaults that match today's hardcoded copy verbatim, so wards without an override see no behavior change.
- New shared `MessageTemplateCard` + `TemplateVariableList` primitives; the older Speaker-email and Ward-invite sections now use the same variable-list layout for a consistent look across all nine sections. `PageRail` grows group labels (Speaker invitation / Response receipts / Conversation / Ward members).
- Server-side `interpolate` + `readMessageTemplate` helpers (with a `bodyMarkdown` fallback) are wired into `sendSpeakerInvitation.helpers.ts`, `invitationReceiptContent.ts`, `onInvitationWrite.ts`, and `invitationReplyNotify.ts`. A drift-check test asserts client and server default files stay aligned.

Fixes #55

## Test plan
- [x] `pnpm run typecheck` (both workspaces)
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] `pnpm run test` (root, 264 pass)
- [x] `pnpm --prefix functions test` (76 pass, incl. new interpolate + readMessageTemplate + drift-check tests)
- [x] `pnpm run build`
- [ ] Manual — send an invitation with default templates, confirm SMS + emails match prior copy verbatim
- [ ] Manual — edit each of the six new templates on `/settings/templates`, trigger each flow, confirm custom wording appears
- [ ] Manual — delete a template doc, confirm default wording reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)