### PR TITLE
Release: v0.9.2 — iOS PWA push delivery fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.2] — 2026-04-23
+
+Hotfix for silently-dropped push notifications on iOS PWAs installed to
+the home screen. Every v0.9.x push payload included a top-level `notification`
+field, which triggers the Firebase JS SDK's auto-display path and
+bypasses the SW's `onBackgroundMessage` handler. On iOS Safari 16.4+
+that auto-display doesn't reliably call `showNotification()` inside
+the service-worker push event, so iOS drops the push (and eventually
+revokes the subscription entirely).
+
+### Fixed
+
+- **Data-only FCM payloads** across all five push call sites
+  (`invitationReplyNotify`, `invitationResponseNotify`, `onCommentCreate`,
+  `drainNotificationQueue`, `scheduledNudges`). Title/body move into
+  `data.title` / `data.body`; the SW's `onBackgroundMessage` now reads
+  them from there and always calls `showNotification()`. Works the
+  same on iOS, Android, and desktop.
+- **`webpush.headers.Urgency: high`** on every payload so APNs treats
+  the data-only message as user-visible. Without the urgency hint iOS
+  can delay or coalesce the push.
+
+### Changed
+
+- **`sendDisplayPush()` helper** in `functions/src/fcm.ts` centralizes
+  the iOS-safe payload shape. All five push call sites delegate to it
+  rather than constructing the FCM message inline.
+- **`webpush.fcmOptions.link` removed** from the payload — only the
+  auto-display path honors it, and auto-display is no longer in play.
+  The SW's `notificationclick` handler routes by `data.kind` (unchanged
+  since v0.9.0), so taps still deep-link to the right surface.
+
 ## [0.9.1] — 2026-04-23
 
 Hotfix for a regression v0.9.0 inherited from #46: eagerly rotating
@@ -845,7 +877,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.2...HEAD
+[0.9.2]: https://github.com/aylabyuk/steward/releases/tag/v0.9.2
 [0.9.1]: https://github.com/aylabyuk/steward/releases/tag/v0.9.1
 [0.9.0]: https://github.com/aylabyuk/steward/releases/tag/v0.9.0
 [0.8.0]: https://github.com/aylabyuk/steward/releases/tag/v0.8.0

--- a/functions/src/drainNotificationQueue.ts
+++ b/functions/src/drainNotificationQueue.ts
@@ -1,7 +1,7 @@
 import { getFirestore, Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onSchedule } from "firebase-functions/v2/scheduler";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
 import { timezoneFor } from "./meetingChange.js";
 import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
@@ -61,11 +61,9 @@ async function dispatchOne(db: FirebaseFirestore.Firestore, entry: QueueEntry): 
     tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
   }
 
