### PR TITLE
feat(notifications): deep-link push taps to the right in-app surface

### DIFF
--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -18,7 +18,12 @@ export interface ResolvedInvitation extends SpeakerInvitationShape {
 
 /** Speaker posted in the conversation → FCM push to active
  *  bishopric members of the ward. Reuses the quiet-hours + token
- *  pruning helpers that the mention notifications already use. */
+ *  pruning helpers that the mention notifications already use.
+ *
+ *  The payload carries `webpush.fcmOptions.link` so a tap deep-links
+ *  to the speaker's chat dialog on the Schedule page; the SW
+ *  `notificationclick` handler reads the same shape for browsers that
+ *  don't honor `fcmOptions.link` natively. */
 export async function pushToBishopric(inv: ResolvedInvitation, body: string): Promise<void> {
   const db = getFirestore();
   const wardSnap = await db.doc(`wards/${inv.wardId}`).get();
@@ -33,11 +38,14 @@ export async function pushToBishopric(inv: ResolvedInvitation, body: string): Pr
     .filter((c): c is RecipientCandidate => c !== null);
   const recipients = filterRecipients(candidates, { now: new Date(), timezone });
   if (recipients.length === 0) return;
+  const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
+  const link = `${origin}/schedule?chat=${encodeURIComponent(inv.token)}`;
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
   await sendAndPrune(inv.wardId, tokensByUid, {
     notification: { title: `${inv.speakerName} replied`, body: truncate(body, 120) },
-    data: { wardId: inv.wardId, token: inv.token, kind: "invitation-reply" },
+    data: { wardId: inv.wardId, invitationId: inv.token, kind: "invitation-reply" },
+    webpush: { fcmOptions: { link } },
   });
 }
 

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -64,13 +64,19 @@ function formatShortDate(meetingDate: string): string {
 /** Push-notify every active bishopric member when a speaker submits
  *  or flips their yes/no on the invite page. Speakers themselves
  *  aren't targeted (they're the actor) and clerks are excluded —
- *  only bishopric gets paged on response activity. */
+ *  only bishopric gets paged on response activity.
+ *
+ *  The FCM payload carries `webpush.fcmOptions.link` so a tap routes
+ *  straight to the matching speaker's chat dialog (the SW's
+ *  `notificationclick` handler reads the same shape for browsers that
+ *  don't honor `fcmOptions.link` natively). */
 export async function notifyBishopricOfResponse(
   db: FirebaseFirestore.Firestore,
   wardId: string,
   invitationId: string,
   before: SpeakerInvitationShape | undefined,
   after: SpeakerInvitationShape,
+  origin: string,
 ): Promise<void> {
   const nextAnswer = after.response?.answer;
   if (!nextAnswer) return;
@@ -96,6 +102,7 @@ export async function notifyBishopricOfResponse(
     nextAnswer,
     ...(after.response?.reason ? { reason: after.response.reason } : {}),
   });
+  const link = `${origin.replace(/\/+$/, "")}/schedule?chat=${encodeURIComponent(invitationId)}`;
 
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
@@ -108,6 +115,7 @@ export async function notifyBishopricOfResponse(
         meetingDate: after.speakerRef.meetingDate,
         kind: "invitation-response",
       },
+      webpush: { fcmOptions: { link } },
     });
   } catch (err) {
     logger.error("response push fan-out failed", {

--- a/functions/src/onCommentCreate.ts
+++ b/functions/src/onCommentCreate.ts
@@ -3,6 +3,7 @@ import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { logger } from "firebase-functions/v2";
 import { sendAndPrune } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
+import { STEWARD_ORIGIN } from "./secrets.js";
 import type { CommentDoc, FcmToken, MemberDoc, WardDoc } from "./types.js";
 
 export const onCommentCreate = onDocumentCreated(
@@ -41,12 +42,15 @@ export const onCommentCreate = onDocumentCreated(
       tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
     }
 
+    const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
+    const link = `${origin}/week/${encodeURIComponent(date)}`;
     const outcome = await sendAndPrune(wardId, tokensByUid, {
       notification: {
         title: `${comment.authorDisplayName} mentioned you`,
         body: `On Sunday ${date}: ${truncate(comment.body, 120)}`,
       },
       data: { wardId, date, kind: "mention" },
+      webpush: { fcmOptions: { link } },
     });
 
     logger.info("comment-mention notification sent", {

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -46,7 +46,7 @@ export const onInvitationWrite = onDocumentWritten(
         ]);
         await Promise.all([
           sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl),
-          notifyBishopricOfResponse(db, wardId, invitationId, before, after),
+          notifyBishopricOfResponse(db, wardId, invitationId, before, after, origin),
         ]);
       }
       if (change.fireBishopric) {

--- a/public/firebase-messaging-sw.template.js
+++ b/public/firebase-messaging-sw.template.js
@@ -31,3 +31,47 @@ messaging.onBackgroundMessage((payload) => {
     data: payload.data ?? {},
   });
 });
+
+/** Deep-link a notification tap into the matching in-app surface.
+ *  Keep the `data.kind` map here in sync with the FCM payloads in
+ *  functions/src/ (invitationResponseNotify, invitationReplyNotify,
+ *  onCommentCreate). If an existing tab is already on our origin we
+ *  focus + navigate that one; otherwise we open a new window. */
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = routeForPushData(event.notification.data);
+  if (!url) return;
+  event.waitUntil(focusOrOpen(url));
+});
+
+function routeForPushData(data) {
+  if (!data || typeof data !== "object") return "/";
+  switch (data.kind) {
+    case "invitation-response":
+    case "invitation-reply":
+      return data.invitationId
+        ? `/schedule?chat=${encodeURIComponent(data.invitationId)}`
+        : "/schedule";
+    case "mention":
+      return data.date ? `/week/${encodeURIComponent(data.date)}` : "/schedule";
+    default:
+      return "/";
+  }
+}
+
+async function focusOrOpen(url) {
+  const target = new URL(url, self.location.origin).href;
+  const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  for (const client of clients) {
+    if (!client.url.startsWith(self.location.origin)) continue;
+    if ("navigate" in client) {
+      try {
+        await client.navigate(target);
+      } catch {
+        // Some browsers reject cross-origin navigate; fall through to focus-only.
+      }
+    }
+    return client.focus();
+  }
+  return self.clients.openWindow(target);
+}

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
 import { BishopInvitationDialog } from "@/features/invitations/BishopInvitationDialog";
 import { useConversationUnread } from "@/features/invitations/useConversationUnread";
 import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
