### PR TITLE
Release: v0.9.0 — deeper push notifications + receipt polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,92 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.0] — 2026-04-23
+
+Push-notification depth: bishopric members now get a push the moment a
+speaker responds (not just an email), tapping a push deep-links into
+the matching chat or week page (no more being dumped at `/`), and the
+receipt email doubles as a durable re-entry point into the speaker's
+invite page. Plus per-device labels and "This device" chips on the
+Profile page so the subscribed-devices list actually reads like it's
+about specific devices.
+
+### Added
+
+- **Push notify bishopric on speaker response** (#17). `onInvitationWrite`
+  already fires on Yes/No transitions for the receipt email — it now
+  fans out an FCM push alongside, with copy that reads "Brother Smith
+  accepted — Sun, May 10" (or "declined: '…' — Sun, May 10" when the
+  speaker included a reason, or "changed response to Yes/No — …" on a
+  flip). Clerks and the speaker themselves are excluded; quiet hours
+  honored via the shared `filterRecipients` helper.
+- **Tap-through deep-links for every push** (#68). Notifications now
+  route:
+  - `invitation-response` / `invitation-reply` → `/schedule?chat=<invitationId>`
+    (auto-opens the speaker's `BishopInvitationDialog`)
+  - `mention` → `/week/<date>`
+
+  Two layers: a `notificationclick` handler in `firebase-messaging-sw.js`
+  that focuses an existing tab and navigates it (falling back to
+  `clients.openWindow`), plus `webpush.fcmOptions.link` on the server
+  payload for Chrome/Edge native handling. Safari/Firefox use the SW
+  handler. `SpeakerRow` reads `?chat=` via `useSearchParams` and
+  auto-opens the matching dialog, stripping the query with
+  `replace: true` so a refresh doesn't re-trigger.
+- **Re-fire the speaker receipt on a yes↔no flip** (#47). Previously
+  `classifyInvitationChange` fired only on first-appearance; a speaker
+  who flipped their answer left an inbox receipt contradicting their
+  current status. Now re-fires whenever `response.answer` actually
+  changes.
+- **Link the speaker receipt email back to the invite page** (#46).
+  `buildSpeakerReceipt` renders a freshly-rotated invite URL (via the
+  existing `rotateTokenForBishopNotification` path — doesn't count
+  against the daily cap). If rotation fails, falls back to the
+  no-link receipt so the send itself never errors out.
+- **Per-device names + "This device" chip** on `/settings/profile`
+  (#53). Subscribed-devices list now labels entries with derived
+  browser+OS strings like "Chrome · macOS" / "Safari · iOS" instead
+  of the generic platform bucket. The row matching the current
+  browser/PWA gets a brass-deep "This device" chip. New
+  `deriveDeviceName` parser prefers `navigator.userAgentData`
+  (Chromium) and falls back to UA-string regex for Safari/Firefox.
+
+### Changed
+
+- **Push toggle on Profile is now scoped to the current device.**
+  Previously the switch read "any device subscribed" and flipping off
+  deleted every token in the array — so flipping off on Safari would
+  nuke a Chrome subscription too. Now tracks only the token matching
+  the current browser's FCM registration (persisted in localStorage
+  at subscribe time, cleared at unsubscribe).
+- **FCM current-token detection moved to localStorage.** Deriving
+  "which token is mine?" via a fresh `getToken()` call on every hook
+  re-run hit SW/permission timing edge cases on Chrome (chip
+  disappeared after subscribe). localStorage is per-origin
+  per-browser — exactly the "this device" identity we want — and
+  reads synchronously with no race conditions.
+
+### Fixed
+
+- `data.token` → `data.invitationId` rename on the
+  `invitation-reply` push payload for consistency with the rest of the
+  payload shape. The field has always been the invitation's Firestore
+  doc ID; the legacy name was misleading.
+
+### Infrastructure
+
+- **New Cloud Function module**: `invitationResponseNotify.ts` houses
+  `composeResponseNotification` (pure, 8 unit tests covering fresh
+  yes/no/reason + flips) and `notifyBishopricOfResponse` (the FCM
+  fan-out). `onInvitationWrite` now runs the push alongside the
+  speaker receipt in a `Promise.all`.
+- **SW template** (`public/firebase-messaging-sw.template.js`) grew a
+  `notificationclick` handler with a `data.kind` switch table. Regen
+  script (`scripts/generate-sw.mjs`) picks it up on every build.
+- **Test coverage**: 273 root unit tests (+9 for `deriveDeviceName`)
+  and 88 functions tests (+8 for the response-notification composer
+  + 2 for the response-flip classifier).
+
 ## [0.8.0] — 2026-04-23
 
 A large release that lands the Claude-Design **Profile** and **Ward
@@ -734,7 +820,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/aylabyuk/steward/releases/tag/v0.9.0
 [0.8.0]: https://github.com/aylabyuk/steward/releases/tag/v0.8.0
 [0.7.0]: https://github.com/aylabyuk/steward/releases/tag/v0.7.0
 [0.6.0]: https://github.com/aylabyuk/steward/releases/tag/v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,13 @@ PWA for a ward bishopric to plan weekly sacrament meeting programs. Desktop + mo
 - **SMS + in-app chat**: Twilio Conversations (bridges the speaker's phone SMS and their web invite page into a single thread — speakers can reply from either side)
 - **Lint**: oxlint &nbsp;·&nbsp; **Format**: Biome (formatter mode; linter disabled)
 - **Test**: Vitest + Playwright + `@firebase/rules-unit-testing`, against Firebase Local Emulator Suite
-- **Backend**: six Firebase Cloud Functions — `onMeetingWrite` (change notifications), `scheduledNudges` (finalization cron), `onCommentCreate` (@mention notifications), `sendSpeakerInvitation` (callable: creates invitation + delivers email/SMS + a hashed capability token), `issueSpeakerSession` (callable: exchanges an invitation capability token for a Firebase custom token + Twilio Conversations JWT; self-heals consumed/expired tokens by rotating + resending the SMS), `onTwilioWebhook` (HTTPS: receives Conversations events, fans out FCM to bishopric + email to speaker). No API server beyond these.
+- **Backend**: eight Firebase Cloud Functions — `onMeetingWrite` (change notifications), `scheduledNudges` (finalization cron, hourly), `drainNotificationQueue` (drains the per-ward notification queue once a minute, sends FCM multicasts for due entries), `onCommentCreate` (@mention notifications), `sendSpeakerInvitation` (callable: creates invitation + delivers email/SMS + a hashed capability token), `issueSpeakerSession` (callable: exchanges an invitation capability token for a Firebase custom token + Twilio Conversations JWT; self-heals consumed/expired tokens by rotating + resending the SMS), `onInvitationWrite` (Firestore trigger: fires receipt emails on authoritative response transitions — speaker gets a Yes/No confirmation, bishopric gets an Apply notice), `onTwilioWebhook` (HTTPS: receives Conversations events, fans out FCM to bishopric + email to speaker). No API server beyond these.
 
 ## Hard rules
 
 - **Everything is always editable.** No field locks based on status; status is a label, never a gate. Editing an `approved` program invalidates approvals (logged, not deleted).
 - **Components ≤ 150 LOC.** Enforced by oxlint `max-lines` + `max-lines-per-function` (error, not warn).
-- **Six Cloud Functions, no API server.** The list above is the full surface; expanding it requires a deliberate scope decision. Firestore rules carry the rest of the authorization logic.
+- **Eight Cloud Functions, no API server.** The list above is the full surface; expanding it requires a deliberate scope decision. Firestore rules carry the rest of the authorization logic.
 - **Multi-ward from day one.** All data scoped under `wards/{wardId}/`.
 - **No direct pushes to `develop` or `main`.** Every change flows through a PR: feature branch → PR into `develop` (see the [`feature-branch-workflow`](.claude/skills/feature-branch-workflow.md) skill); releases go via PR from `develop` → `main` (see [`release-to-main`](.claude/skills/release-to-main.md)). GitHub's free tier doesn't enforce this — discipline does. No force-pushes to either branch, ever.
 - **Merge-commit is the only enabled merge method** at the repo level (squash + rebase disabled). Keeps `develop` and `main` SHA-aligned and prevents "N ahead / N behind" drift.
@@ -55,11 +55,15 @@ functions/          # Firebase Cloud Functions
   src/
     onMeetingWrite.ts           # change notifications
     scheduledNudges.ts          # finalization nudges (hourly cron)
+    drainNotificationQueue.ts   # per-ward notification queue drainer (every-minute cron)
     onCommentCreate.ts          # @mention notifications
     sendSpeakerInvitation.ts    # callable: create invitation + deliver via SendGrid + Twilio; issues a hashed capability token
     issueSpeakerSession.ts      # callable: exchange capability token for Firebase custom token + Twilio JWT; self-heals via rotation
+    onInvitationWrite.ts        # Firestore trigger: speaker + bishopric receipt emails on response transitions
     onTwilioWebhook.ts          # HTTPS: Twilio Conversations events → FCM / SendGrid fan-out
     invitationToken.ts          # shared capability-token helpers (generate / hash / timing-safe compare / rotation bucket)
+    invitationDelivery.ts       # shared SMS + email delivery paths (trySms / tryEmail / sendInvitationSms)
+    messageTemplates.ts         # interpolate + readMessageTemplate (falls back to default when doc absent)
     twilio/, sendgrid/          # thin transport wrappers
 ```
 

--- a/functions/src/invitationChange.test.ts
+++ b/functions/src/invitationChange.test.ts
@@ -42,6 +42,24 @@ describe("classifyInvitationChange", () => {
     });
   });
 
+  it("re-fires the speaker receipt when the answer flips yes → no", () => {
+    const before = mk({ response: { answer: "yes" } });
+    const after = mk({ response: { answer: "no", reason: "changed mind" } });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: true,
+      fireBishopric: false,
+    });
+  });
+
+  it("re-fires the speaker receipt when the answer flips no → yes", () => {
+    const before = mk({ response: { answer: "no" } });
+    const after = mk({ response: { answer: "yes" } });
+    expect(classifyInvitationChange(before, after)).toEqual({
+      fireSpeaker: true,
+      fireBishopric: false,
+    });
+  });
+
   it("fires the bishopric receipt when acknowledgedAt appears", () => {
     const before = mk({ response: { answer: "yes" } });
     const after = mk({

--- a/functions/src/invitationChange.ts
+++ b/functions/src/invitationChange.ts
@@ -1,7 +1,7 @@
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface InvitationChange {
-  /** Response just went from absent → present. */
+  /** Response newly set OR flipped to a different answer (yes↔no). */
   fireSpeaker: boolean;
   /** `response.acknowledgedAt` just appeared (Apply was tapped). */
   fireBishopric: boolean;
@@ -11,13 +11,16 @@ export interface InvitationChange {
  *  for a given before/after snapshot of the invitation doc.
  *
  *  - Deletions: no receipts.
- *  - Response newly set (was absent before): speaker receipt.
+ *  - Response newly set OR the answer flipped (yes↔no): speaker receipt.
+ *    We re-fire on a flip so the speaker's inbox reflects their current
+ *    status (an old yes-accepted email would otherwise linger after a
+ *    change of mind) and the bishopric CC keeps a paper trail.
  *  - Acknowledgement newly set: bishopric receipt.
  *  - Other writes (token rotation, heartbeat, delivery record): none.
  *
- *  The "appeared" guard deduplicates retried trigger invocations:
- *  a doc write that already had `response.answer` set will produce
- *  `fireSpeaker=false` on re-fire. */
+ *  Firestore writes settle once per user action, so a legitimate flip
+ *  fires exactly one receipt; re-fires of the same trigger invocation
+ *  still dedupe because `answerBefore === answerAfter` on the re-run. */
 export function classifyInvitationChange(
   before: SpeakerInvitationShape | undefined,
   after: SpeakerInvitationShape | undefined,
@@ -28,7 +31,7 @@ export function classifyInvitationChange(
   const ackBefore = before?.response?.acknowledgedAt;
   const ackAfter = after.response?.acknowledgedAt;
   return {
-    fireSpeaker: !answerBefore && Boolean(answerAfter),
+    fireSpeaker: Boolean(answerAfter) && answerBefore !== answerAfter,
     fireBishopric: !ackBefore && Boolean(ackAfter),
   };
 }

--- a/functions/src/invitationReceiptContent.test.ts
+++ b/functions/src/invitationReceiptContent.test.ts
@@ -57,6 +57,28 @@ describe("buildSpeakerReceipt", () => {
     expect(content.text).toMatch(/Your note: I'm out of town/);
     expect(content.html).toMatch(/I&#39;m out of town/);
   });
+
+  it("renders an invite URL when provided", () => {
+    const url = "https://steward-app.ca/invite/speaker/w1/inv1/tok123";
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+      inviteUrl: url,
+    });
+    expect(content.text).toMatch(
+      new RegExp(`Open your invitation page: ${url.replace(/[/.]/g, "\\$&")}`),
+    );
+    expect(content.html).toMatch(new RegExp(`href="${url.replace(/[/.]/g, "\\$&")}"`));
+  });
+
+  it("omits the invite URL block when not provided", () => {
+    const content = buildSpeakerReceipt({
+      invitation: mk({ response: { answer: "yes" } }),
+      headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
+    });
+    expect(content.text).not.toMatch(/Open your invitation page/);
+    expect(content.html).not.toMatch(/Open your invitation page/);
+  });
 });
 
 describe("buildBishopricReceipt", () => {

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -12,6 +12,10 @@ export interface ReceiptBuildArgs {
    *  `buildBishopricReceipt`. Caller loads the template via
    *  `readMessageTemplate` so builders stay pure. */
   headerTemplate: string;
+  /** Freshly-rotated invite URL for `buildSpeakerReceipt`. Optional —
+   *  rotation can fail, in which case the receipt falls back to the
+   *  no-link shape (the speaker still has the original SMS/email). */
+  inviteUrl?: string;
 }
 
 export interface ReceiptContent {
@@ -51,13 +55,14 @@ function letterText(invitation: SpeakerInvitationShape): string {
   ].join("\n");
 }
 
-/** Email sent to the speaker when their Yes/No first lands on the
- *  invitation doc. Confirms exactly what was recorded; the original
- *  letter is rendered inline for reference. No link is included —
- *  the speaker already has the invite URL in their inbox/SMS, and
- *  rotating a fresh token per receipt would be gratuitous. */
+/** Email sent to the speaker when their Yes/No lands on the invitation
+ *  doc (or flips). Confirms what was recorded and carries a freshly
+ *  rotated invite link so the speaker can reopen the chat even if
+ *  they've deleted the original SMS. `inviteUrl` is optional — if
+ *  rotation failed upstream, the receipt falls back to the no-link
+ *  shape (the original SMS is still a valid entry point). */
 export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
-  const { invitation, headerTemplate } = args;
+  const { invitation, headerTemplate, inviteUrl } = args;
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("speaker receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
@@ -73,6 +78,8 @@ export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
     "",
     invitation.response?.reason ? `Your note: ${invitation.response.reason}` : null,
     invitation.response?.reason ? "" : null,
+    inviteUrl ? `Open your invitation page: ${inviteUrl}` : null,
+    inviteUrl ? "" : null,
     "For reference, the original letter you received:",
     "",
     letterText(invitation),
@@ -88,6 +95,7 @@ ${
     ? `<blockquote style="margin:0 0 16px 0;padding-left:10px;border-left:3px solid #bca788;color:#4a3a30;"><em>${escapeHtml(invitation.response.reason)}</em></blockquote>`
     : ""
 }
+${inviteUrl ? `<p><a href="${inviteUrl}">Open your invitation page</a></p>` : ""}
 <hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
 <p style="color:#666;font-size:12px;margin:0 0 6px 0;">For reference, the original letter you received:</p>
 ${letterHtml(invitation)}

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -18,7 +18,12 @@ export interface ResolvedInvitation extends SpeakerInvitationShape {
 
 /** Speaker posted in the conversation → FCM push to active
  *  bishopric members of the ward. Reuses the quiet-hours + token
- *  pruning helpers that the mention notifications already use. */
+ *  pruning helpers that the mention notifications already use.
+ *
+ *  The payload carries `webpush.fcmOptions.link` so a tap deep-links
+ *  to the speaker's chat dialog on the Schedule page; the SW
+ *  `notificationclick` handler reads the same shape for browsers that
+ *  don't honor `fcmOptions.link` natively. */
 export async function pushToBishopric(inv: ResolvedInvitation, body: string): Promise<void> {
   const db = getFirestore();
   const wardSnap = await db.doc(`wards/${inv.wardId}`).get();
@@ -33,11 +38,14 @@ export async function pushToBishopric(inv: ResolvedInvitation, body: string): Pr
     .filter((c): c is RecipientCandidate => c !== null);
   const recipients = filterRecipients(candidates, { now: new Date(), timezone });
   if (recipients.length === 0) return;
+  const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
+  const link = `${origin}/schedule?chat=${encodeURIComponent(inv.token)}`;
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
   await sendAndPrune(inv.wardId, tokensByUid, {
     notification: { title: `${inv.speakerName} replied`, body: truncate(body, 120) },
-    data: { wardId: inv.wardId, token: inv.token, kind: "invitation-reply" },
+    data: { wardId: inv.wardId, invitationId: inv.token, kind: "invitation-reply" },
+    webpush: { fcmOptions: { link } },
   });
 }
 

--- a/functions/src/invitationResponseNotify.test.ts
+++ b/functions/src/invitationResponseNotify.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { composeResponseNotification } from "./invitationResponseNotify.js";
+
+describe("composeResponseNotification", () => {
+  const base = { speakerName: "Brother Smith", meetingDate: "2026-05-10" } as const;
+
+  it("phrases a fresh Yes with a short date", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "yes",
+    });
+    expect(p.title).toBe("Brother Smith accepted");
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("phrases a fresh No without a reason", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "no",
+    });
+    expect(p.title).toBe("Brother Smith declined");
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("includes the reason when a fresh No has one", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "no",
+      reason: "out of town that weekend",
+    });
+    expect(p.title).toBe("Brother Smith declined");
+    expect(p.body).toBe('"out of town that weekend" — Sun, May 10');
+  });
+
+  it("ignores blank/whitespace-only reasons", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: undefined,
+      nextAnswer: "no",
+      reason: "   ",
+    });
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("phrases a yes → no flip as 'changed response to No'", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: "yes",
+      nextAnswer: "no",
+      reason: "sick",
+    });
+    expect(p.title).toBe("Brother Smith changed response to No");
+    // Flip omits the reason — the title leads with "changed" and the
+    // bishopric already has the prior answer in context.
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("phrases a no → yes flip as 'changed response to Yes'", () => {
+    const p = composeResponseNotification({
+      ...base,
+      prevAnswer: "no",
+      nextAnswer: "yes",
+    });
+    expect(p.title).toBe("Brother Smith changed response to Yes");
+    expect(p.body).toBe("Sun, May 10");
+  });
+
+  it("falls back to the raw meetingDate on an unparseable input", () => {
+    const p = composeResponseNotification({
+      speakerName: "A",
+      meetingDate: "not-a-date",
+      prevAnswer: undefined,
+      nextAnswer: "yes",
+    });
+    expect(p.body).toBe("not-a-date");
+  });
+
+  it("renders the date in UTC so timezone can't skew the weekday", () => {
+    // 2026-05-10 is a Sunday in UTC; we format in UTC to preserve that.
+    const p = composeResponseNotification({
+      speakerName: "A",
+      meetingDate: "2026-05-10",
+      prevAnswer: undefined,
+      nextAnswer: "yes",
+    });
+    expect(p.body).toMatch(/^Sun,/);
+  });
+});

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -64,13 +64,19 @@ function formatShortDate(meetingDate: string): string {
 /** Push-notify every active bishopric member when a speaker submits
  *  or flips their yes/no on the invite page. Speakers themselves
  *  aren't targeted (they're the actor) and clerks are excluded —
- *  only bishopric gets paged on response activity. */
+ *  only bishopric gets paged on response activity.
+ *
+ *  The FCM payload carries `webpush.fcmOptions.link` so a tap routes
+ *  straight to the matching speaker's chat dialog (the SW's
+ *  `notificationclick` handler reads the same shape for browsers that
+ *  don't honor `fcmOptions.link` natively). */
 export async function notifyBishopricOfResponse(
   db: FirebaseFirestore.Firestore,
   wardId: string,
   invitationId: string,
   before: SpeakerInvitationShape | undefined,
   after: SpeakerInvitationShape,
+  origin: string,
 ): Promise<void> {
   const nextAnswer = after.response?.answer;
   if (!nextAnswer) return;
@@ -96,6 +102,7 @@ export async function notifyBishopricOfResponse(
     nextAnswer,
     ...(after.response?.reason ? { reason: after.response.reason } : {}),
   });
+  const link = `${origin.replace(/\/+$/, "")}/schedule?chat=${encodeURIComponent(invitationId)}`;
 
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
@@ -108,6 +115,7 @@ export async function notifyBishopricOfResponse(
         meetingDate: after.speakerRef.meetingDate,
         kind: "invitation-response",
       },
+      webpush: { fcmOptions: { link } },
     });
   } catch (err) {
     logger.error("response push fan-out failed", {

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -1,0 +1,119 @@
+import { logger } from "firebase-functions/v2";
+import { sendAndPrune } from "./fcm.js";
+import { filterRecipients, type RecipientCandidate } from "./recipients.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
+
+export interface ResponseNotification {
+  title: string;
+  body: string;
+}
+
+/** Builds the FCM push payload for a speaker's yes/no response. Pure
+ *  — no Firestore, no I/O — so it can be unit-tested. Caller passes
+ *  the relevant slices of the before/after invitation shape. */
+export function composeResponseNotification(input: {
+  speakerName: string;
+  meetingDate: string;
+  prevAnswer: "yes" | "no" | undefined;
+  nextAnswer: "yes" | "no";
+  reason?: string;
+}): ResponseNotification {
+  const shortDate = formatShortDate(input.meetingDate);
+  const flipped = input.prevAnswer !== undefined && input.prevAnswer !== input.nextAnswer;
+  if (flipped) {
+    const verb = input.nextAnswer === "yes" ? "Yes" : "No";
+    return {
+      title: `${input.speakerName} changed response to ${verb}`,
+      body: shortDate,
+    };
+  }
+  if (input.nextAnswer === "yes") {
+    return {
+      title: `${input.speakerName} accepted`,
+      body: shortDate,
+    };
+  }
+  const reason = input.reason?.trim();
+  if (reason) {
+    return {
+      title: `${input.speakerName} declined`,
+      body: `"${reason}" — ${shortDate}`,
+    };
+  }
+  return {
+    title: `${input.speakerName} declined`,
+    body: shortDate,
+  };
+}
+
+/** "2026-05-10" → "Sun, May 10". Parses at UTC midnight + formats in
+ *  UTC so timezones can't skew the weekday. Falls back to the raw
+ *  string on bad input — not a critical path. */
+function formatShortDate(meetingDate: string): string {
+  const date = new Date(`${meetingDate}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return meetingDate;
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+/** Push-notify every active bishopric member when a speaker submits
+ *  or flips their yes/no on the invite page. Speakers themselves
+ *  aren't targeted (they're the actor) and clerks are excluded —
+ *  only bishopric gets paged on response activity. */
+export async function notifyBishopricOfResponse(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+  invitationId: string,
+  before: SpeakerInvitationShape | undefined,
+  after: SpeakerInvitationShape,
+): Promise<void> {
+  const nextAnswer = after.response?.answer;
+  if (!nextAnswer) return;
+
+  const wardSnap = await db.doc(`wards/${wardId}`).get();
+  const ward = wardSnap.data() as WardDoc | undefined;
+  const timezone = ward?.settings?.timezone ?? "UTC";
+
+  const membersSnap = await db.collection(`wards/${wardId}/members`).get();
+  const candidates: RecipientCandidate[] = membersSnap.docs
+    .map((d) => {
+      const m = d.data() as MemberDoc;
+      return m.role === "bishopric" ? { uid: d.id, member: m } : null;
+    })
+    .filter((c): c is RecipientCandidate => c !== null);
+  const recipients = filterRecipients(candidates, { now: new Date(), timezone });
+  if (recipients.length === 0) return;
+
+  const payload = composeResponseNotification({
+    speakerName: after.speakerName,
+    meetingDate: after.speakerRef.meetingDate,
+    prevAnswer: before?.response?.answer,
+    nextAnswer,
+    ...(after.response?.reason ? { reason: after.response.reason } : {}),
+  });
+
+  const tokensByUid = new Map<string, readonly FcmToken[]>();
+  for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
+  try {
+    await sendAndPrune(wardId, tokensByUid, {
+      notification: payload,
+      data: {
+        wardId,
+        invitationId,
+        meetingDate: after.speakerRef.meetingDate,
+        kind: "invitation-response",
+      },
+    });
+  } catch (err) {
+    logger.error("response push fan-out failed", {
+      wardId,
+      invitationId,
+      err: (err as Error).message,
+    });
+  }
+}

--- a/functions/src/onCommentCreate.ts
+++ b/functions/src/onCommentCreate.ts
@@ -3,6 +3,7 @@ import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { logger } from "firebase-functions/v2";
 import { sendAndPrune } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
+import { STEWARD_ORIGIN } from "./secrets.js";
 import type { CommentDoc, FcmToken, MemberDoc, WardDoc } from "./types.js";
 
 export const onCommentCreate = onDocumentCreated(
@@ -41,12 +42,15 @@ export const onCommentCreate = onDocumentCreated(
       tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
     }
 
+    const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
+    const link = `${origin}/week/${encodeURIComponent(date)}`;
     const outcome = await sendAndPrune(wardId, tokensByUid, {
       notification: {
         title: `${comment.authorDisplayName} mentioned you`,
         body: `On Sunday ${date}: ${truncate(comment.body, 120)}`,
       },
       data: { wardId, date, kind: "mention" },
+      webpush: { fcmOptions: { link } },
     });
 
     logger.info("comment-mention notification sent", {

--- a/functions/src/onInvitationWrite.helpers.ts
+++ b/functions/src/onInvitationWrite.helpers.ts
@@ -1,0 +1,121 @@
+import { logger } from "firebase-functions/v2";
+import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
+import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
+import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
+import { sendEmail } from "./sendgrid/client.js";
+import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import type { MemberDoc } from "./types.js";
+
+export interface BishopricContact {
+  uid: string;
+  email: string;
+  displayName: string;
+}
+
+export async function fetchActiveBishopricEmails(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+): Promise<BishopricContact[]> {
+  const snap = await db.collection(`wards/${wardId}/members`).get();
+  const out: BishopricContact[] = [];
+  for (const d of snap.docs) {
+    const m = d.data() as MemberDoc;
+    if (!m.active) continue;
+    if (m.role !== "bishopric" && m.role !== "clerk") continue;
+    if (!m.email) continue;
+    // Bishopric is always CC'd (non-negotiable — bishopric visibility
+    // on invitation activity is load-bearing). Clerks and secretaries
+    // opt in via `ccOnEmails` (default true for back-compat).
+    if (m.role === "clerk" && m.ccOnEmails === false) continue;
+    out.push({ uid: d.id, email: m.email, displayName: m.displayName });
+  }
+  return out;
+}
+
+export async function sendSpeakerReceipt(
+  invitation: SpeakerInvitationShape,
+  bishopric: BishopricContact[],
+  headerTemplate: string,
+  inviteUrl: string | undefined,
+): Promise<void> {
+  if (!invitation.speakerEmail) {
+    logger.info("speaker receipt skipped — no speakerEmail on invitation", {
+      speakerName: invitation.speakerName,
+    });
+    return;
+  }
+  const content = buildSpeakerReceipt({
+    invitation,
+    headerTemplate,
+    ...(inviteUrl ? { inviteUrl } : {}),
+  });
+  await sendEmail({
+    to: invitation.speakerEmail,
+    fromDisplayName: `${invitation.wardName} (via Steward)`,
+    subject: content.subject,
+    text: content.text,
+    html: content.html,
+    ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
+  });
+}
+
+/** Rotate a fresh capability token for the receipt email's invite
+ *  link. Bishop-origin rotations don't count against the daily cap
+ *  (same rationale as the reply-notify path). Returns `undefined` on
+ *  any failure — the receipt still goes out, just without a link. */
+export async function rotateInviteUrl(
+  wardId: string,
+  invitationId: string,
+  origin: string,
+): Promise<string | undefined> {
+  try {
+    const rotated = await rotateTokenForBishopNotification(wardId, invitationId);
+    if (!rotated) return undefined;
+    return buildInviteUrl(origin, wardId, invitationId, rotated.newToken);
+  } catch (err) {
+    logger.warn("speaker-receipt token rotation failed — sending no-link receipt", {
+      wardId,
+      invitationId,
+      err: (err as Error).message,
+    });
+    return undefined;
+  }
+}
+
+export async function sendBishopricReceipt(
+  invitation: SpeakerInvitationShape,
+  bishopric: BishopricContact[],
+  ctx: { wardId: string; invitationId: string; origin: string; headerTemplate: string },
+): Promise<void> {
+  if (bishopric.length === 0) {
+    logger.warn("bishopric receipt skipped — no bishopric emails found", { wardId: ctx.wardId });
+    return;
+  }
+  const acknowledgedByName = bishopric.find(
+    (b) => b.uid === invitation.response?.acknowledgedBy,
+  )?.displayName;
+  const respondedAt = invitation.response?.respondedAt?.toDate();
+  const origin = ctx.origin.replace(/\/+$/, "");
+  const bishopricViewUrl = `${origin}/ward/${ctx.wardId}/invitations/${ctx.invitationId}/view`;
+  const content = buildBishopricReceipt({
+    invitation,
+    bishopricViewUrl,
+    acknowledgedByName,
+    respondedAt,
+    headerTemplate: ctx.headerTemplate,
+  });
+  // Send individually rather than via CC: the bishopric list can be 3-7
+  // people and individual sends give SendGrid cleaner bounce handling
+  // per recipient.
+  await Promise.all(
+    bishopric.map((b) =>
+      sendEmail({
+        to: b.email,
+        fromDisplayName: `Steward`,
+        subject: content.subject,
+        text: content.text,
+        html: content.html,
+      }),
+    ),
+  );
+}

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -46,7 +46,7 @@ export const onInvitationWrite = onDocumentWritten(
         ]);
         await Promise.all([
           sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl),
-          notifyBishopricOfResponse(db, wardId, invitationId, before, after),
+          notifyBishopricOfResponse(db, wardId, invitationId, before, after, origin),
         ]);
       }
       if (change.fireBishopric) {

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -2,6 +2,7 @@ import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
 import { classifyInvitationChange } from "./invitationChange.js";
+import { notifyBishopricOfResponse } from "./invitationResponseNotify.js";
 import { readMessageTemplate } from "./messageTemplates.js";
 import {
   fetchActiveBishopricEmails,
@@ -43,7 +44,10 @@ export const onInvitationWrite = onDocumentWritten(
           readMessageTemplate(db, wardId, key),
           rotateInviteUrl(wardId, invitationId, origin),
         ]);
-        await sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl);
+        await Promise.all([
+          sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl),
+          notifyBishopricOfResponse(db, wardId, invitationId, before, after),
+        ]);
       }
       if (change.fireBishopric) {
         const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -1,22 +1,27 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onDocumentWritten } from "firebase-functions/v2/firestore";
-import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
 import { classifyInvitationChange } from "./invitationChange.js";
 import { readMessageTemplate } from "./messageTemplates.js";
+import {
+  fetchActiveBishopricEmails,
+  rotateInviteUrl,
+  sendBishopricReceipt,
+  sendSpeakerReceipt,
+} from "./onInvitationWrite.helpers.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
-import { sendEmail } from "./sendgrid/client.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
-import type { MemberDoc } from "./types.js";
 
 /** Fires receipt emails on authoritative response transitions:
- *   - `response.answer` appears → speaker receipt (to speaker, CC bishopric)
+ *   - `response.answer` appears or flips → speaker receipt (to speaker,
+ *      CC bishopric) with a freshly-rotated invite link so they can
+ *      reopen the chat even if the original SMS has been deleted.
  *   - `response.acknowledgedAt` appears → bishopric receipt (to bishopric)
  *
  *  Other writes (token rotation, delivery-record updates, heartbeats)
  *  are classified as no-ops and return early. The receipts contain the
  *  original letter inline so the email itself is the archive — no
- *  external dependency on the invite URL or the app being reachable. */
+ *  external dependency on the app being reachable. */
 export const onInvitationWrite = onDocumentWritten(
   "wards/{wardId}/speakerInvitations/{invitationId}",
   async (event) => {
@@ -28,16 +33,19 @@ export const onInvitationWrite = onDocumentWritten(
 
     const { wardId, invitationId } = event.params;
     const db = getFirestore();
+    const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
     try {
       const bishopric = await fetchActiveBishopricEmails(db, wardId);
       if (change.fireSpeaker) {
         const answer = after.response?.answer;
         const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
-        const headerTemplate = await readMessageTemplate(db, wardId, key);
-        await sendSpeakerReceipt(after, bishopric, headerTemplate);
+        const [headerTemplate, inviteUrl] = await Promise.all([
+          readMessageTemplate(db, wardId, key),
+          rotateInviteUrl(wardId, invitationId, origin),
+        ]);
+        await sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl);
       }
       if (change.fireBishopric) {
-        const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
         const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");
         await sendBishopricReceipt(after, bishopric, {
           wardId,
@@ -55,89 +63,3 @@ export const onInvitationWrite = onDocumentWritten(
     }
   },
 );
-
-interface BishopricContact {
-  uid: string;
-  email: string;
-  displayName: string;
-}
-
-async function fetchActiveBishopricEmails(
-  db: FirebaseFirestore.Firestore,
-  wardId: string,
-): Promise<BishopricContact[]> {
-  const snap = await db.collection(`wards/${wardId}/members`).get();
-  const out: BishopricContact[] = [];
-  for (const d of snap.docs) {
-    const m = d.data() as MemberDoc;
-    if (!m.active) continue;
-    if (m.role !== "bishopric" && m.role !== "clerk") continue;
-    if (!m.email) continue;
-    // Bishopric is always CC'd (non-negotiable — bishopric visibility
-    // on invitation activity is load-bearing). Clerks and secretaries
-    // opt in via `ccOnEmails` (default true for back-compat).
-    if (m.role === "clerk" && m.ccOnEmails === false) continue;
-    out.push({ uid: d.id, email: m.email, displayName: m.displayName });
-  }
-  return out;
-}
-
-async function sendSpeakerReceipt(
-  invitation: SpeakerInvitationShape,
-  bishopric: BishopricContact[],
-  headerTemplate: string,
-): Promise<void> {
-  if (!invitation.speakerEmail) {
-    logger.info("speaker receipt skipped — no speakerEmail on invitation", {
-      speakerName: invitation.speakerName,
-    });
-    return;
-  }
-  const content = buildSpeakerReceipt({ invitation, headerTemplate });
-  await sendEmail({
-    to: invitation.speakerEmail,
-    fromDisplayName: `${invitation.wardName} (via Steward)`,
-    subject: content.subject,
-    text: content.text,
-    html: content.html,
-    ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
-  });
-}
-
-async function sendBishopricReceipt(
-  invitation: SpeakerInvitationShape,
-  bishopric: BishopricContact[],
-  ctx: { wardId: string; invitationId: string; origin: string; headerTemplate: string },
-): Promise<void> {
-  if (bishopric.length === 0) {
-    logger.warn("bishopric receipt skipped — no bishopric emails found", { wardId: ctx.wardId });
-    return;
-  }
-  const acknowledgedByName = bishopric.find(
-    (b) => b.uid === invitation.response?.acknowledgedBy,
-  )?.displayName;
-  const respondedAt = invitation.response?.respondedAt?.toDate();
-  const origin = ctx.origin.replace(/\/+$/, "");
-  const bishopricViewUrl = `${origin}/ward/${ctx.wardId}/invitations/${ctx.invitationId}/view`;
-  const content = buildBishopricReceipt({
-    invitation,
-    bishopricViewUrl,
-    acknowledgedByName,
-    respondedAt,
-    headerTemplate: ctx.headerTemplate,
-  });
-  // Send individually rather than via CC: the bishopric list can be 3-7
-  // people and individual sends give SendGrid cleaner bounce handling
-  // per recipient.
-  await Promise.all(
-    bishopric.map((b) =>
-      sendEmail({
-        to: b.email,
-        fromDisplayName: `Steward`,
-        subject: content.subject,
-        text: content.text,
-        html: content.html,
-      }),
-    ),
-  );
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/public/firebase-messaging-sw.template.js
+++ b/public/firebase-messaging-sw.template.js
@@ -31,3 +31,47 @@ messaging.onBackgroundMessage((payload) => {
     data: payload.data ?? {},
   });
 });
+
+/** Deep-link a notification tap into the matching in-app surface.
+ *  Keep the `data.kind` map here in sync with the FCM payloads in
+ *  functions/src/ (invitationResponseNotify, invitationReplyNotify,
+ *  onCommentCreate). If an existing tab is already on our origin we
+ *  focus + navigate that one; otherwise we open a new window. */
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = routeForPushData(event.notification.data);
+  if (!url) return;
+  event.waitUntil(focusOrOpen(url));
+});
+
+function routeForPushData(data) {
+  if (!data || typeof data !== "object") return "/";
+  switch (data.kind) {
+    case "invitation-response":
+    case "invitation-reply":
+      return data.invitationId
+        ? `/schedule?chat=${encodeURIComponent(data.invitationId)}`
+        : "/schedule";
+    case "mention":
+      return data.date ? `/week/${encodeURIComponent(data.date)}` : "/schedule";
+    default:
+      return "/";
+  }
+}
+
+async function focusOrOpen(url) {
+  const target = new URL(url, self.location.origin).href;
+  const clients = await self.clients.matchAll({ type: "window", includeUncontrolled: true });
+  for (const client of clients) {
+    if (!client.url.startsWith(self.location.origin)) continue;
+    if ("navigate" in client) {
+      try {
+        await client.navigate(target);
+      } catch {
+        // Some browsers reject cross-origin navigate; fall through to focus-only.
+      }
+    }
+    return client.focus();
+  }
+  return self.clients.openWindow(target);
+}

--- a/src/features/notifications/deriveDeviceName.test.ts
+++ b/src/features/notifications/deriveDeviceName.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { deriveDeviceName, type NavigatorLike } from "./deriveDeviceName";
+
+describe("deriveDeviceName — UA-CH (Chromium) path", () => {
+  it("recognizes Chrome on macOS from userAgentData", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36",
+      userAgentData: {
+        brands: [
+          { brand: "Google Chrome", version: "129" },
+          { brand: "Chromium", version: "129" },
+          { brand: "Not.A/Brand", version: "99" },
+        ],
+        platform: "macOS",
+        mobile: false,
+      },
+    };
+    expect(deriveDeviceName(nav)).toBe("Chrome · macOS");
+  });
+
+  it("prefers Microsoft Edge over Chromium when both brands are present", () => {
+    const nav: NavigatorLike = {
+      userAgent: "Mozilla/5.0 … Edg/130.0.0.0",
+      userAgentData: {
+        brands: [
+          { brand: "Chromium", version: "130" },
+          { brand: "Not.A/Brand", version: "99" },
+          { brand: "Microsoft Edge", version: "130" },
+        ],
+        platform: "Windows",
+      },
+    };
+    expect(deriveDeviceName(nav)).toBe("Microsoft Edge · Windows");
+  });
+
+  it("recognizes Chrome on Android", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/129.0.0.0 Mobile Safari/537.36",
+      userAgentData: {
+        brands: [{ brand: "Google Chrome", version: "129" }],
+        platform: "Android",
+        mobile: true,
+      },
+    };
+    expect(deriveDeviceName(nav)).toBe("Chrome · Android");
+  });
+
+  it("skips filler brands like Not.A/Brand when picking the browser name", () => {
+    const nav: NavigatorLike = {
+      userAgent: "Mozilla/5.0 …",
+      userAgentData: {
+        brands: [{ brand: "Not.A/Brand", version: "99" }],
+        platform: "Linux",
+      },
+    };
+    // With no real brand name, falls back to UA string — which has nothing either, so "Browser".
+    expect(deriveDeviceName(nav)).toBe("Browser · Linux");
+  });
+});
+
+describe("deriveDeviceName — legacy UA fallback", () => {
+  it("recognizes Safari on iOS", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+    };
+    expect(deriveDeviceName(nav)).toBe("Safari · iOS");
+  });
+
+  it("recognizes Firefox on Windows", () => {
+    const nav: NavigatorLike = {
+      userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:130.0) Gecko/20100101 Firefox/130.0",
+    };
+    expect(deriveDeviceName(nav)).toBe("Firefox · Windows");
+  });
+
+  it("recognizes Safari on macOS (not the also-present Chrome token)", () => {
+    // Apple's Safari UA includes "Safari/…" but not "Chrome/…"
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15",
+    };
+    expect(deriveDeviceName(nav)).toBe("Safari · macOS");
+  });
+
+  it("recognizes iPad as iOS", () => {
+    const nav: NavigatorLike = {
+      userAgent:
+        "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+    };
+    expect(deriveDeviceName(nav)).toBe("Safari · iOS");
+  });
+
+  it("falls back to Browser · Unknown when nothing matches", () => {
+    const nav: NavigatorLike = { userAgent: "SomeCustomAgent/1.0" };
+    expect(deriveDeviceName(nav)).toBe("Browser · Unknown");
+  });
+});

