### PR TITLE
feat(notifications): push bishopric when a speaker responds

### DIFF
--- a/functions/src/invitationResponseNotify.test.ts
+++ b/functions/src/invitationResponseNotify.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { composeResponseNotification } from "./invitationResponseNotify.js";
+
+describe("composeResponseNotification", () => {
+  const base = { speakerName: "Brother Smith", meetingDate: "2026-05-10" } as const;
+
+  it("phrases a fresh Yes with a short date", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "yes",
+    });
+    expect(p.title).toBe("Brother Smith accepted");
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("phrases a fresh No without a reason", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "no",
+    });
+    expect(p.title).toBe("Brother Smith declined");
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("includes the reason when a fresh No has one", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "no",
+      reason: "out of town that weekend",
+    });
+    expect(p.title).toBe("Brother Smith declined");
+    expect(p.body).toBe('"out of town that weekend" — Sun, May 10');
+  });
+
+  it("ignores blank/whitespace-only reasons", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "no",
+      reason: "   ",
+    });
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("phrases a yes → no flip as 'changed response to No'", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: "yes",
+      nextAnswer: "no",
+      reason: "sick",
+    });
+    expect(p.title).toBe("Brother Smith changed response to No");
+    // Flip omits the reason — the title leads with "changed" and the
+    // bishopric already has the prior answer in context.
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("phrases a no → yes flip as 'changed response to Yes'", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: "no",
+      nextAnswer: "yes",
+    });
+    expect(p.title).toBe("Brother Smith changed response to Yes");
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("falls back to the raw meetingDate on an unparseable input", () => {
+    const p = composeResponseNotification({
+      speakerName: "A",
+      meetingDate: "not-a-date",
+      prevAnswer: undefined,
+      nextAnswer: "yes",
+    });
+    expect(p.body).toBe("not-a-date");
+  });
+
+  it("renders the date in UTC so timezone can't skew the weekday", () => {
+    // 2026-05-10 is a Sunday in UTC; we format in UTC to preserve that.
+    const p = composeResponseNotification({
+      speakerName: "A",
+      meetingDate: "2026-05-10",
+      prevAnswer: undefined,
+      nextAnswer: "yes",
+    });
+    expect(p.body).toMatch(/^Sun,/);
+  });
+});

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -1,0 +1,119 @@
+import { logger } from "firebase-functions/v2";
+import { sendAndPrune } from "./fcm.js";
+import { filterRecipients, type RecipientCandidate } from "./recipients.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
+
+export interface ResponseNotification {
+  title: string;
+  body: string;
+}
+
+/** Builds the FCM push payload for a speaker's yes/no response. Pure
+ *  — no Firestore, no I/O — so it can be unit-tested. Caller passes
+ *  the relevant slices of the before/after invitation shape. */
+export function composeResponseNotification(input: {
+  speakerName: string;
+  meetingDate: string;
+  prevAnswer: "yes" | "no" | undefined;
+  nextAnswer: "yes" | "no";
+  reason?: string;
+}): ResponseNotification {
+  const shortDate = formatShortDate(input.meetingDate);
+  const flipped = input.prevAnswer !== undefined && input.prevAnswer !== input.nextAnswer;
+  if (flipped) {
+    const verb = input.nextAnswer === "yes" ? "Yes" : "No";
+    return {
+      title: `${input.speakerName} changed response to ${verb}`,
+      body: shortDate,
+    };
+  }
+  if (input.nextAnswer === "yes") {
+    return {
+      title: `${input.speakerName} accepted`,
+      body: shortDate,
+    };
+  }
+  const reason = input.reason?.trim();
+  if (reason) {
+    return {
+      title: `${input.speakerName} declined`,
+      body: `"${reason}" — ${shortDate}`,
+    };
+  }
+  return {
+    title: `${input.speakerName} declined`,
+    body: shortDate,
+  };
+}
+
+/** "2026-05-10" → "Sun, May 10". Parses at UTC midnight + formats in
+ *  UTC so timezones can't skew the weekday. Falls back to the raw
+ *  string on bad input — not a critical path. */
+function formatShortDate(meetingDate: string): string {
+  const date = new Date(`${meetingDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return meetingDate;
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+/** Push-notify every active bishopric member when a speaker submits
+ *  or flips their yes/no on the invite page. Speakers themselves
+ *  aren't targeted (they're the actor) and clerks are excluded —
+ *  only bishopric gets paged on response activity. */
+export async function notifyBishopricOfResponse(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+  invitationId: string,
+  before: SpeakerInvitationShape | undefined,
+  after: SpeakerInvitationShape,
+): Promise<void> {
+  const nextAnswer = after.response?.answer;
+  if (!nextAnswer) return;
+
+  const wardSnap = await db.doc(`wards/${wardId}`).get();
+  const ward = wardSnap.data() as WardDoc | undefined;
+  const timezone = ward?.settings?.timezone ?? "UTC";
+
+  const membersSnap = await db.collection(`wards/${wardId}/members`).get();
+  const candidates: RecipientCandidate[] = membersSnap.docs
+    .map((d) => {
+      const m = d.data() as MemberDoc;
+      return m.role === "bishopric" ? { uid: d.id, member: m } : null;
+    })
+    .filter((c): c is RecipientCandidate => c !== null);
+  const recipients = filterRecipients(candidates, { now: new Date(), timezone });
+  if (recipients.length === 0) return;
+
+  const payload = composeResponseNotification({
+    speakerName: after.speakerName,
+    meetingDate: after.speakerRef.meetingDate,
+    prevAnswer: before?.response?.answer,
+    nextAnswer,
+    ...(after.response?.reason ? { reason: after.response.reason } : {}),
+  });
+
+  const tokensByUid = new Map<string, readonly FcmToken[]>();
+  for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
+  try {
+    await sendAndPrune(wardId, tokensByUid, {
+      notification: payload,
+      data: {
+        wardId,
+        invitationId,
+        meetingDate: after.speakerRef.meetingDate,
+        kind: "invitation-response",
+      },
+    });
+  } catch (err) {
+    logger.error("response push fan-out failed", {
+      wardId,
+      invitationId,
+      err: (err as Error).message,
+    });
+  }
+}

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -2,6 +2,7 @@ import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 import { classifyInvitationChange } from "./invitationChange.js";
+import { notifyBishopricOfResponse } from "./invitationResponseNotify.js";
 import { readMessageTemplate } from "./messageTemplates.js";
 import {
   fetchActiveBishopricEmails,
@@ -43,7 +44,10 @@ export const onInvitationWrite = onDocumentWritten(
           readMessageTemplate(db, wardId, key),
           rotateInviteUrl(wardId, invitationId, origin),
         ]);
-        await sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl);
+        await Promise.all([
+          sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl),
+          notifyBishopricOfResponse(db, wardId, invitationId, before, after),
+        ]);
       }
       if (change.fireBishopric) {
         const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");


### PR DESCRIPTION
Closes #17.

## What changes

FCM push to every active bishopric member the moment a speaker taps Yes / No / flips on the invite page — so bishops don't have to refresh the app or wait for the receipt email to know a response landed.

### Notification copy

| Case | Title | Body |
|---|---|---|
| Fresh Yes | "Brother Smith accepted" | "Sun, May 10" |
| Fresh No | "Brother Smith declined" | "Sun, May 10" |
| Fresh No + reason | "Brother Smith declined" | "\"out of town that weekend\" — Sun, May 10" |
| Flip (yes→no or no→yes) | "Brother Smith changed response to No/Yes" | "Sun, May 10" |

On flip we intentionally omit the reason — the title leads with "changed" and the bishopric already has the prior answer in context.

### Where it hooks in

Reuses the \`onInvitationWrite\` trigger from v0.8.0. The existing \`fireSpeaker\` branch already runs on any response transition (new or flip, per #47). This PR runs \`notifyBishopricOfResponse\` alongside the speaker receipt email — same transaction window, same condition.

### Who gets it

- ✅ Active **bishopric** members with registered \`fcmTokens\`
- ❌ Clerks (matches the existing \`pushToBishopric\` pattern in \`invitationReplyNotify\`)
- ❌ The speaker themselves (they're the actor)
- ❌ Bishopric override via the Apply modal — unchanged; that path flips \`acknowledgedAt\` and is handled by the separate \`fireBishopric\` branch (receipt email, not push — per the issue spec: "the person making the change is already in-app")

### Data payload for tap-through

\`{ wardId, invitationId, meetingDate, kind: "invitation-response" }\` — the client can route taps to \`/week/\${meetingDate}\`. Client-side routing in a follow-up if needed (the \`onCommentCreate\` push uses the same pattern and the SW reads \`data\` to navigate).

## Test plan

- [x] \`pnpm run typecheck\` (both workspaces)
- [x] \`pnpm run lint\`, \`pnpm run format:check\`
- [x] \`pnpm --prefix functions test\` — 88 pass (+8 composer tests)
- [x] \`pnpm run test\` (root) — 273 pass
- [ ] Manual (emulator): speaker submits Yes → bishop's phone pings with "accepted" title. Flip to No → "changed response to No". Fresh No with reason → reason appears in body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)