### PR TITLE
feat(receipts): re-fire on flip + link receipt to invite page

### DIFF
--- a/functions/src/invitationChange.test.ts
+++ b/functions/src/invitationChange.test.ts
@@ -42,6 +42,24 @@ describe("classifyInvitationChange", () => {
     });
   });
 
+  it("re-fires the speaker receipt when the answer flips yes → no", () => {
+    const before = mk({ response: { answer: "yes" } });
+    const after = mk({ response: { answer: "no", reason: "changed mind" } });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: true,
+      fireBishopric: false,
+    });
+  });
+
+  it("re-fires the speaker receipt when the answer flips no → yes", () => {
+    const before = mk({ response: { answer: "no" } });
+    const after = mk({ response: { answer: "yes" } });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: true,
+      fireBishopric: false,
+    });
+  });
+
   it("fires the bishopric receipt when acknowledgedAt appears", () => {
     const before = mk({ response: { answer: "yes" } });
     const after = mk({

--- a/functions/src/invitationChange.ts
+++ b/functions/src/invitationChange.ts
@@ -1,7 +1,7 @@
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface InvitationChange {
-  /** Response just went from absent → present. */
+  /** Response newly set OR flipped to a different answer (yes↔no). */
   fireSpeaker: boolean;
   /** `response.acknowledgedAt` just appeared (Apply was tapped). */
   fireBishopric: boolean;
@@ -11,13 +11,16 @@ export interface InvitationChange {
  *  for a given before/after snapshot of the invitation doc.
  *
  *  - Deletions: no receipts.
- *  - Response newly set (was absent before): speaker receipt.
+ *  - Response newly set OR the answer flipped (yes↔no): speaker receipt.
+ *    We re-fire on a flip so the speaker's inbox reflects their current
+ *    status (an old yes-accepted email would otherwise linger after a
+ *    change of mind) and the bishopric CC keeps a paper trail.
  *  - Acknowledgement newly set: bishopric receipt.
  *  - Other writes (token rotation, heartbeat, delivery record): none.
  *
- *  The "appeared" guard deduplicates retried trigger invocations:
- *  a doc write that already had `response.answer` set will produce
- *  `fireSpeaker=false` on re-fire. */
+ *  Firestore writes settle once per user action, so a legitimate flip
+ *  fires exactly one receipt; re-fires of the same trigger invocation
+ *  still dedupe because `answerBefore === answerAfter` on the re-run. */
 export function classifyInvitationChange(
   before: SpeakerInvitationShape | undefined,
   after: SpeakerInvitationShape | undefined,
@@ -28,7 +31,7 @@ export function classifyInvitationChange(
   const ackBefore = before?.response?.acknowledgedAt;
   const ackAfter = after.response?.acknowledgedAt;
   return {
-    fireSpeaker: !answerBefore && Boolean(answerAfter),
+    fireSpeaker: Boolean(answerAfter) && answerBefore !== answerAfter,
     fireBishopric: !ackBefore && Boolean(ackAfter),
   };
 }

--- a/functions/src/invitationReceiptContent.test.ts
+++ b/functions/src/invitationReceiptContent.test.ts
@@ -57,6 +57,28 @@ describe("buildSpeakerReceipt", () => {
     expect(content.text).toMatch(/Your note: I'm out of town/);
     expect(content.html).toMatch(/I&#39;m out of town/);
   });
+
+  it("renders an invite URL when provided", () => {
+    const url = "https://steward-app.ca/invite/speaker/w1/inv1/tok123";
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+      inviteUrl: url,
+    });
+    expect(content.text).toMatch(
+      new RegExp(`Open your invitation page: ${url.replace(/[/.]/g, "\\$&")}`),
+    );
+    expect(content.html).toMatch(new RegExp(`href="${url.replace(/[/.]/g, "\\$&")}"`));
+  });
+
+  it("omits the invite URL block when not provided", () => {
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+    });
+    expect(content.text).not.toMatch(/Open your invitation page/);
+    expect(content.html).not.toMatch(/Open your invitation page/);
+  });
 });
 
 describe("buildBishopricReceipt", () => {

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -12,6 +12,10 @@ export interface ReceiptBuildArgs {
    *  `buildBishopricReceipt`. Caller loads the template via
    *  `readMessageTemplate` so builders stay pure. */
   headerTemplate: string;
+  /** Freshly-rotated invite URL for `buildSpeakerReceipt`. Optional —
+   *  rotation can fail, in which case the receipt falls back to the
+   *  no-link shape (the speaker still has the original SMS/email). */
+  inviteUrl?: string;
 }
 
 export interface ReceiptContent {
@@ -51,13 +55,14 @@ function letterText(invitation: SpeakerInvitationShape): string {
   ].join("\n");
 }
 
-/** Email sent to the speaker when their Yes/No first lands on the
- *  invitation doc. Confirms exactly what was recorded; the original
- *  letter is rendered inline for reference. No link is included —
- *  the speaker already has the invite URL in their inbox/SMS, and
- *  rotating a fresh token per receipt would be gratuitous. */
+/** Email sent to the speaker when their Yes/No lands on the invitation
+ *  doc (or flips). Confirms what was recorded and carries a freshly
+ *  rotated invite link so the speaker can reopen the chat even if
+ *  they've deleted the original SMS. `inviteUrl` is optional — if
+ *  rotation failed upstream, the receipt falls back to the no-link
+ *  shape (the original SMS is still a valid entry point). */
 export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
-  const { invitation, headerTemplate } = args;
+  const { invitation, headerTemplate, inviteUrl } = args;
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("speaker receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
@@ -73,6 +78,8 @@ export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
     "",
     invitation.response?.reason ? `Your note: ${invitation.response.reason}` : null,
     invitation.response?.reason ? "" : null,
+    inviteUrl ? `Open your invitation page: ${inviteUrl}` : null,
+    inviteUrl ? "" : null,
     "For reference, the original letter you received:",
     "",
     letterText(invitation),
@@ -88,6 +95,7 @@ ${
     ? `<blockquote style="margin:0 0 16px 0;padding-left:10px;border-left:3px solid #bca788;color:#4a3a30;"><em>${escapeHtml(invitation.response.reason)}</em></blockquote>`
     : ""
 }
+${inviteUrl ? `<p><a href="${inviteUrl}">Open your invitation page</a></p>` : ""}
 <hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
 <p style="color:#666;font-size:12px;margin:0 0 6px 0;">For reference, the original letter you received:</p>
 ${letterHtml(invitation)}

--- a/functions/src/onInvitationWrite.helpers.ts
+++ b/functions/src/onInvitationWrite.helpers.ts
@@ -1,0 +1,121 @@
+import { logger } from "firebase-functions/v2";
+import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
+import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
+import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
+import { sendEmail } from "./sendgrid/client.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import type { MemberDoc } from "./types.js";
+
+export interface BishopricContact {
+  uid: string;
+  email: string;
+  displayName: string;
+}
+
+export async function fetchActiveBishopricEmails(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+): Promise<BishopricContact[]> {
+  const snap = await db.collection(`wards/${wardId}/members`).get();
+  const out: BishopricContact[] = [];
+  for (const d of snap.docs) {
+    const m = d.data() as MemberDoc;
+    if (!m.active) continue;
+    if (m.role !== "bishopric" && m.role !== "clerk") continue;
+    if (!m.email) continue;
+    // Bishopric is always CC'd (non-negotiable — bishopric visibility
+    // on invitation activity is load-bearing). Clerks and secretaries
+    // opt in via `ccOnEmails` (default true for back-compat).
+    if (m.role === "clerk" && m.ccOnEmails === false) continue;
+    out.push({ uid: d.id, email: m.email, displayName: m.displayName });
+  }
+  return out;
+}
+
+export async function sendSpeakerReceipt(
+  invitation: SpeakerInvitationShape,
+  bishopric: BishopricContact[],
+  headerTemplate: string,
+  inviteUrl: string | undefined,
+): Promise<void> {
+  if (!invitation.speakerEmail) {
+    logger.info("speaker receipt skipped — no speakerEmail on invitation", {
+      speakerName: invitation.speakerName,
+    });
+    return;
+  }
+  const content = buildSpeakerReceipt({
+    invitation,
+    headerTemplate,
+    ...(inviteUrl ? { inviteUrl } : {}),
+  });
+  await sendEmail({
+    to: invitation.speakerEmail,
+    fromDisplayName: `${invitation.wardName} (via Steward)`,
+    subject: content.subject,
+    text: content.text,
+    html: content.html,
+    ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
+  });
+}
+
+/** Rotate a fresh capability token for the receipt email's invite
+ *  link. Bishop-origin rotations don't count against the daily cap
+ *  (same rationale as the reply-notify path). Returns `undefined` on
+ *  any failure — the receipt still goes out, just without a link. */
+export async function rotateInviteUrl(
+  wardId: string,
+  invitationId: string,
+  origin: string,
+): Promise<string | undefined> {
+  try {
+    const rotated = await rotateTokenForBishopNotification(wardId, invitationId);
+    if (!rotated) return undefined;
+    return buildInviteUrl(origin, wardId, invitationId, rotated.newToken);
+  } catch (err) {
+    logger.warn("speaker-receipt token rotation failed — sending no-link receipt", {
+      wardId,
+      invitationId,
+      err: (err as Error).message,
+    });
+    return undefined;
+  }
+}
+
+export async function sendBishopricReceipt(
+  invitation: SpeakerInvitationShape,
+  bishopric: BishopricContact[],
+  ctx: { wardId: string; invitationId: string; origin: string; headerTemplate: string },
+): Promise<void> {
+  if (bishopric.length === 0) {
+    logger.warn("bishopric receipt skipped — no bishopric emails found", { wardId: ctx.wardId });
+    return;
+  }
+  const acknowledgedByName = bishopric.find(
+    (b) => b.uid === invitation.response?.acknowledgedBy,
+  )?.displayName;
+  const respondedAt = invitation.response?.respondedAt?.toDate();
+  const origin = ctx.origin.replace(/\/+$/, "");
+  const bishopricViewUrl = `${origin}/ward/${ctx.wardId}/invitations/${ctx.invitationId}/view`;
+  const content = buildBishopricReceipt({
+    invitation,
+    bishopricViewUrl,
+    acknowledgedByName,
+    respondedAt,
+    headerTemplate: ctx.headerTemplate,
+  });
+  // Send individually rather than via CC: the bishopric list can be 3-7
+  // people and individual sends give SendGrid cleaner bounce handling
+  // per recipient.
+  await Promise.all(
+    bishopric.map((b) =>
+      sendEmail({
+        to: b.email,
+        fromDisplayName: `Steward`,
+        subject: content.subject,
+        text: content.text,
+        html: content.html,
+      }),
+    ),
+  );
+}

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -1,22 +1,27 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
-import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
 import { classifyInvitationChange } from "./invitationChange.js";
 import { readMessageTemplate } from "./messageTemplates.js";
+import {
+  fetchActiveBishopricEmails,
+  rotateInviteUrl,
+  sendBishopricReceipt,
+  sendSpeakerReceipt,
+} from "./onInvitationWrite.helpers.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
-import { sendEmail } from "./sendgrid/client.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
-import type { MemberDoc } from "./types.js";
 
 /** Fires receipt emails on authoritative response transitions:
- *   - `response.answer` appears → speaker receipt (to speaker, CC bishopric)
+ *   - `response.answer` appears or flips → speaker receipt (to speaker,
+ *      CC bishopric) with a freshly-rotated invite link so they can
+ *      reopen the chat even if the original SMS has been deleted.
  *   - `response.acknowledgedAt` appears → bishopric receipt (to bishopric)
  *
  *  Other writes (token rotation, delivery-record updates, heartbeats)
  *  are classified as no-ops and return early. The receipts contain the
  *  original letter inline so the email itself is the archive — no
- *  external dependency on the invite URL or the app being reachable. */
+ *  external dependency on the app being reachable. */
 export const onInvitationWrite = onDocumentWritten(
   "wards/{wardId}/speakerInvitations/{invitationId}",
   async (event) => {
@@ -28,16 +33,19 @@ export const onInvitationWrite = onDocumentWritten(
 
     const { wardId, invitationId } = event.params;
     const db = getFirestore();
+    const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
     try {
       const bishopric = await fetchActiveBishopricEmails(db, wardId);
       if (change.fireSpeaker) {
         const answer = after.response?.answer;
         const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
-        const headerTemplate = await readMessageTemplate(db, wardId, key);
-        await sendSpeakerReceipt(after, bishopric, headerTemplate);
+        const [headerTemplate, inviteUrl] = await Promise.all([
+          readMessageTemplate(db, wardId, key),
+          rotateInviteUrl(wardId, invitationId, origin),
+        ]);
+        await sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl);
       }
       if (change.fireBishopric) {
-        const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
         const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");
         await sendBishopricReceipt(after, bishopric, {
           wardId,
@@ -55,89 +63,3 @@ export const onInvitationWrite = onDocumentWritten(
     }
   },
 );
-
-interface BishopricContact {
-  uid: string;
-  email: string;
-  displayName: string;
-}
-
-async function fetchActiveBishopricEmails(
-  db: FirebaseFirestore.Firestore,
-  wardId: string,
-): Promise<BishopricContact[]> {
-  const snap = await db.collection(`wards/${wardId}/members`).get();
-  const out: BishopricContact[] = [];
-  for (const d of snap.docs) {
-    const m = d.data() as MemberDoc;
-    if (!m.active) continue;
-    if (m.role !== "bishopric" && m.role !== "clerk") continue;
-    if (!m.email) continue;
-    // Bishopric is always CC'd (non-negotiable — bishopric visibility
-    // on invitation activity is load-bearing). Clerks and secretaries
-    // opt in via `ccOnEmails` (default true for back-compat).
-    if (m.role === "clerk" && m.ccOnEmails === false) continue;
-    out.push({ uid: d.id, email: m.email, displayName: m.displayName });
-  }
-  return out;
-}
-
-async function sendSpeakerReceipt(
-  invitation: SpeakerInvitationShape,
-  bishopric: BishopricContact[],
-  headerTemplate: string,
-): Promise<void> {
-  if (!invitation.speakerEmail) {
-    logger.info("speaker receipt skipped — no speakerEmail on invitation", {
-      speakerName: invitation.speakerName,
-    });
-    return;
-  }
-  const content = buildSpeakerReceipt({ invitation, headerTemplate });
-  await sendEmail({
-    to: invitation.speakerEmail,
-    fromDisplayName: `${invitation.wardName} (via Steward)`,
-    subject: content.subject,
-    text: content.text,
-    html: content.html,
-    ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
-  });
-}
-
-async function sendBishopricReceipt(
-  invitation: SpeakerInvitationShape,
-  bishopric: BishopricContact[],
-  ctx: { wardId: string; invitationId: string; origin: string; headerTemplate: string },
-): Promise<void> {
-  if (bishopric.length === 0) {
-    logger.warn("bishopric receipt skipped — no bishopric emails found", { wardId: ctx.wardId });
-    return;
-  }
-  const acknowledgedByName = bishopric.find(
-    (b) => b.uid === invitation.response?.acknowledgedBy,
-  )?.displayName;
-  const respondedAt = invitation.response?.respondedAt?.toDate();
-  const origin = ctx.origin.replace(/\/+$/, "");
-  const bishopricViewUrl = `${origin}/ward/${ctx.wardId}/invitations/${ctx.invitationId}/view`;
-  const content = buildBishopricReceipt({
-    invitation,
-    bishopricViewUrl,
-    acknowledgedByName,
-    respondedAt,
-    headerTemplate: ctx.headerTemplate,
-  });
-  // Send individually rather than via CC: the bishopric list can be 3-7
-  // people and individual sends give SendGrid cleaner bounce handling
-  // per recipient.
-  await Promise.all(
-    bishopric.map((b) =>
-      sendEmail({
-        to: b.email,
-        fromDisplayName: `Steward`,
-        subject: content.subject,
-        text: content.text,
-        html: content.html,
-      }),
-    ),
-  );
-}


### PR DESCRIPTION
Two small follow-ups to v0.8.0's receipt work.

## Summary

### #47 — Re-fire speaker receipt on a yes↔no flip

\`classifyInvitationChange\` only fired \`fireSpeaker\` on **first appearance** (\`!answerBefore && Boolean(answerAfter)\`). If a speaker flipped yes→no later, no new receipt went out — the inbox kept a stale accepted-receipt and the bishopric CC lost the paper trail.

The classifier now fires on any real change: \`Boolean(answerAfter) && answerBefore !== answerAfter\`. Same-answer re-writes stay silent. Two new unit tests cover yes→no and no→yes.

### #46 — Speaker receipt email links back to the invite page

The receipt shipped without a link back to the chat. If a speaker deleted the original SMS (common after responding) they had no way to reopen the thread with the bishopric.

- \`buildSpeakerReceipt\` now takes an optional \`inviteUrl\` and renders a link inline (text + HTML).
- \`onInvitationWrite\` rotates a fresh capability token via the existing \`rotateTokenForBishopNotification\` (the same bishop-origin path the reply notifier already uses — doesn't count against the daily cap) and passes the URL through.
- Rotation failure falls back to the no-link receipt rather than blocking the send.
- Because the fire-speaker path grew a \`Promise.all\` + rotation call, I split \`onInvitationWrite\` helpers into a companion file to stay under the 150-LOC cap.

## Test plan

- [x] \`pnpm run typecheck\` (both workspaces)
- [x] \`pnpm run lint\`, \`pnpm run format:check\`
- [x] \`pnpm --prefix functions test\` — 80 pass (+4: 2 flip cases, 2 inviteUrl cases)
- [x] \`pnpm run test\` (root) — 264 pass
- [ ] Manual (emulator): respond yes, confirm receipt w/ link lands; flip to no, confirm second receipt w/ link; tap link in email → reopens the chat

Closes #46
Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)