--- a/src/features/notifications/deriveDeviceName.ts
+++ b/src/features/notifications/deriveDeviceName.ts
@@ -1,0 +1,65 @@
+/** Browsers expose `navigator.userAgentData` (Chromium) and/or the
+ *  legacy `navigator.userAgent` string. Both are lies — the UA string
+ *  is spoofable and Apple/Firefox don't yet ship UA-CH. This parser
+ *  produces a friendly `{browser} · {os}` label with reasonable
+ *  fallbacks; it's display-only, never used for feature-gating. */
+
+interface UaBrand {
+  brand: string;
+  version: string;
+}
+
+export interface NavigatorLike {
+  userAgent: string;
+  userAgentData?: {
+    brands?: UaBrand[];
+    platform?: string;
+    mobile?: boolean;
+  };
+}
+
+export function deriveDeviceName(nav: NavigatorLike): string {
+  const browser = detectBrowser(nav);
+  const os = detectOs(nav);
+  return `${browser} · ${os}`;
+}
+
+function detectBrowser(nav: NavigatorLike): string {
+  const brands = nav.userAgentData?.brands;
+  if (brands && brands.length > 0) {
+    // Prefer real brand names over filler ("Not.A/Brand") and the
+    // Chromium base. Edge and Opera ship both their own brand and
+    // Chromium, so iteration order matters.
+    const preferred = ["Microsoft Edge", "Opera", "Google Chrome", "Chromium"];
+    for (const name of preferred) {
+      if (brands.some((b) => b.brand === name)) return name === "Google Chrome" ? "Chrome" : name;
+    }
+  }
+  const ua = nav.userAgent;
+  if (/Edg\//.test(ua)) return "Microsoft Edge";
+  if (/OPR\//.test(ua)) return "Opera";
+  if (/Firefox\//.test(ua)) return "Firefox";
+  if (/Chrome\//.test(ua)) return "Chrome";
+  if (/Safari\//.test(ua)) return "Safari";
+  return "Browser";
+}
+
+function detectOs(nav: NavigatorLike): string {
+  const platform = nav.userAgentData?.platform;
+  if (platform) {
+    // UA-CH returns "macOS", "Windows", "Linux", "Android", "ChromeOS", etc.
+    if (platform === "macOS") return "macOS";
+    if (platform === "Windows") return "Windows";
+    if (platform === "Android") return "Android";
+    if (platform === "Chrome OS" || platform === "ChromeOS") return "ChromeOS";
+    if (platform === "Linux") return "Linux";
+  }
+  const ua = nav.userAgent;
+  if (/iPhone|iPad|iPod/.test(ua)) return "iOS";
+  if (/Android/.test(ua)) return "Android";
+  if (/Mac OS X|Macintosh/.test(ua)) return "macOS";
+  if (/Windows/.test(ua)) return "Windows";
+  if (/CrOS/.test(ua)) return "ChromeOS";
+  if (/Linux/.test(ua)) return "Linux";
+  return "Unknown";
+}

--- a/src/features/notifications/fcmToken.ts
+++ b/src/features/notifications/fcmToken.ts
@@ -8,12 +8,14 @@ import {
 } from "firebase/firestore";
 import { deleteToken, getToken } from "firebase/messaging";
 import { db, getMessagingIfSupported } from "@/lib/firebase";
+import { deriveDeviceName } from "./deriveDeviceName";
 
 const SW_PATH = "/firebase-messaging-sw.js";
 
 export interface SubscribeResult {
   token: string;
   platform: "web" | "ios" | "android";
+  name: string;
 }
 
 function detectPlatform(): "web" | "ios" | "android" {
@@ -59,14 +61,36 @@ export async function subscribeDevice(input: {
   if (!token) return null;
 
   const platform = detectPlatform();
+  const name = deriveDeviceName(navigator as unknown as Parameters<typeof deriveDeviceName>[0]);
   // serverTimestamp() can't ride inside arrayUnion (Firestore rejects sentinel
   // values nested in arrays), so we stamp client-side. The doc-level
   // updatedAt below is still server-authoritative.
   await updateDoc(doc(db, "wards", input.wardId, "members", input.uid), {
-    fcmTokens: arrayUnion({ token, platform, updatedAt: Timestamp.now() }),
+    fcmTokens: arrayUnion({ token, platform, name, updatedAt: Timestamp.now() }),
     updatedAt: serverTimestamp(),
   });
-  return { token, platform };
+  return { token, platform, name };
+}
+
+/** Returns the FCM token registered on this device *right now*, if
+ *  any. Used by the Profile page to flag the matching `fcmTokens[]`
+ *  row with a "This device" chip. Silent-returns null when messaging
+ *  isn't supported, permission hasn't been granted, or no SW exists. */
+export async function readCurrentDeviceToken(): Promise<string | null> {
+  const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
+  if (!vapidKey) return null;
+  const messaging = await getMessagingIfSupported();
+  if (!messaging) return null;
+  if (typeof Notification === "undefined" || Notification.permission !== "granted") return null;
+  if (!("serviceWorker" in navigator)) return null;
+  const swReg = await navigator.serviceWorker.getRegistration(SW_PATH);
+  if (!swReg) return null;
+  try {
+    const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: swReg });
+    return token || null;
+  } catch {
+    return null;
+  }
 }
 
 export async function unsubscribeDevice(input: {

--- a/src/features/notifications/fcmToken.ts
+++ b/src/features/notifications/fcmToken.ts
@@ -12,6 +12,37 @@ import { deriveDeviceName } from "./deriveDeviceName";
 
 const SW_PATH = "/firebase-messaging-sw.js";
 
+/** localStorage key for "the FCM token subscribed on THIS browser/PWA".
+ *  Read on mount by the Profile page to flag the matching fcmTokens[]
+ *  row with a "This device" chip. localStorage is per-origin
+ *  per-browser, so the match is exactly "this device" — no async FCM
+ *  lookups or SW timing guesswork. */
+const CURRENT_TOKEN_KEY = "steward:fcmToken:current";
+
+function rememberCurrentToken(token: string): void {
+  try {
+    localStorage.setItem(CURRENT_TOKEN_KEY, token);
+  } catch {
+    /* private-mode or disabled storage — chip won't light up, not fatal */
+  }
+}
+
+function forgetCurrentToken(): void {
+  try {
+    localStorage.removeItem(CURRENT_TOKEN_KEY);
+  } catch {
+    /* ignore */
+  }
+}
+
+export function readCurrentDeviceToken(): string | null {
+  try {
+    return localStorage.getItem(CURRENT_TOKEN_KEY);
+  } catch {
+    return null;
+  }
+}
+
 export interface SubscribeResult {
   token: string;
   platform: "web" | "ios" | "android";
@@ -69,28 +100,8 @@ export async function subscribeDevice(input: {
     fcmTokens: arrayUnion({ token, platform, name, updatedAt: Timestamp.now() }),
     updatedAt: serverTimestamp(),
   });
+  rememberCurrentToken(token);
   return { token, platform, name };
-}
-
-/** Returns the FCM token registered on this device *right now*, if
- *  any. Used by the Profile page to flag the matching `fcmTokens[]`
- *  row with a "This device" chip. Silent-returns null when messaging
- *  isn't supported, permission hasn't been granted, or no SW exists. */
-export async function readCurrentDeviceToken(): Promise<string | null> {
-  const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
-  if (!vapidKey) return null;
-  const messaging = await getMessagingIfSupported();
-  if (!messaging) return null;
-  if (typeof Notification === "undefined" || Notification.permission !== "granted") return null;
-  if (!("serviceWorker" in navigator)) return null;
-  const swReg = await navigator.serviceWorker.getRegistration(SW_PATH);
-  if (!swReg) return null;
-  try {
-    const token = await getToken(messaging, { vapidKey, serviceWorkerRegistration: swReg });
-    return token || null;
-  } catch {
-    return null;
-  }
 }
 
 export async function unsubscribeDevice(input: {
@@ -110,4 +121,5 @@ export async function unsubscribeDevice(input: {
     fcmTokens: arrayRemove(input.token),
     updatedAt: serverTimestamp(),
   });
+  if (readCurrentDeviceToken() === input.token.token) forgetCurrentToken();
 }

--- a/src/features/notifications/useCurrentDeviceToken.ts
+++ b/src/features/notifications/useCurrentDeviceToken.ts
@@ -1,23 +1,15 @@
 import { useEffect, useState } from "react";
 import { readCurrentDeviceToken } from "./fcmToken";
 
-/** Resolves the FCM token registered on this browser/PWA right now.
- *  Returns null while pending, or if no token is registered (permission
- *  denied, SW not installed, etc). The `tokens` input re-triggers the
- *  lookup after subscribe/unsubscribe so the "This device" chip can
- *  follow state changes. */
+/** The FCM token subscribed on THIS browser/PWA (persisted in
+ *  localStorage at subscribe time). Used by the Profile page to flag
+ *  the matching `fcmTokens[]` row with a "This device" chip. The
+ *  `tokens` dep re-reads after subscribe/unsubscribe so the chip
+ *  follows state changes without a page reload. */
 export function useCurrentDeviceToken(tokens: readonly { token: string }[]): string | null {
-  const [current, setCurrent] = useState<string | null>(null);
+  const [current, setCurrent] = useState<string | null>(() => readCurrentDeviceToken());
   useEffect(() => {
-    let cancelled = false;
-    void readCurrentDeviceToken().then((token) => {
-      if (!cancelled) setCurrent(token);
-    });
-    return () => {
-      cancelled = true;
-    };
-    // Re-run when the token set changes — after subscribe, the new token
-    // is in `tokens` and we want the chip to light up without a reload.
+    setCurrent(readCurrentDeviceToken());
   }, [tokens]);
   return current;
 }

--- a/src/features/notifications/useCurrentDeviceToken.ts
+++ b/src/features/notifications/useCurrentDeviceToken.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+import { readCurrentDeviceToken } from "./fcmToken";
+
+/** Resolves the FCM token registered on this browser/PWA right now.
+ *  Returns null while pending, or if no token is registered (permission
+ *  denied, SW not installed, etc). The `tokens` input re-triggers the
+ *  lookup after subscribe/unsubscribe so the "This device" chip can
+ *  follow state changes. */
+export function useCurrentDeviceToken(tokens: readonly { token: string }[]): string | null {
+  const [current, setCurrent] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    void readCurrentDeviceToken().then((token) => {
+      if (!cancelled) setCurrent(token);
+    });
+    return () => {
+      cancelled = true;
+    };
+    // Re-run when the token set changes — after subscribe, the new token
+    // is in `tokens` and we want the chip to light up without a reload.
+  }, [tokens]);
+  return current;
+}

--- a/src/features/profile/DeviceRow.tsx
+++ b/src/features/profile/DeviceRow.tsx
@@ -3,6 +3,7 @@ import type { FcmToken } from "@/lib/types";
 
 interface Props {
   token: FcmToken;
+  isCurrentDevice: boolean;
   busy: boolean;
   onRemove: () => void;
 }
@@ -20,19 +21,25 @@ function formatAddedAt(at: unknown): string {
   return "—";
 }
 
-/** Single row in the Subscribed devices list: icon + platform name +
- *  added-date, with a Remove button. Per-device naming + "This
- *  device" chip are deferred — see the follow-up issue filed with
- *  this PR. */
-export function DeviceRow({ token, busy, onRemove }: Props): React.ReactElement {
+/** Single row in the Subscribed devices list: icon + friendly name +
+ *  added-date, with a Remove button. The row the user is reading on
+ *  right now gets a "This device" chip. Legacy tokens without a
+ *  `name` fall back to the bare platform label. */
+export function DeviceRow({ token, isCurrentDevice, busy, onRemove }: Props): React.ReactElement {
+  const label = token.name ?? PLATFORM_LABELS[token.platform];
   return (
     <li className="grid grid-cols-[38px_1fr_auto] items-center gap-3.5 px-3.5 py-2.5 bg-parchment border border-border rounded-lg">
       <span className="inline-flex items-center justify-center w-8 h-8 bg-chalk border border-border rounded-md text-walnut-2">
         <DeviceIcon platform={token.platform} />
       </span>
       <div className="min-w-0">
-        <div className="font-sans text-[14px] font-semibold text-walnut">
-          {PLATFORM_LABELS[token.platform]}
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="font-sans text-[14px] font-semibold text-walnut truncate">{label}</span>
+          {isCurrentDevice && (
+            <span className="shrink-0 font-mono text-[10px] uppercase tracking-[0.12em] text-brass-deep bg-chalk border border-border-strong px-1.5 py-0.5 rounded">
+              This device
+            </span>
+          )}
         </div>
         <div className="font-mono text-[11px] text-walnut-3 mt-0.5">
           Added {formatAddedAt(token.updatedAt)}

--- a/src/features/profile/NotificationsSection.tsx
+++ b/src/features/profile/NotificationsSection.tsx
@@ -29,7 +29,10 @@ export function NotificationsSection({
   const [error, setError] = useState<string | null>(null);
   const currentToken = useCurrentDeviceToken(tokens);
 
-  const deviceSubscribed = tokens.length > 0;
+  // Scope the push toggle to *this* device so flipping off on Safari
+  // can't nuke a token registered on a different browser/OS.
+  const thisDeviceEntry = currentToken ? tokens.find((t) => t.token === currentToken) : undefined;
+  const deviceSubscribed = thisDeviceEntry !== undefined;
 
   async function togglePush(next: boolean) {
     setBusy("subscribe");
@@ -40,10 +43,8 @@ export function NotificationsSection({
         if (!result) {
           setError("Enable notifications in your browser or OS, then try again.");
         }
-      } else {
-        for (const t of tokens) {
-          await unsubscribeDevice({ wardId, uid, token: t });
-        }
+      } else if (thisDeviceEntry) {
+        await unsubscribeDevice({ wardId, uid, token: thisDeviceEntry });
       }
     } catch (e) {
       setError((e as Error).message);

--- a/src/features/profile/NotificationsSection.tsx
+++ b/src/features/profile/NotificationsSection.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { subscribeDevice, unsubscribeDevice } from "@/features/notifications/fcmToken";
+import { useCurrentDeviceToken } from "@/features/notifications/useCurrentDeviceToken";
 import type { FcmToken, NotificationPrefs } from "@/lib/types";
 import { CategoryRowsComingSoon, DigestSelectComingSoon } from "./ComingSoonRows";
 import { DeviceRow } from "./DeviceRow";
@@ -26,6 +27,7 @@ export function NotificationsSection({
 }: Props): React.ReactElement {
   const [busy, setBusy] = useState<string | "subscribe" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const currentToken = useCurrentDeviceToken(tokens);
 
   const deviceSubscribed = tokens.length > 0;
 
@@ -109,6 +111,7 @@ export function NotificationsSection({
               <DeviceRow
                 key={t.token}
                 token={t}
+                isCurrentDevice={t.token === currentToken}
                 busy={busy === t.token}
                 onRemove={() => void removeOne(t)}
               />

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
 import { BishopInvitationDialog } from "@/features/invitations/BishopInvitationDialog";
 import { useConversationUnread } from "@/features/invitations/useConversationUnread";
 import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
@@ -38,6 +39,21 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
   const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
   const members = useWardMembers();
   const provenance = statusProvenanceLabel(speaker, members);
+
+  // Auto-open the dialog when a push notification deep-links us here
+  // via `?chat=<invitationId>`. Each row checks independently — only
+  // the matching one opens + clears the query. Invitation loads async,
+  // so we can't check until it arrives.
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    if (!invitation) return;
+    const target = searchParams.get("chat");
+    if (!target || target !== invitation.invitationId) return;
+    setOpen(true);
+    const next = new URLSearchParams(searchParams);
+    next.delete("chat");
+    setSearchParams(next, { replace: true });
+  }, [invitation, searchParams, setSearchParams]);
 
   return (
     <li className="flex items-center gap-3 py-3 border-b border-border last:border-b-0">

--- a/src/lib/types/member.ts
+++ b/src/lib/types/member.ts
@@ -26,6 +26,10 @@ export function callingToRole(calling: Calling): Role {
 export const fcmTokenSchema = z.object({
   token: z.string().min(1),
   platform: z.enum(["web", "ios", "android"]).default("web"),
+  /** Friendly browser+OS label derived at subscribe time (e.g.
+   *  "Chrome · macOS"). Optional so legacy entries without a name
+   *  still validate; UI renders the platform label as a fallback. */
+  name: z.string().optional(),
   updatedAt: z.any(),
 });
 export type FcmToken = z.infer<typeof fcmTokenSchema>;


### PR DESCRIPTION
Release v0.9.0. Full changelog: https://github.com/aylabyuk/steward/blob/develop/CHANGELOG.md#090--2026-04-23

## Highlights

- **Bishopric gets a push when a speaker responds** (#17) — not just an email. Yes / No / flip phrasing built in, clerks and the speaker excluded, quiet hours honored.
- **Tap-through deep-linking** (#68) — notifications open the right surface (speaker chat dialog for invitation pushes, week view for mentions) instead of dumping the user at `/`. Two layers: SW `notificationclick` handler + `webpush.fcmOptions.link`.
- **Receipt follow-ups** (#46, #47) — email re-fires on a yes↔no flip; carries a freshly-rotated invite link so the speaker can reopen the chat from the receipt.
- **Per-device names + "This device" chip** (#53) on `/settings/profile`. UA parser + persistent localStorage identity for the current device.
- **Push toggle scope fix** — flipping off on Safari no longer nukes Chrome's subscription (#65/#66).

## Test plan

- [x] `pnpm run test:all` passes (273 root unit + 88 functions + rules green on develop)
- [x] CI green on develop (release-prep commit)
- [ ] Manual: speaker responds → bishop's phone pings, tap opens the chat dialog for that speaker
- [ ] Manual: Chrome subscribe → chip lights on Chrome row, Safari switch stays off

## Post-merge

- [ ] Tag `v0.9.0` on the merge commit + publish GitHub Release
- [ ] Deploy Firestore rules to prod (no rule changes in this window; confirm + deploy anyway)
- [ ] Deploy Cloud Functions to prod (functions/ changed: `invitationResponseNotify.ts` new, `invitationReplyNotify.ts` + `onCommentCreate.ts` updated, `onInvitationWrite.ts` threads origin)
- [ ] Regenerate `firebase-messaging-sw.js` on Vercel build (happens automatically in CI)
- [ ] Smoke-test prod