### PR TITLE
feat(notifications): per-device names + 'This device' chip

### DIFF
--- a/src/features/notifications/deriveDeviceName.test.ts
+++ b/src/features/notifications/deriveDeviceName.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { deriveDeviceName, type NavigatorLike } from "./deriveDeviceName";
+
+describe("deriveDeviceName — UA-CH (Chromium) path", () => {
+  it("recognizes Chrome on macOS from userAgentData", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
+      userAgentData: {
+        brands: [
+          { brand: "Google Chrome", version: "129" },
+          { brand: "Chromium", version: "129" },
+          { brand: "Not.A/Brand", version: "99" },
+        ],
+        platform: "macOS",
+        mobile: false,
+      },
+    };
+    expect(deriveDeviceName(nav)).toBe("Chrome · macOS");
+  });
+
+  it("prefers Microsoft Edge over Chromium when both brands are present", () => {
+    const nav: NavigatorLike = {
+      userAgent: "Mozilla/5.0 … Edg/130.0.0.0",
+      userAgentData: {
+        brands: [
+          { brand: "Chromium", version: "130" },
+          { brand: "Not.A/Brand", version: "99" },
+          { brand: "Microsoft Edge", version: "130" },
+        ],
+        platform: "Windows",
+      },
+    };
+    expect(deriveDeviceName(nav)).toBe("Microsoft Edge · Windows");
+  });
+
+  it("recognizes Chrome on Android", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/129.0.0.0 Mobile Safari/537.36",
+      userAgentData: {
+        brands: [{ brand: "Google Chrome", version: "129" }],
+        platform: "Android",
+        mobile: true,
+      },
+    };
+    expect(deriveDeviceName(nav)).toBe("Chrome · Android");
+  });
+
+  it("skips filler brands like Not.A/Brand when picking the browser name", () => {
+    const nav: NavigatorLike = {
+      userAgent: "Mozilla/5.0 …",
+      userAgentData: {
+        brands: [{ brand: "Not.A/Brand", version: "99" }],
+        platform: "Linux",
+      },
+    };
+    // With no real brand name, falls back to UA string — which has nothing either, so "Browser".
+    expect(deriveDeviceName(nav)).toBe("Browser · Linux");
+  });
+});
+
+describe("deriveDeviceName — legacy UA fallback", () => {
+  it("recognizes Safari on iOS", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+    };
+    expect(deriveDeviceName(nav)).toBe("Safari · iOS");
+  });
+
+  it("recognizes Firefox on Windows", () => {
+    const nav: NavigatorLike = {
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0",
+    };
+    expect(deriveDeviceName(nav)).toBe("Firefox · Windows");
+  });
+
+  it("recognizes Safari on macOS (not the also-present Chrome token)", () => {
+    // Apple's Safari UA includes "Safari/…" but not "Chrome/…"
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15",
+    };
+    expect(deriveDeviceName(nav)).toBe("Safari · macOS");
+  });
+
+  it("recognizes iPad as iOS", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+    };
+    expect(deriveDeviceName(nav)).toBe("Safari · iOS");
+  });
+
+  it("falls back to Browser · Unknown when nothing matches", () => {
+    const nav: NavigatorLike = { userAgent: "SomeCustomAgent/1.0" };
+    expect(deriveDeviceName(nav)).toBe("Browser · Unknown");
+  });
+});