-  const outcome = await sendAndPrune(entry.wardId, tokensByUid, {
-    notification: {
-      title: `Sacrament program — ${entry.date}`,
-      body: entry.description,
-    },
+  const outcome = await sendDisplayPush(entry.wardId, tokensByUid, {
+    title: `Sacrament program — ${entry.date}`,
+    body: entry.description,
     data: { wardId: entry.wardId, date: entry.date, kind: "meeting-change" },
   });
   logger.info("dispatched meeting-change notification", {

--- a/functions/src/fcm.ts
+++ b/functions/src/fcm.ts
@@ -2,6 +2,36 @@ import { getFirestore } from "firebase-admin/firestore";
 import { getMessaging, type MulticastMessage } from "firebase-admin/messaging";
 import type { FcmToken } from "./types.js";
 
+/** Display payload for a user-visible push. Title/body ride inside
+ *  `data` (not the top-level `notification` field) so the SW's
+ *  `onBackgroundMessage` handler is always invoked and can call
+ *  `showNotification()` itself. iOS Safari PWAs (16.4+) silently drop
+ *  pushes that aren't displayed inside the SW push event, and the
+ *  Firebase JS SDK's auto-display path (triggered by a `notification`
+ *  field) doesn't reliably satisfy that contract on iOS. Going
+ *  data-only routes every platform through the same explicit
+ *  `showNotification()` call.
+ *
+ *  `Urgency: high` keeps APNs/FCM from coalescing the push as
+ *  background priority — required when the payload has no
+ *  `notification` field. */
+export interface DisplayPush {
+  title: string;
+  body: string;
+  data: Record<string, string>;
+}
+
+export async function sendDisplayPush(
+  wardId: string,
+  tokensByUid: ReadonlyMap<string, readonly FcmToken[]>,
+  push: DisplayPush,
+): Promise<SendOutcome> {
+  return sendAndPrune(wardId, tokensByUid, {
+    data: { ...push.data, title: push.title, body: push.body },
+    webpush: { headers: { Urgency: "high" } },
+  });
+}
+
 // Token errors that indicate the device unsubscribed or the token is invalid.
 // Anything else (server error, throttling) is transient — keep the token.
 const DEAD_TOKEN_CODES = new Set<string>([

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,6 +1,6 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
 import { interpolate, readMessageTemplate } from "./messageTemplates.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
@@ -38,14 +38,12 @@ export async function pushToBishopric(inv: ResolvedInvitation, body: string): Pr
     .filter((c): c is RecipientCandidate => c !== null);
   const recipients = filterRecipients(candidates, { now: new Date(), timezone });
   if (recipients.length === 0) return;
-  const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
-  const link = `${origin}/schedule?chat=${encodeURIComponent(inv.token)}`;
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
-  await sendAndPrune(inv.wardId, tokensByUid, {
-    notification: { title: `${inv.speakerName} replied`, body: truncate(body, 120) },
+  await sendDisplayPush(inv.wardId, tokensByUid, {
+    title: `${inv.speakerName} replied`,
+    body: truncate(body, 120),
     data: { wardId: inv.wardId, invitationId: inv.token, kind: "invitation-reply" },
-    webpush: { fcmOptions: { link } },
   });
 }
 

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -1,5 +1,5 @@
 import { logger } from "firebase-functions/v2";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
@@ -66,17 +66,15 @@ function formatShortDate(meetingDate: string): string {
  *  aren't targeted (they're the actor) and clerks are excluded —
  *  only bishopric gets paged on response activity.
  *
- *  The FCM payload carries `webpush.fcmOptions.link` so a tap routes
- *  straight to the matching speaker's chat dialog (the SW's
- *  `notificationclick` handler reads the same shape for browsers that
- *  don't honor `fcmOptions.link` natively). */
+ *  The SW's `notificationclick` handler reads `data.kind` +
+ *  `data.invitationId` to deep-link the bishop straight into the
+ *  matching speaker's chat dialog. */
 export async function notifyBishopricOfResponse(
   db: FirebaseFirestore.Firestore,
   wardId: string,
   invitationId: string,
   before: SpeakerInvitationShape | undefined,
   after: SpeakerInvitationShape,
-  origin: string,
 ): Promise<void> {
   const nextAnswer = after.response?.answer;
   if (!nextAnswer) return;
@@ -102,20 +100,19 @@ export async function notifyBishopricOfResponse(
     nextAnswer,
     ...(after.response?.reason ? { reason: after.response.reason } : {}),
   });
-  const link = `${origin.replace(/\/+$/, "")}/schedule?chat=${encodeURIComponent(invitationId)}`;
 
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
   try {
-    await sendAndPrune(wardId, tokensByUid, {
-      notification: payload,
+    await sendDisplayPush(wardId, tokensByUid, {
+      title: payload.title,
+      body: payload.body,
       data: {
         wardId,
         invitationId,
         meetingDate: after.speakerRef.meetingDate,
         kind: "invitation-response",
       },
-      webpush: { fcmOptions: { link } },
     });
   } catch (err) {
     logger.error("response push fan-out failed", {

--- a/functions/src/onCommentCreate.ts
+++ b/functions/src/onCommentCreate.ts
@@ -1,9 +1,8 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { onDocumentCreated } from "firebase-functions/v2/firestore";
 import { logger } from "firebase-functions/v2";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import { filterRecipients, type RecipientCandidate } from "./recipients.js";
-import { STEWARD_ORIGIN } from "./secrets.js";
 import type { CommentDoc, FcmToken, MemberDoc, WardDoc } from "./types.js";
 
 export const onCommentCreate = onDocumentCreated(
@@ -42,15 +41,10 @@ export const onCommentCreate = onDocumentCreated(
       tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
     }
 
-    const origin = (process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value()).replace(/\/+$/, "");
-    const link = `${origin}/week/${encodeURIComponent(date)}`;
-    const outcome = await sendAndPrune(wardId, tokensByUid, {
-      notification: {
-        title: `${comment.authorDisplayName} mentioned you`,
-        body: `On Sunday ${date}: ${truncate(comment.body, 120)}`,
-      },
+    const outcome = await sendDisplayPush(wardId, tokensByUid, {
+      title: `${comment.authorDisplayName} mentioned you`,
+      body: `On Sunday ${date}: ${truncate(comment.body, 120)}`,
       data: { wardId, date, kind: "mention" },
-      webpush: { fcmOptions: { link } },
     });
 
     logger.info("comment-mention notification sent", {

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -46,7 +46,7 @@ export const onInvitationWrite = onDocumentWritten(
         const headerTemplate = await readMessageTemplate(db, wardId, key);
         await Promise.all([
           sendSpeakerReceipt(after, bishopric, headerTemplate),
-          notifyBishopricOfResponse(db, wardId, invitationId, before, after, origin),
+          notifyBishopricOfResponse(db, wardId, invitationId, before, after),
         ]);
       }
       if (change.fireBishopric) {

--- a/functions/src/scheduledNudges.ts
+++ b/functions/src/scheduledNudges.ts
@@ -1,7 +1,7 @@
 import { FieldValue, getFirestore, Timestamp } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { onSchedule } from "firebase-functions/v2/scheduler";
-import { sendAndPrune } from "./fcm.js";
+import { sendDisplayPush } from "./fcm.js";
 import type { MeetingDocLite } from "./meetingChange.js";
 import { currentSlot, type NudgeSchedule, slotKey, upcomingSundayIso } from "./nudgeSlot.js";
 import { computeNudgeTarget, type NudgeMember, type NudgeTarget } from "./nudgeTarget.js";
@@ -110,8 +110,9 @@ async function deliverNudge(
   if (recipients.length === 0) return;
   const tokensByUid = new Map<string, readonly FcmToken[]>();
   for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
-  const outcome = await sendAndPrune(wardId, tokensByUid, {
-    notification: { title: target.title, body: target.body },
+  const outcome = await sendDisplayPush(wardId, tokensByUid, {
+    title: target.title,
+    body: target.body,
     data: { wardId, kind: "nudge", severity: target.severity },
   });
   logger.info("nudge dispatched", {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/public/firebase-messaging-sw.template.js
+++ b/public/firebase-messaging-sw.template.js
@@ -21,14 +21,23 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
+// Display payload rides inside `payload.data` (not the top-level
+// `notification` field) so this handler always fires on iOS PWAs. iOS
+// Safari 16.4+ silently drops pushes that aren't displayed inside the
+// SW push event, and the Firebase JS SDK's auto-display path
+// (triggered when a `notification` field is present) doesn't reliably
+// satisfy that contract on iOS. Backend pairs this with
+// `webpush.headers.Urgency: high` so APNs treats data-only messages
+// as user-visible. See functions/src/fcm.ts → sendDisplayPush.
 messaging.onBackgroundMessage((payload) => {
-  const title = payload.notification?.title ?? "Steward";
-  const body = payload.notification?.body ?? "";
+  const data = payload.data ?? {};
+  const title = data.title ?? "Steward";
+  const body = data.body ?? "";
   self.registration.showNotification(title, {
     body,
     icon: "/icon.svg",
     badge: "/icon.svg",
-    data: payload.data ?? {},
+    data,
   });
 });
 


### PR DESCRIPTION
Hotfix. v0.9.x pushes silently dropped on iOS PWAs installed to the home screen — the top-level \`notification\` field triggered the Firebase SDK's auto-display path, which iOS Safari 16.4+ doesn't reliably surface from the SW push event.

Changelog: https://github.com/aylabyuk/steward/blob/develop/CHANGELOG.md#092--2026-04-23

## What ships

- Data-only FCM payloads across all 5 push call sites; title/body move into \`data\`.
- \`webpush.headers.Urgency: high\` so APNs treats them as user-visible.
- Centralized \`sendDisplayPush()\` helper in \`functions/src/fcm.ts\`.
- SW's \`onBackgroundMessage\` reads title/body from \`data\` and always calls \`showNotification()\` — works on iOS, Android, desktop.
- \`webpush.fcmOptions.link\` removed (only the auto-display path honored it). Tap-routing still works via the SW's \`notificationclick\` handler keyed on \`data.kind\` (unchanged since v0.9.0).

## Test plan

- [x] CI green on develop
- [ ] Manual: iOS PWA subscribed, bishop sends a reply in chat → speaker's iPhone pings. Open → routes to chat. Same for response-push and mention-push.
- [ ] Android + desktop: no regression.

## Post-merge

- [ ] Tag \`v0.9.2\`
- [ ] Deploy Cloud Functions to \`steward-prod-65a36\` (rules unchanged)
- [ ] Vercel auto-redeploys the web app + regenerates the SW on main push