### PR TITLE
Release: v0.9.1 — restore speaker's original SMS link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.1] — 2026-04-23
+
+Hotfix for a regression v0.9.0 inherited from #46: eagerly rotating
+the capability token when a speaker submitted Yes/No broke the
+speaker's original SMS link. Reopening it showed "link has expired"
+because the stored hash had been overwritten by the receipt-email's
+fresh token. Real bishops testing prod hit this on the first
+end-to-end run.
+
+### Fixed
+
+- **Speaker receipt no longer rotates the capability token** (#73).
+  `onInvitationWrite` stops calling `rotateInviteUrl` in the
+  `fireSpeaker` branch; the receipt email goes out without an invite
+  URL. The speaker's SMS stays the canonical entry point — if they
+  consume it and come back, `decideTokenAction`'s pre-existing
+  rotate branch self-heals with a fresh SMS, which was the v0.8.0
+  behavior and the one that actually works.
+
+### Removed
+
+- `rotateInviteUrl` helper in `onInvitationWrite.helpers.ts` and the
+  `inviteUrl` arg on `buildSpeakerReceipt`. Dead after the revert —
+  the #46 "receipt has a working link" feature went with them.
+
 ## [0.9.0] — 2026-04-23
 
 Push-notification depth: bishopric members now get a push the moment a
@@ -820,7 +845,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.1...HEAD
+[0.9.1]: https://github.com/aylabyuk/steward/releases/tag/v0.9.1
 [0.9.0]: https://github.com/aylabyuk/steward/releases/tag/v0.9.0
 [0.8.0]: https://github.com/aylabyuk/steward/releases/tag/v0.8.0
 [0.7.0]: https://github.com/aylabyuk/steward/releases/tag/v0.7.0

--- a/functions/src/invitationReceiptContent.test.ts
+++ b/functions/src/invitationReceiptContent.test.ts
@@ -58,20 +58,7 @@ describe("buildSpeakerReceipt", () => {
     expect(content.html).toMatch(/I&#39;m out of town/);
   });
 
-  it("renders an invite URL when provided", () => {
-    const url = "https://steward-app.ca/invite/speaker/w1/inv1/tok123";
-    const content = buildSpeakerReceipt({
-      invitation: mk({ response: { answer: "yes" } }),
-      headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
-      inviteUrl: url,
-    });
-    expect(content.text).toMatch(
-      new RegExp(`Open your invitation page: ${url.replace(/[/.]/g, "\\$&")}`),
-    );
-    expect(content.html).toMatch(new RegExp(`href="${url.replace(/[/.]/g, "\\$&")}"`));
-  });
-
-  it("omits the invite URL block when not provided", () => {
+  it("does not embed an invite URL — the SMS stays canonical (#73)", () => {
     const content = buildSpeakerReceipt({
       invitation: mk({ response: { answer: "yes" } }),
       headerTemplate: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -12,10 +12,6 @@ export interface ReceiptBuildArgs {
    *  `buildBishopricReceipt`. Caller loads the template via
    *  `readMessageTemplate` so builders stay pure. */
   headerTemplate: string;
-  /** Freshly-rotated invite URL for `buildSpeakerReceipt`. Optional —
-   *  rotation can fail, in which case the receipt falls back to the
-   *  no-link shape (the speaker still has the original SMS/email). */
-  inviteUrl?: string;
 }
 
 export interface ReceiptContent {
@@ -56,13 +52,14 @@ function letterText(invitation: SpeakerInvitationShape): string {
 }
 
 /** Email sent to the speaker when their Yes/No lands on the invitation
- *  doc (or flips). Confirms what was recorded and carries a freshly
- *  rotated invite link so the speaker can reopen the chat even if
- *  they've deleted the original SMS. `inviteUrl` is optional — if
- *  rotation failed upstream, the receipt falls back to the no-link
- *  shape (the original SMS is still a valid entry point). */
+ *  doc (or flips). Confirms what was recorded; the original letter is
+ *  rendered inline for reference. No invite link — embedding one would
+ *  require rotating the capability token, which invalidates the
+ *  speaker's original SMS link (see #73). The SMS stays canonical; if
+ *  the speaker reopens a consumed link, `decideTokenAction` rotates
+ *  on demand and texts them a fresh URL. */
 export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
-  const { invitation, headerTemplate, inviteUrl } = args;
+  const { invitation, headerTemplate } = args;
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("speaker receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
@@ -78,8 +75,6 @@ export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
     "",
     invitation.response?.reason ? `Your note: ${invitation.response.reason}` : null,
     invitation.response?.reason ? "" : null,
-    inviteUrl ? `Open your invitation page: ${inviteUrl}` : null,
-    inviteUrl ? "" : null,
     "For reference, the original letter you received:",
     "",
     letterText(invitation),
@@ -95,7 +90,6 @@ ${
     ? `<blockquote style="margin:0 0 16px 0;padding-left:10px;border-left:3px solid #bca788;color:#4a3a30;"><em>${escapeHtml(invitation.response.reason)}</em></blockquote>`
     : ""
 }
-${inviteUrl ? `<p><a href="${inviteUrl}">Open your invitation page</a></p>` : ""}
 <hr style="border:none;border-top:1px solid #ddd;margin:18px 0;">
 <p style="color:#666;font-size:12px;margin:0 0 6px 0;">For reference, the original letter you received:</p>
 ${letterHtml(invitation)}

--- a/functions/src/onInvitationWrite.helpers.ts
+++ b/functions/src/onInvitationWrite.helpers.ts
@@ -1,7 +1,5 @@
 import { logger } from "firebase-functions/v2";
 import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
-import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
-import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
 import { sendEmail } from "./sendgrid/client.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 import type { MemberDoc } from "./types.js";
@@ -36,7 +34,6 @@ export async function sendSpeakerReceipt(
   invitation: SpeakerInvitationShape,
   bishopric: BishopricContact[],
   headerTemplate: string,
-  inviteUrl: string | undefined,
 ): Promise<void> {
   if (!invitation.speakerEmail) {
     logger.info("speaker receipt skipped — no speakerEmail on invitation", {
@@ -44,11 +41,7 @@ export async function sendSpeakerReceipt(
     });
     return;
   }
-  const content = buildSpeakerReceipt({
-    invitation,
-    headerTemplate,
-    ...(inviteUrl ? { inviteUrl } : {}),
-  });
+  const content = buildSpeakerReceipt({ invitation, headerTemplate });
   await sendEmail({
     to: invitation.speakerEmail,
     fromDisplayName: `${invitation.wardName} (via Steward)`,
@@ -57,29 +50,6 @@ export async function sendSpeakerReceipt(
     html: content.html,
     ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
   });
-}
-
-/** Rotate a fresh capability token for the receipt email's invite
- *  link. Bishop-origin rotations don't count against the daily cap
- *  (same rationale as the reply-notify path). Returns `undefined` on
- *  any failure — the receipt still goes out, just without a link. */
-export async function rotateInviteUrl(
-  wardId: string,
-  invitationId: string,
-  origin: string,
-): Promise<string | undefined> {
-  try {
-    const rotated = await rotateTokenForBishopNotification(wardId, invitationId);
-    if (!rotated) return undefined;
-    return buildInviteUrl(origin, wardId, invitationId, rotated.newToken);
-  } catch (err) {
-    logger.warn("speaker-receipt token rotation failed — sending no-link receipt", {
-      wardId,
-      invitationId,
-      err: (err as Error).message,
-    });
-    return undefined;
-  }
 }
 
 export async function sendBishopricReceipt(

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -6,7 +6,6 @@ import { notifyBishopricOfResponse } from "./invitationResponseNotify.js";
 import { readMessageTemplate } from "./messageTemplates.js";
 import {
   fetchActiveBishopricEmails,
-  rotateInviteUrl,
   sendBishopricReceipt,
   sendSpeakerReceipt,
 } from "./onInvitationWrite.helpers.js";
@@ -15,14 +14,18 @@ import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 /** Fires receipt emails on authoritative response transitions:
  *   - `response.answer` appears or flips → speaker receipt (to speaker,
- *      CC bishopric) with a freshly-rotated invite link so they can
- *      reopen the chat even if the original SMS has been deleted.
- *   - `response.acknowledgedAt` appears → bishopric receipt (to bishopric)
+ *      CC bishopric) + FCM push to the bishopric.
+ *   - `response.acknowledgedAt` appears → bishopric receipt (to bishopric).
+ *
+ *  The speaker receipt intentionally does NOT carry an invite link: any
+ *  URL we'd embed requires rotating the capability token, which in turn
+ *  invalidates the speaker's original SMS link. The canonical re-entry
+ *  point is the SMS — if the speaker reopens a consumed SMS link,
+ *  `decideTokenAction` rotates on demand and texts them a fresh URL.
+ *  See #73 for the regression this behavior restores.
  *
  *  Other writes (token rotation, delivery-record updates, heartbeats)
- *  are classified as no-ops and return early. The receipts contain the
- *  original letter inline so the email itself is the archive — no
- *  external dependency on the app being reachable. */
+ *  are classified as no-ops and return early. */
 export const onInvitationWrite = onDocumentWritten(
   "wards/{wardId}/speakerInvitations/{invitationId}",
   async (event) => {
@@ -40,12 +43,9 @@ export const onInvitationWrite = onDocumentWritten(
       if (change.fireSpeaker) {
         const answer = after.response?.answer;
         const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
-        const [headerTemplate, inviteUrl] = await Promise.all([
-          readMessageTemplate(db, wardId, key),
-          rotateInviteUrl(wardId, invitationId, origin),
-        ]);
+        const headerTemplate = await readMessageTemplate(db, wardId, key);
         await Promise.all([
-          sendSpeakerReceipt(after, bishopric, headerTemplate, inviteUrl),
+          sendSpeakerReceipt(after, bishopric, headerTemplate),
           notifyBishopricOfResponse(db, wardId, invitationId, before, after, origin),
         ]);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
Hotfix release. v0.9.0 inherited a regression from #46 where submitting Yes/No on the invite page pre-emptively rotated the capability token — invalidating the speaker's original SMS link. Real bishops testing prod hit "link has expired" on reopen.

Changelog: https://github.com/aylabyuk/steward/blob/develop/CHANGELOG.md#091--2026-04-23

## What ships

- Speaker receipt no longer rotates the token (#73 via #74).
- \`rotateInviteUrl\` helper deleted; \`buildSpeakerReceipt\` loses its \`inviteUrl\` arg.
- The speaker's SMS stays canonical; \`decideTokenAction\`'s existing rotate branch handles reopen self-healing (pre-#46 behavior).

## Test plan

- [x] CI green on develop
- [x] Functions tests — 87 pass
- [ ] Manual: speaker taps SMS → Yes → close → re-tap SMS → fresh link arrives via SMS (self-heal)

## Post-merge

- [ ] Tag \`v0.9.1\`
- [ ] Deploy Cloud Functions to \`steward-prod-65a36\` (rules unchanged)
- [ ] Smoke-test prod