### PR TITLE
fix(notifications): persist current token in localStorage

### DIFF
--- a/src/features/notifications/fcmToken.ts
+++ b/src/features/notifications/fcmToken.ts
@@ -12,6 +12,37 @@ import { deriveDeviceName } from "./deriveDeviceName";
 
 const SW_PATH = "/firebase-messaging-sw.js";
 
+/** localStorage key for "the FCM token subscribed on THIS browser/PWA".
+ *  Read on mount by the Profile page to flag the matching fcmTokens[]
+ *  row with a "This device" chip. localStorage is per-origin
+ *  per-browser, so the match is exactly "this device" — no async FCM
+ *  lookups or SW timing guesswork. */
+const CURRENT_TOKEN_KEY = "steward:fcmToken:current";
+
+function rememberCurrentToken(token: string): void {
+  try {
+    localStorage.setItem(CURRENT_TOKEN_KEY, token);
+  } catch {
+    /* private-mode or disabled storage — chip won't light up, not fatal */
+  }
+}
+
+function forgetCurrentToken(): void {
+  try {
+    localStorage.removeItem(CURRENT_TOKEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function readCurrentDeviceToken(): string | null {
+  try {
+    return localStorage.getItem(CURRENT_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
 export interface SubscribeResult {
   token: string;
   platform: "web" | "ios" | "android";
@@ -69,28 +100,8 @@ export async function subscribeDevice(input: {
     fcmTokens: arrayUnion({ token, platform, name, updatedAt: Timestamp.now() }),
     updatedAt: serverTimestamp(),
   });
+  rememberCurrentToken(token);
   return { token, platform, name };
-}
-
-/** Returns the FCM token registered on this device *right now*, if
- *  any. Used by the Profile page to flag the matching `fcmTokens[]`
- *  row with a "This device" chip. Silent-returns null when messaging
- *  isn't supported, permission hasn't been granted, or no SW exists. */
-export async function readCurrentDeviceToken(): Promise<string | null> {
-  const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
-  if (!vapidKey) return null;
-  const messaging = await getMessagingIfSupported();
-  if (!messaging) return null;
-  if (typeof Notification === "undefined" || Notification.permission !== "granted") return null;
-  if (!("serviceWorker" in navigator)) return null;
-  const swReg = await navigator.serviceWorker.getRegistration(SW_PATH);
-  if (!swReg) return null;
-  try {
-    const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: swReg });
-    return token || null;
-  } catch {
-    return null;
-  }
 }
 
 export async function unsubscribeDevice(input: {
@@ -110,4 +121,5 @@ export async function unsubscribeDevice(input: {
     fcmTokens: arrayRemove(input.token),
     updatedAt: serverTimestamp(),
   });
+  if (readCurrentDeviceToken() === input.token.token) forgetCurrentToken();
 }

--- a/src/features/notifications/useCurrentDeviceToken.ts
+++ b/src/features/notifications/useCurrentDeviceToken.ts
@@ -1,23 +1,15 @@
 import { useEffect, useState } from "react";
 import { readCurrentDeviceToken } from "./fcmToken";
 
-/** Resolves the FCM token registered on this browser/PWA right now.
- *  Returns null while pending, or if no token is registered (permission
- *  denied, SW not installed, etc). The `tokens` input re-triggers the
- *  lookup after subscribe/unsubscribe so the "This device" chip can
- *  follow state changes. */
+/** The FCM token subscribed on THIS browser/PWA (persisted in
+ *  localStorage at subscribe time). Used by the Profile page to flag
+ *  the matching `fcmTokens[]` row with a "This device" chip. The
+ *  `tokens` dep re-reads after subscribe/unsubscribe so the chip
+ *  follows state changes without a page reload. */
 export function useCurrentDeviceToken(tokens: readonly { token: string }[]): string | null {
-  const [current, setCurrent] = useState<string | null>(null);
+  const [current, setCurrent] = useState<string | null>(() => readCurrentDeviceToken());
   useEffect(() => {
-    let cancelled = false;
-    void readCurrentDeviceToken().then((token) => {
-      if (!cancelled) setCurrent(token);
-    });
-    return () => {
-      cancelled = true;
-    };
-    // Re-run when the token set changes — after subscribe, the new token
-    // is in `tokens` and we want the chip to light up without a reload.
+    setCurrent(readCurrentDeviceToken());
   }, [tokens]);
   return current;
 }


### PR DESCRIPTION
Reopens the localStorage-based fix that got stranded when #65 merged before my second commit landed. The bug it addresses is still live on develop.

## The bug (still live, reproducible on Chrome)

1. Open \`/settings/profile\` on Chrome, switch currently off.
2. Flip Push notifications → on. Permission prompt, grant it. Chrome row appears in Subscribed Devices.
3. **Observed**: switch flips back to off, "This device" chip is missing from the Chrome row.
4. **Expected**: switch stays on, Chrome row gets the chip.

Root cause: \`readCurrentDeviceToken\` calls \`getToken()\` every time the hook re-runs. Something in the SW/permission/IndexedDB state between subscribe completing and the hook re-firing makes that call return null on Chrome (couldn't fully isolate it — probably a known FCM SDK race against SW activation).

## Fix

Stop calling \`getToken\` from the hook entirely. Instead:

- \`subscribeDevice\` writes the token to localStorage after the Firestore arrayUnion succeeds.
- \`unsubscribeDevice\` clears the localStorage entry (only if it matches — so removing a different device's row via the Remove button doesn't clobber this device's record).
- \`readCurrentDeviceToken\` now reads localStorage synchronously. No await, no SW state, no permission check.
- \`useCurrentDeviceToken\` just returns the synchronous read, refreshing when \`tokens\` changes.

localStorage is per-origin per-browser — it's precisely the "this device" identity we want.

## Edge cases

- **Private mode / localStorage disabled**: \`try/catch\` falls through. Chip won't light up. Not fatal — rest of the push flow works fine.
- **Remove this device's row from another browser**: localStorage here has stale token; on next open, it fails to match \`fcmTokens[]\` and correctly shows off/no-chip. Self-heals.
- **Upgrade path**: users who subscribed pre-fix have no localStorage entry. Switch shows off until they re-subscribe (overwrites the server row + stashes the token).

## Test plan

- [x] \`pnpm run typecheck\`, \`pnpm run lint\`, \`pnpm run format:check\`
- [x] \`pnpm run test\` — 273 pass
- [ ] Manual: Chrome subscribe → chip + switch on. Reload → still on. Safari: switch off (no stale localStorage). Unsubscribe Chrome via switch → chip + switch off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)