### PR TITLE
docs(claude): bump Cloud Function count to eight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,13 @@ PWA for a ward bishopric to plan weekly sacrament meeting programs. Desktop + mo
 - **SMS + in-app chat**: Twilio Conversations (bridges the speaker's phone SMS and their web invite page into a single thread — speakers can reply from either side)
 - **Lint**: oxlint &nbsp;·&nbsp; **Format**: Biome (formatter mode; linter disabled)
 - **Test**: Vitest + Playwright + `@firebase/rules-unit-testing`, against Firebase Local Emulator Suite
-- **Backend**: six Firebase Cloud Functions — `onMeetingWrite` (change notifications), `scheduledNudges` (finalization cron), `onCommentCreate` (@mention notifications), `sendSpeakerInvitation` (callable: creates invitation + delivers email/SMS + a hashed capability token), `issueSpeakerSession` (callable: exchanges an invitation capability token for a Firebase custom token + Twilio Conversations JWT; self-heals consumed/expired tokens by rotating + resending the SMS), `onTwilioWebhook` (HTTPS: receives Conversations events, fans out FCM to bishopric + email to speaker). No API server beyond these.
+- **Backend**: eight Firebase Cloud Functions — `onMeetingWrite` (change notifications), `scheduledNudges` (finalization cron, hourly), `drainNotificationQueue` (drains the per-ward notification queue once a minute, sends FCM multicasts for due entries), `onCommentCreate` (@mention notifications), `sendSpeakerInvitation` (callable: creates invitation + delivers email/SMS + a hashed capability token), `issueSpeakerSession` (callable: exchanges an invitation capability token for a Firebase custom token + Twilio Conversations JWT; self-heals consumed/expired tokens by rotating + resending the SMS), `onInvitationWrite` (Firestore trigger: fires receipt emails on authoritative response transitions — speaker gets a Yes/No confirmation, bishopric gets an Apply notice), `onTwilioWebhook` (HTTPS: receives Conversations events, fans out FCM to bishopric + email to speaker). No API server beyond these.
 
 ## Hard rules
 
 - **Everything is always editable.** No field locks based on status; status is a label, never a gate. Editing an `approved` program invalidates approvals (logged, not deleted).
 - **Components ≤ 150 LOC.** Enforced by oxlint `max-lines` + `max-lines-per-function` (error, not warn).
-- **Six Cloud Functions, no API server.** The list above is the full surface; expanding it requires a deliberate scope decision. Firestore rules carry the rest of the authorization logic.
+- **Eight Cloud Functions, no API server.** The list above is the full surface; expanding it requires a deliberate scope decision. Firestore rules carry the rest of the authorization logic.
 - **Multi-ward from day one.** All data scoped under `wards/{wardId}/`.
 - **No direct pushes to `develop` or `main`.** Every change flows through a PR: feature branch → PR into `develop` (see the [`feature-branch-workflow`](.claude/skills/feature-branch-workflow.md) skill); releases go via PR from `develop` → `main` (see [`release-to-main`](.claude/skills/release-to-main.md)). GitHub's free tier doesn't enforce this — discipline does. No force-pushes to either branch, ever.
 - **Merge-commit is the only enabled merge method** at the repo level (squash + rebase disabled). Keeps `develop` and `main` SHA-aligned and prevents "N ahead / N behind" drift.
@@ -55,11 +55,15 @@ functions/          # Firebase Cloud Functions
   src/
     onMeetingWrite.ts           # change notifications
     scheduledNudges.ts          # finalization nudges (hourly cron)
+    drainNotificationQueue.ts   # per-ward notification queue drainer (every-minute cron)
     onCommentCreate.ts          # @mention notifications
     sendSpeakerInvitation.ts    # callable: create invitation + deliver via SendGrid + Twilio; issues a hashed capability token
     issueSpeakerSession.ts      # callable: exchange capability token for Firebase custom token + Twilio JWT; self-heals via rotation
+    onInvitationWrite.ts        # Firestore trigger: speaker + bishopric receipt emails on response transitions
     onTwilioWebhook.ts          # HTTPS: Twilio Conversations events → FCM / SendGrid fan-out
     invitationToken.ts          # shared capability-token helpers (generate / hash / timing-safe compare / rotation bucket)
+    invitationDelivery.ts       # shared SMS + email delivery paths (trySms / tryEmail / sendInvitationSms)
+    messageTemplates.ts         # interpolate + readMessageTemplate (falls back to default when doc absent)
     twilio/, sendgrid/          # thin transport wrappers
 ```
 


### PR DESCRIPTION
CLAUDE.md was out of date: said **six** Cloud Functions when prod runs **eight**.

- Adds \`drainNotificationQueue\` (per-ward notification queue drainer, every-minute cron) — was added in an earlier PR but never made it into the CLAUDE.md list.
- Adds \`onInvitationWrite\` (receipt emails trigger) — landed in v0.8.0 / PR #56.
- Updates the hard rule (\`Six → Eight Cloud Functions\`).
- Updates the \`functions/src/\` directory listing with \`invitationDelivery.ts\` + \`messageTemplates.ts\` which were extracted during the v0.8.0 work.

Purely doc — no code changes. Spotted while reviewing the Firebase console after the v0.8.0 deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)