### PR TITLE
fix(notifications): scope push toggle to this device only

### DIFF
--- a/src/features/profile/NotificationsSection.tsx
+++ b/src/features/profile/NotificationsSection.tsx
@@ -29,7 +29,10 @@ export function NotificationsSection({
   const [error, setError] = useState<string | null>(null);
   const currentToken = useCurrentDeviceToken(tokens);
 
-  const deviceSubscribed = tokens.length > 0;
+  // Scope the push toggle to *this* device so flipping off on Safari
+  // can't nuke a token registered on a different browser/OS.
+  const thisDeviceEntry = currentToken ? tokens.find((t) => t.token === currentToken) : undefined;
+  const deviceSubscribed = thisDeviceEntry !== undefined;
 
   async function togglePush(next: boolean) {
     setBusy("subscribe");
@@ -40,10 +43,8 @@ export function NotificationsSection({
         if (!result) {
           setError("Enable notifications in your browser or OS, then try again.");
         }
-      } else {
-        for (const t of tokens) {
-          await unsubscribeDevice({ wardId, uid, token: t });
-        }
+      } else if (thisDeviceEntry) {
+        await unsubscribeDevice({ wardId, uid, token: thisDeviceEntry });
       }
     } catch (e) {
       setError((e as Error).message);


### PR DESCRIPTION
Follow-up to #64 — user-spotted bug on a real two-device test.

## What was wrong

- Subscribed in Chrome. Opened Profile on Safari.
- Switch showed **on** in Safari (because `tokens.length > 0`).
- Flipping it off called `unsubscribeDevice` for **every** token in the array → Chrome's subscription got nuked.

## Fix

The switch now reflects only the token matching `readCurrentDeviceToken()` — the FCM token registered on the current browser/PWA.

- \`deviceSubscribed\` ← \`thisDeviceEntry !== undefined\` where \`thisDeviceEntry\` is the row whose \`.token\` matches \`currentToken\`.
- Flip-off unsubscribes \`thisDeviceEntry\` only; other devices are untouched.
- Flip-on still calls \`subscribeDevice\` which adds a new entry for this device.

## Expected after merge

1. Subscribe in Chrome → switch on in Chrome, "This device" chip on the Chrome row.
2. Open Safari → switch **off** (correctly — Safari isn't subscribed, regardless of what other devices have).
3. Flip on in Safari → Safari permission prompt → new row appears for Safari.
4. Flip off in Safari → only Safari's row disappears; Chrome stays subscribed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)