### PR TITLE
fix(notifications): FCM push survives missing SendGrid config

### DIFF
--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -44,10 +44,24 @@ export const onInvitationWrite = onDocumentWritten(
         const answer = after.response?.answer;
         const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
         const headerTemplate = await readMessageTemplate(db, wardId, key);
-        await Promise.all([
+        // allSettled — one leg failing must NOT cancel the other.
+        // Promise.all rejects on first failure; the outer try/catch
+        // then catches and the function exits, which tears down the
+        // container and kills any in-flight operation. Waiting on
+        // allSettled keeps both sides running to completion.
+        const results = await Promise.allSettled([
           sendSpeakerReceipt(after, bishopric, headerTemplate),
           notifyBishopricOfResponse(db, wardId, invitationId, before, after),
         ]);
+        for (const r of results) {
+          if (r.status === "rejected") {
+            logger.error("speaker-response side effect failed", {
+              wardId,
+              invitationId,
+              err: (r.reason as Error)?.message ?? String(r.reason),
+            });
+          }
+        }
       }
       if (change.fireBishopric) {
         const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");

--- a/functions/src/sendgrid/client.ts
+++ b/functions/src/sendgrid/client.ts
@@ -4,19 +4,24 @@ import { logger } from "firebase-functions/v2";
 /** In local dev the Firebase emulator sets `FUNCTIONS_EMULATOR=true`.
  *  We use that as the single signal to stub SendGrid delivery — real
  *  sends would need a live API key that dev machines shouldn't carry
- *  anyway. Outside the emulator a missing key still throws, so a
- *  prod mis-config fails loud. */
+ *  anyway. */
 function isStubbed(): boolean {
   return process.env.FUNCTIONS_EMULATOR === "true";
 }
 
 let configured = false;
-function ensureConfigured(): void {
-  if (configured) return;
+/** Returns true when SendGrid is ready to send; false when the key is
+ *  missing. Missing-config is NOT a throw — callers degrade gracefully
+ *  (log + skip) so that email failures don't cascade into killing
+ *  unrelated side effects (FCM pushes, SMS, status writes) that
+ *  happen alongside in the same Cloud Function invocation. */
+function ensureConfigured(): boolean {
+  if (configured) return true;
   const key = process.env.SENDGRID_API_KEY;
-  if (!key) throw new Error("SENDGRID_API_KEY missing.");
+  if (!key) return false;
   sgMail.setApiKey(key);
   configured = true;
+  return true;
 }
 
 export interface EmailInput {
@@ -45,9 +50,21 @@ export async function sendEmail(input: EmailInput): Promise<string | null> {
     });
     return `stub-${Date.now()}`;
   }
-  ensureConfigured();
+  if (!ensureConfigured()) {
+    logger.warn("sendEmail skipped — SENDGRID_API_KEY not configured", {
+      to: input.to,
+      subject: input.subject,
+    });
+    return null;
+  }
   const fromAddress = process.env.INVITATION_FROM_EMAIL;
-  if (!fromAddress) throw new Error("INVITATION_FROM_EMAIL missing.");
+  if (!fromAddress) {
+    logger.warn("sendEmail skipped — INVITATION_FROM_EMAIL not configured", {
+      to: input.to,
+      subject: input.subject,
+    });
+    return null;
+  }
   const [res] = await sgMail.send({
     to: input.to,
     from: { email: fromAddress, name: input.fromDisplayName },


### PR DESCRIPTION
Third push-delivery hotfix. Confirmed via prod Cloud Function logs:

\`\`\`
E oninvitationwrite: {\"message\":\"Error: invitation receipt dispatch failed\", \"err\":\"SENDGRID_API_KEY missing.\"}
\`\`\`

## Root cause

Prod has no \`SENDGRID_API_KEY\` (not in \`.env.steward-prod-65a36\`, not declared via defineSecret). Every speaker response triggered \`onInvitationWrite\`, which tried:

\`\`\`ts
await Promise.all([
  sendSpeakerReceipt(...),         // throws \"SENDGRID_API_KEY missing.\"
  notifyBishopricOfResponse(...),  // in-flight when Promise.all rejects
]);
\`\`\`

Sequence:
1. \`sendSpeakerReceipt\` throws (inside \`sendEmail\` → \`ensureConfigured\`).
2. \`Promise.all\` rejects.
3. Outer try/catch logs \"invitation receipt dispatch failed\".
4. Function returns — Cloud Functions tears down the container.
5. \`notifyBishopricOfResponse\` was still awaiting its Firestore reads / \`sendAndPrune\` — killed mid-flight.

Net effect: no email AND no push.

## Fix (two parts)

### 1. \`sendgrid/client.ts\` — degrade gracefully on missing config

Missing \`SENDGRID_API_KEY\` or \`INVITATION_FROM_EMAIL\` logs a warning and returns \`null\` instead of throwing. Real SendGrid API errors at send time still throw (that's a legitimate error). Rationale: a missing config shouldn't cascade into killing unrelated side effects.

### 2. \`onInvitationWrite.ts\` — \`Promise.all\` → \`Promise.allSettled\`

Speaker-response side effects now run independently. Each rejection is logged via \`logger.error\` with the specific reason. Defense in depth even if fix #1 had an edge case.

## Test plan

- [x] \`pnpm run typecheck\`, \`pnpm run lint\`, \`pnpm run format:check\`
- [x] \`pnpm --prefix functions test\` — 87 pass
- [x] \`pnpm run test\` (root) — 273 pass
- [ ] Manual (after deploy): speaker response on prod → bishop's browser pings with FCM push, even though SendGrid isn't configured

## Follow-up (not this PR)

\`SENDGRID_API_KEY\` + \`INVITATION_FROM_EMAIL\` still need to be set in prod if email receipts are wanted. That's an infra/config task, not a code fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)