--- a/src/features/notifications/deriveDeviceName.ts
+++ b/src/features/notifications/deriveDeviceName.ts
@@ -1,0 +1,65 @@
+/** Browsers expose `navigator.userAgentData` (Chromium) and/or the
+ *  legacy `navigator.userAgent` string. Both are lies — the UA string
+ *  is spoofable and Apple/Firefox don't yet ship UA-CH. This parser
+ *  produces a friendly `{browser} · {os}` label with reasonable
+ *  fallbacks; it's display-only, never used for feature-gating. */
+
+interface UaBrand {
+  brand: string;
+  version: string;
+}
+
+export interface NavigatorLike {
+  userAgent: string;
+  userAgentData?: {
+    brands?: UaBrand[];
+    platform?: string;
+    mobile?: boolean;
+  };
+}
+
+export function deriveDeviceName(nav: NavigatorLike): string {
+  const browser = detectBrowser(nav);
+  const os = detectOs(nav);
+  return `${browser} · ${os}`;
+}
+
+function detectBrowser(nav: NavigatorLike): string {
+  const brands = nav.userAgentData?.brands;
+  if (brands && brands.length > 0) {
+    // Prefer real brand names over filler ("Not.A/Brand") and the
+    // Chromium base. Edge and Opera ship both their own brand and
+    // Chromium, so iteration order matters.
+    const preferred = ["Microsoft Edge", "Opera", "Google Chrome", "Chromium"];
+    for (const name of preferred) {
+      if (brands.some((b) => b.brand === name)) return name === "Google Chrome" ? "Chrome" : name;
+    }
+  }
+  const ua = nav.userAgent;
+  if (/Edg\//.test(ua)) return "Microsoft Edge";
+  if (/OPR\//.test(ua)) return "Opera";
+  if (/Firefox\//.test(ua)) return "Firefox";
+  if (/Chrome\//.test(ua)) return "Chrome";
+  if (/Safari\//.test(ua)) return "Safari";
+  return "Browser";
+}
+
+function detectOs(nav: NavigatorLike): string {
+  const platform = nav.userAgentData?.platform;
+  if (platform) {
+    // UA-CH returns "macOS", "Windows", "Linux", "Android", "ChromeOS", etc.
+    if (platform === "macOS") return "macOS";
+    if (platform === "Windows") return "Windows";
+    if (platform === "Android") return "Android";
+    if (platform === "Chrome OS" || platform === "ChromeOS") return "ChromeOS";
+    if (platform === "Linux") return "Linux";
+  }
+  const ua = nav.userAgent;
+  if (/iPhone|iPad|iPod/.test(ua)) return "iOS";
+  if (/Android/.test(ua)) return "Android";
+  if (/Mac OS X|Macintosh/.test(ua)) return "macOS";
+  if (/Windows/.test(ua)) return "Windows";
+  if (/CrOS/.test(ua)) return "ChromeOS";
+  if (/Linux/.test(ua)) return "Linux";
+  return "Unknown";
+}

--- a/src/features/notifications/fcmToken.ts
+++ b/src/features/notifications/fcmToken.ts
@@ -8,12 +8,14 @@ import {
 } from "firebase/firestore";
 import { deleteToken, getToken } from "firebase/messaging";
 import { db, getMessagingIfSupported } from "@/lib/firebase";
+import { deriveDeviceName } from "./deriveDeviceName";
 
 const SW_PATH = "/firebase-messaging-sw.js";
 
 export interface SubscribeResult {
   token: string;
   platform: "web" | "ios" | "android";
+  name: string;
 }
 
 function detectPlatform(): "web" | "ios" | "android" {
@@ -59,14 +61,36 @@ export async function subscribeDevice(input: {
   if (!token) return null;
 
   const platform = detectPlatform();
+  const name = deriveDeviceName(navigator as unknown as Parameters<typeof deriveDeviceName>[0]);
   // serverTimestamp() can't ride inside arrayUnion (Firestore rejects sentinel
   // values nested in arrays), so we stamp client-side. The doc-level
   // updatedAt below is still server-authoritative.
   await updateDoc(doc(db, "wards", input.wardId, "members", input.uid), {
-    fcmTokens: arrayUnion({ token, platform, updatedAt: Timestamp.now() }),
+    fcmTokens: arrayUnion({ token, platform, name, updatedAt: Timestamp.now() }),
     updatedAt: serverTimestamp(),
   });
-  return { token, platform };
+  return { token, platform, name };
+}
+
+/** Returns the FCM token registered on this device *right now*, if
+ *  any. Used by the Profile page to flag the matching `fcmTokens[]`
+ *  row with a "This device" chip. Silent-returns null when messaging
+ *  isn't supported, permission hasn't been granted, or no SW exists. */
+export async function readCurrentDeviceToken(): Promise<string | null> {
+  const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
+  if (!vapidKey) return null;
+  const messaging = await getMessagingIfSupported();
+  if (!messaging) return null;
+  if (typeof Notification === "undefined" || Notification.permission !== "granted") return null;
+  if (!("serviceWorker" in navigator)) return null;
+  const swReg = await navigator.serviceWorker.getRegistration(SW_PATH);
+  if (!swReg) return null;
+  try {
+    const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: swReg });
+    return token || null;
+  } catch {
+    return null;
+  }
 }
 
 export async function unsubscribeDevice(input: {

--- a/src/features/notifications/useCurrentDeviceToken.ts
+++ b/src/features/notifications/useCurrentDeviceToken.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { readCurrentDeviceToken } from "./fcmToken";
+
+/** Resolves the FCM token registered on this browser/PWA right now.
+ *  Returns null while pending, or if no token is registered (permission
+ *  denied, SW not installed, etc). The `tokens` input re-triggers the
+ *  lookup after subscribe/unsubscribe so the "This device" chip can
+ *  follow state changes. */
+export function useCurrentDeviceToken(tokens: readonly { token: string }[]): string | null {
+  const [current, setCurrent] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void readCurrentDeviceToken().then((token) => {
+      if (!cancelled) setCurrent(token);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Re-run when the token set changes — after subscribe, the new token
+    // is in `tokens` and we want the chip to light up without a reload.
+  }, [tokens]);
+  return current;
+}

--- a/src/features/profile/DeviceRow.tsx
+++ b/src/features/profile/DeviceRow.tsx
@@ -3,6 +3,7 @@ import type { FcmToken } from "@/lib/types";
 
 interface Props {
   token: FcmToken;
+  isCurrentDevice: boolean;
   busy: boolean;
   onRemove: () => void;
 }
@@ -20,19 +21,25 @@ function formatAddedAt(at: unknown): string {
   return "—";
 }
 
-/** Single row in the Subscribed devices list: icon + platform name +
- *  added-date, with a Remove button. Per-device naming + "This
- *  device" chip are deferred — see the follow-up issue filed with
- *  this PR. */
-export function DeviceRow({ token, busy, onRemove }: Props): React.ReactElement {
+/** Single row in the Subscribed devices list: icon + friendly name +
+ *  added-date, with a Remove button. The row the user is reading on
+ *  right now gets a "This device" chip. Legacy tokens without a
+ *  `name` fall back to the bare platform label. */
+export function DeviceRow({ token, isCurrentDevice, busy, onRemove }: Props): React.ReactElement {
+  const label = token.name ?? PLATFORM_LABELS[token.platform];
   return (
     <li className="grid grid-cols-[38px_1fr_auto] items-center gap-3.5 px-3.5 py-2.5 bg-parchment border border-border rounded-lg">
       <span className="inline-flex items-center justify-center w-8 h-8 bg-chalk border border-border rounded-md text-walnut-2">
         <DeviceIcon platform={token.platform} />
       </span>
       <div className="min-w-0">
-        <div className="font-sans text-[14px] font-semibold text-walnut">
-          {PLATFORM_LABELS[token.platform]}
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-sans text-[14px] font-semibold text-walnut truncate">{label}</span>
+          {isCurrentDevice && (
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.12em] text-brass-deep bg-chalk border border-border-strong px-1.5 py-0.5 rounded">
+              This device
+            </span>
+          )}
         </div>
         <div className="font-mono text-[11px] text-walnut-3 mt-0.5">
           Added {formatAddedAt(token.updatedAt)}

--- a/src/features/profile/NotificationsSection.tsx
+++ b/src/features/profile/NotificationsSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { subscribeDevice, unsubscribeDevice } from "@/features/notifications/fcmToken";
+import { useCurrentDeviceToken } from "@/features/notifications/useCurrentDeviceToken";
 import type { FcmToken, NotificationPrefs } from "@/lib/types";
 import { CategoryRowsComingSoon, DigestSelectComingSoon } from "./ComingSoonRows";
 import { DeviceRow } from "./DeviceRow";
@@ -26,6 +27,7 @@ export function NotificationsSection({
 }: Props): React.ReactElement {
   const [busy, setBusy] = useState<string | "subscribe" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const currentToken = useCurrentDeviceToken(tokens);
 
   const deviceSubscribed = tokens.length > 0;
 
@@ -109,6 +111,7 @@ export function NotificationsSection({
               <DeviceRow
                 key={t.token}
                 token={t}
+                isCurrentDevice={t.token === currentToken}
                 busy={busy === t.token}
                 onRemove={() => void removeOne(t)}
               />

--- a/src/lib/types/member.ts
+++ b/src/lib/types/member.ts
@@ -26,6 +26,10 @@ export function callingToRole(calling: Calling): Role {
 export const fcmTokenSchema = z.object({
   token: z.string().min(1),
   platform: z.enum(["web", "ios", "android"]).default("web"),
+  /** Friendly browser+OS label derived at subscribe time (e.g.
+   *  "Chrome · macOS"). Optional so legacy entries without a name
+   *  still validate; UI renders the platform label as a fallback. */
+  name: z.string().optional(),
   updatedAt: z.any(),
 });
 export type FcmToken = z.infer<typeof fcmTokenSchema>;


### PR DESCRIPTION
Closes #53.

## What changes on the Profile page

- Each **Subscribed Devices** row now shows a friendly label like **"Chrome · macOS"** or **"Safari · iOS"** instead of the generic "Web" / "iOS" / "Android".
- The row matching the browser/PWA the user is *currently reading from* gets a **"This device"** chip in brass-deep uppercase mono.
- Legacy tokens without a `name` keep rendering the platform label — nothing breaks on refresh.

## How it works

- **`deriveDeviceName`** (pure fn): tries `navigator.userAgentData` first (Chromium gives `.brands` + `.platform`), falls back to regex-parsing the legacy UA string for Safari/Firefox. Display-only; never feature-gates. 9 unit tests cover Chrome/Edge/Firefox/Safari across macOS/Windows/iOS/Android + filler-brand handling + unknown-UA fallback.
- **`subscribeDevice`** writes the derived name into the new optional \`name\` field on the arrayUnion entry.
- **\`readCurrentDeviceToken\` + \`useCurrentDeviceToken\`** read back the FCM token registered on this browser (re-running \`getToken\` silently — no permission prompt, no-op if SW isn't installed) so the chip can match against \`fcmTokens[].token\`.

## Test plan

- [x] \`pnpm run typecheck\`, \`pnpm run lint\`, \`pnpm run format:check\`
- [x] \`pnpm run test\` — 273 pass (+9 new for the UA parser)
- [x] \`pnpm run build\`
- [ ] Manual: subscribe on two browsers with the same account → Profile shows two rows with distinct labels + the active one is chipped
- [ ] Manual: sign in to an account that subscribed before this change → rows still show "Web" / "iOS" / "Android" until re-subscribe

## Out of scope (per issue)

- User rename of a device
- Per-device push opt-out (the account-wide switch is fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)