### PR TITLE
fix(notifications): switch FCM payloads to data-only for iOS PWA push

### DIFF
--- a/functions/src/drainNotificationQueue.ts
+++ b/functions/src/drainNotificationQueue.ts
@@ -1,7 +1,7 @@
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onSchedule } from "firebase-functions/v2/scheduler";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
 import { timezoneFor } from "./meetingChange.js";
 import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
@@ -61,11 +61,9 @@ async function dispatchOne(db: FirebaseFirestore.Firestore, entry: QueueEntry): 
     tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
   }
 
-  const outcome = await sendAndPrune(entry.wardId, tokensByUid, {
-    notification: {
-      title: `Sacrament program — ${entry.date}`,
-      body: entry.description,
-    },
+  const outcome = await sendDisplayPush(entry.wardId, tokensByUid, {
+    title: `Sacrament program — ${entry.date}`,
+    body: entry.description,
     data: { wardId: entry.wardId, date: entry.date, kind: "meeting-change" },
   });
   logger.info("dispatched meeting-change notification", {

--- a/functions/src/fcm.ts
+++ b/functions/src/fcm.ts
@@ -2,6 +2,36 @@ import { getFirestore } from "firebase-admin/firestore";
 import { getMessaging, type MulticastMessage } from "firebase-admin/messaging";
 import type { FcmToken } from "./types.js";
 
+/** Display payload for a user-visible push. Title/body ride inside
+ *  `data` (not the top-level `notification` field) so the SW's
+ *  `onBackgroundMessage` handler is always invoked and can call
+ *  `showNotification()` itself. iOS Safari PWAs (16.4+) silently drop
+ *  pushes that aren't displayed inside the SW push event, and the
+ *  Firebase JS SDK's auto-display path (triggered by a `notification`
+ *  field) doesn't reliably satisfy that contract on iOS. Going
+ *  data-only routes every platform through the same explicit
+ *  `showNotification()` call.
+ *
+ *  `Urgency: high` keeps APNs/FCM from coalescing the push as
+ *  background priority — required when the payload has no
+ *  `notification` field. */
+export interface DisplayPush {
+  title: string;
+  body: string;
+  data: Record<string, string>;
+}
+
+export async function sendDisplayPush(
+  wardId: string,
+  tokensByUid: ReadonlyMap<string, readonly FcmToken[]>,
+  push: DisplayPush,
+): Promise<SendOutcome> {
+  return sendAndPrune(wardId, tokensByUid, {
+    data: { ...push.data, title: push.title, body: push.body },
+    webpush: { headers: { Urgency: "high" } },
+  });
+}
+
 // Token errors that indicate the device unsubscribed or the token is invalid.
 // Anything else (server error, throttling) is transient — keep the token.
 const DEAD_TOKEN_CODES = new Set<string>([

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,6 +1,6 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
 import { interpolate, readMessageTemplate } from "./messageTemplates.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
@@ -38,14 +38,12 @@ export async function pushToBishopric(inv: ResolvedInvitation, body: string): Pr
     .filter((c): c is RecipientCandidate => c !== null);
   const recipients = filterRecipients(candidates, { now: new Date(), timezone });
   if (recipients.length === 0) return;
-  const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
-  const link = `${origin}/schedule?chat=${encodeURIComponent(inv.token)}`;
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
-  await sendAndPrune(inv.wardId, tokensByUid, {
-    notification: { title: `${inv.speakerName} replied`, body: truncate(body, 120) },
+  await sendDisplayPush(inv.wardId, tokensByUid, {
+    title: `${inv.speakerName} replied`,
+    body: truncate(body, 120),
     data: { wardId: inv.wardId, invitationId: inv.token, kind: "invitation-reply" },
-    webpush: { fcmOptions: { link } },
   });
 }
 

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -1,5 +1,5 @@
 import { logger } from "firebase-functions/v2";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
@@ -66,17 +66,15 @@ function formatShortDate(meetingDate: string): string {
  *  aren't targeted (they're the actor) and clerks are excluded —
  *  only bishopric gets paged on response activity.
  *
- *  The FCM payload carries `webpush.fcmOptions.link` so a tap routes
- *  straight to the matching speaker's chat dialog (the SW's
- *  `notificationclick` handler reads the same shape for browsers that
- *  don't honor `fcmOptions.link` natively). */
+ *  The SW's `notificationclick` handler reads `data.kind` +
+ *  `data.invitationId` to deep-link the bishop straight into the
+ *  matching speaker's chat dialog. */
 export async function notifyBishopricOfResponse(
   db: FirebaseFirestore.Firestore,
   wardId: string,
   invitationId: string,
   before: SpeakerInvitationShape | undefined,
   after: SpeakerInvitationShape,
-  origin: string,
 ): Promise<void> {
   const nextAnswer = after.response?.answer;
   if (!nextAnswer) return;
@@ -102,20 +100,19 @@ export async function notifyBishopricOfResponse(
     nextAnswer,
     ...(after.response?.reason ? { reason: after.response.reason } : {}),
   });
-  const link = `${origin.replace(/\/+$/, "")}/schedule?chat=${encodeURIComponent(invitationId)}`;
 
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
   try {
-    await sendAndPrune(wardId, tokensByUid, {
-      notification: payload,
+    await sendDisplayPush(wardId, tokensByUid, {
+      title: payload.title,
+      body: payload.body,
       data: {
         wardId,
         invitationId,
         meetingDate: after.speakerRef.meetingDate,
         kind: "invitation-response",
       },
-      webpush: { fcmOptions: { link } },
     });
   } catch (err) {
     logger.error("response push fan-out failed", {

--- a/functions/src/onCommentCreate.ts
+++ b/functions/src/onCommentCreate.ts
@@ -1,9 +1,8 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { logger } from "firebase-functions/v2";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
-import { STEWARD_ORIGIN } from "./secrets.js";
 import type { CommentDoc, FcmToken, MemberDoc, WardDoc } from "./types.js";
 
 export const onCommentCreate = onDocumentCreated(
@@ -42,15 +41,10 @@ export const onCommentCreate = onDocumentCreated(
       tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
     }
 
-    const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
-    const link = `${origin}/week/${encodeURIComponent(date)}`;
-    const outcome = await sendAndPrune(wardId, tokensByUid, {
-      notification: {
-        title: `${comment.authorDisplayName} mentioned you`,
-        body: `On Sunday ${date}: ${truncate(comment.body, 120)}`,
-      },
+    const outcome = await sendDisplayPush(wardId, tokensByUid, {
+      title: `${comment.authorDisplayName} mentioned you`,
+      body: `On Sunday ${date}: ${truncate(comment.body, 120)}`,
       data: { wardId, date, kind: "mention" },
-      webpush: { fcmOptions: { link } },
     });
 
     logger.info("comment-mention notification sent", {

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -46,7 +46,7 @@ export const onInvitationWrite = onDocumentWritten(
         const headerTemplate = await readMessageTemplate(db, wardId, key);
         await Promise.all([
           sendSpeakerReceipt(after, bishopric, headerTemplate),
-          notifyBishopricOfResponse(db, wardId, invitationId, before, after, origin),
+          notifyBishopricOfResponse(db, wardId, invitationId, before, after),
         ]);
       }
       if (change.fireBishopric) {

--- a/functions/src/scheduledNudges.ts
+++ b/functions/src/scheduledNudges.ts
@@ -1,7 +1,7 @@
 import { FieldValue, getFirestore, Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onSchedule } from "firebase-functions/v2/scheduler";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import type { MeetingDocLite } from "./meetingChange.js";
 import { currentSlot, type NudgeSchedule, slotKey, upcomingSundayIso } from "./nudgeSlot.js";
 import { computeNudgeTarget, type NudgeMember, type NudgeTarget } from "./nudgeTarget.js";
@@ -110,8 +110,9 @@ async function deliverNudge(
   if (recipients.length === 0) return;
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
-  const outcome = await sendAndPrune(wardId, tokensByUid, {
-    notification: { title: target.title, body: target.body },
+  const outcome = await sendDisplayPush(wardId, tokensByUid, {
+    title: target.title,
+    body: target.body,
     data: { wardId, kind: "nudge", severity: target.severity },
   });
   logger.info("nudge dispatched", {

--- a/public/firebase-messaging-sw.template.js
+++ b/public/firebase-messaging-sw.template.js
@@ -21,14 +21,23 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
+// Display payload rides inside `payload.data` (not the top-level
+// `notification` field) so this handler always fires on iOS PWAs. iOS
+// Safari 16.4+ silently drops pushes that aren't displayed inside the
+// SW push event, and the Firebase JS SDK's auto-display path
+// (triggered when a `notification` field is present) doesn't reliably
+// satisfy that contract on iOS. Backend pairs this with
+// `webpush.headers.Urgency: high` so APNs treats data-only messages
+// as user-visible. See functions/src/fcm.ts → sendDisplayPush.
 messaging.onBackgroundMessage((payload) => {
-  const title = payload.notification?.title ?? "Steward";
-  const body = payload.notification?.body ?? "";
+  const data = payload.data ?? {};
+  const title = data.title ?? "Steward";
+  const body = data.body ?? "";
   self.registration.showNotification(title, {
     body,
     icon: "/icon.svg",
     badge: "/icon.svg",
-    data: payload.data ?? {},
+    data,
   });
 });
 


### PR DESCRIPTION
Speaker chat replies (and the other four push paths) silently dropped on
iOS PWAs because every payload included a top-level `notification`
field. With `notification` present, the Firebase JS SDK's auto-display
path takes over and bypasses the SW's `onBackgroundMessage` handler.
That auto-display doesn't reliably call `showNotification()` inside
the SW push event on iOS Safari 16.4+, so iOS drops the push (and
eventually revokes the subscription).

Move title/body into `data`, drop the top-level `notification` field,
and add `webpush.headers.Urgency: high` so APNs treats the data-only
payload as user-visible. The SW's `onBackgroundMessage` now reads
title/body from `data` and always calls `showNotification()`, which
works on iOS, Android, and desktop.

Centralized in `sendDisplayPush()` (functions/src/fcm.ts) so all five
push call sites — speaker reply, response yes/no, mention, meeting
change, finalization nudge — share the iOS-friendly shape.

The SW's `notificationclick` deep-link routing already keys off
`data.kind`, so taps still route to the chat / week view as before;
`webpush.fcmOptions.link` (only honored by the now-unused auto-display
path) is removed.