@@ -38,6 +39,21 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
   const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
   const members = useWardMembers();
   const provenance = statusProvenanceLabel(speaker, members);
+
+  // Auto-open the dialog when a push notification deep-links us here
+  // via `?chat=<invitationId>`. Each row checks independently — only
+  // the matching one opens + clears the query. Invitation loads async,
+  // so we can't check until it arrives.
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    if (!invitation) return;
+    const target = searchParams.get("chat");
+    if (!target || target !== invitation.invitationId) return;
+    setOpen(true);
+    const next = new URLSearchParams(searchParams);
+    next.delete("chat");
+    setSearchParams(next, { replace: true });
+  }, [invitation, searchParams, setSearchParams]);
 
   return (
     <li className="flex items-center gap-3 py-3 border-b border-border last:border-b-0">


### PR DESCRIPTION
Closes #68. Builds on #67 (speaker-response push delivery) — taps on those and every other push now route somewhere useful instead of dumping the user at /.

## Routing table

| \`data.kind\` | Target URL |
|---|---|
| \`invitation-response\` | \`/schedule?chat={invitationId}\` — auto-opens the speaker's chat dialog |
| \`invitation-reply\` | same |
| \`mention\` | \`/week/{date}\` |

## Two-layer implementation

### 1. SW \`notificationclick\` handler

Added to [firebase-messaging-sw.template.js](public/firebase-messaging-sw.template.js). Reads \`data.kind\` + relevant id/date and constructs the URL. Tries to **focus an existing tab** via \`clients.matchAll\` + \`client.focus()\` (and navigate via \`client.navigate\` where supported) before falling back to \`clients.openWindow\`. Runs on every browser that supports Web Push — no SDK gating.

### 2. \`webpush.fcmOptions.link\` on the server

Added to the three push fan-outs:
- \`notifyBishopricOfResponse\` (now takes \`origin\`, passed through from \`onInvitationWrite\`)
- \`pushToBishopric\` in \`invitationReplyNotify\` (origin already available via \`STEWARD_ORIGIN\`)
- \`onCommentCreate\` (imported \`STEWARD_ORIGIN\`)

Chrome/Edge honor \`fcmOptions.link\` natively for faster tap-to-navigate; the SW handler is the fallback for Safari/Firefox/older Chromium. Both point at the same URL so the outcome is identical.

## Client-side auto-open

\`SpeakerRow\` reads \`?chat=\` via \`useSearchParams\`. On mount (and after \`useLatestInvitation\` resolves) it checks for a match against its own \`invitation.invitationId\` — if found, it \`setOpen(true)\` and strips the query with \`replace: true\` so a refresh doesn't re-trigger. Each row checks independently; since invitation IDs are unique, only the matching one fires.

## Small rename

Renamed the \`data.token\` field → \`data.invitationId\` in the \`invitation-reply\` push payload. The field has always been the invitation's Firestore doc ID (see \`token: d.id\` in \`onTwilioWebhook.findInvitationByConversation\`), just confusingly named. SW handler standardizes on \`invitationId\`.

## Test plan

- [x] \`pnpm run typecheck\`, \`pnpm run lint\`, \`pnpm run format:check\`
- [x] \`pnpm run test\` (root 273) and \`pnpm --prefix functions test\` (88) pass
- [x] \`pnpm run build\`
- [ ] Manual: trigger each push kind via the emulator or prod — tap lands on the expected surface
- [ ] Manual: app already open on \`/schedule\` → tap focuses the existing tab instead of opening a new one

🤖 Generated with [Claude Code](https://claude.com/claude-code)