### PR TITLE
Release: v0.9.4 — FCM push survives missing SendGrid config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.4] — 2026-04-24
+
+Third push-delivery hotfix in a row. Prod Cloud Function logs revealed
+`onInvitationWrite` was throwing `SENDGRID_API_KEY missing.` on every
+speaker response — prod has no SendGrid configured. The throw rejected
+the `Promise.all` wrapping the email receipt and the FCM push, and
+when the outer try/catch caught, the container tore down and killed
+the in-flight push fan-out. Net effect: speaker responded → no email
+AND no push.
+
+### Fixed
+
+- **`sendEmail` degrades gracefully on missing config** in
+  `functions/src/sendgrid/client.ts`. Missing `SENDGRID_API_KEY` or
+  `INVITATION_FROM_EMAIL` now logs a warning and returns `null`
+  instead of throwing. Real send-time API errors (bad key, bounced
+  recipient) still throw — those are genuine errors worth escalating.
+  Rationale: a missing config shouldn't cascade into killing
+  unrelated side effects (FCM, SMS, status writes) that share the
+  same Cloud Function invocation.
+- **`Promise.all` → `Promise.allSettled`** in `onInvitationWrite`'s
+  speaker-response path. Each side effect (speaker receipt email,
+  bishopric FCM push) now runs independently; one failing no longer
+  short-circuits the other. Rejected entries are logged individually.
+  Defense in depth on top of the fix above.
+
+### Known follow-up
+
+Email receipts still won't send in prod until SendGrid is configured.
+Set `SENDGRID_API_KEY` and `INVITATION_FROM_EMAIL` in
+`functions/.env.steward-prod-65a36` (or declare via `defineSecret`)
+when email is in scope.
+
 ## [0.9.3] — 2026-04-24
 
 Second hotfix for push-notification delivery. v0.9.2 moved payloads to
@@ -914,7 +947,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.3...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.4...HEAD
+[0.9.4]: https://github.com/aylabyuk/steward/releases/tag/v0.9.4
 [0.9.3]: https://github.com/aylabyuk/steward/releases/tag/v0.9.3
 [0.9.2]: https://github.com/aylabyuk/steward/releases/tag/v0.9.2
 [0.9.1]: https://github.com/aylabyuk/steward/releases/tag/v0.9.1

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -44,10 +44,24 @@ export const onInvitationWrite = onDocumentWritten(
         const answer = after.response?.answer;
         const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
         const headerTemplate = await readMessageTemplate(db, wardId, key);
-        await Promise.all([
+        // allSettled — one leg failing must NOT cancel the other.
+        // Promise.all rejects on first failure; the outer try/catch
+        // then catches and the function exits, which tears down the
+        // container and kills any in-flight operation. Waiting on
+        // allSettled keeps both sides running to completion.
+        const results = await Promise.allSettled([
           sendSpeakerReceipt(after, bishopric, headerTemplate),
           notifyBishopricOfResponse(db, wardId, invitationId, before, after),
         ]);
+        for (const r of results) {
+          if (r.status === "rejected") {
+            logger.error("speaker-response side effect failed", {
+              wardId,
+              invitationId,
+              err: (r.reason as Error)?.message ?? String(r.reason),
+            });
+          }
+        }
       }
       if (change.fireBishopric) {
         const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");

--- a/functions/src/sendgrid/client.ts
+++ b/functions/src/sendgrid/client.ts
@@ -4,19 +4,24 @@ import { logger } from "firebase-functions/v2";
 /** In local dev the Firebase emulator sets `FUNCTIONS_EMULATOR=true`.
  *  We use that as the single signal to stub SendGrid delivery — real
  *  sends would need a live API key that dev machines shouldn't carry
- *  anyway. Outside the emulator a missing key still throws, so a
- *  prod mis-config fails loud. */
+ *  anyway. */
 function isStubbed(): boolean {
   return process.env.FUNCTIONS_EMULATOR === "true";
 }
 
 let configured = false;
-function ensureConfigured(): void {
-  if (configured) return;
+/** Returns true when SendGrid is ready to send; false when the key is
+ *  missing. Missing-config is NOT a throw — callers degrade gracefully
+ *  (log + skip) so that email failures don't cascade into killing
+ *  unrelated side effects (FCM pushes, SMS, status writes) that
+ *  happen alongside in the same Cloud Function invocation. */
+function ensureConfigured(): boolean {
+  if (configured) return true;
   const key = process.env.SENDGRID_API_KEY;
-  if (!key) throw new Error("SENDGRID_API_KEY missing.");
+  if (!key) return false;
   sgMail.setApiKey(key);
   configured = true;
+  return true;
 }
 
 export interface EmailInput {
@@ -45,9 +50,21 @@ export async function sendEmail(input: EmailInput): Promise<string | null> {
     });
     return `stub-${Date.now()}`;
   }
-  ensureConfigured();
+  if (!ensureConfigured()) {
+    logger.warn("sendEmail skipped — SENDGRID_API_KEY not configured", {
+      to: input.to,
+      subject: input.subject,
+    });
+    return null;
+  }
   const fromAddress = process.env.INVITATION_FROM_EMAIL;
-  if (!fromAddress) throw new Error("INVITATION_FROM_EMAIL missing.");
+  if (!fromAddress) {
+    logger.warn("sendEmail skipped — INVITATION_FROM_EMAIL not configured", {
+      to: input.to,
+      subject: input.subject,
+    });
+    return null;
+  }
   const [res] = await sgMail.send({
     to: input.to,
     from: { email: fromAddress, name: input.fromDisplayName },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
Third push-delivery hotfix. Prod logs showed \`onInvitationWrite\` throwing \`SENDGRID_API_KEY missing.\` on every speaker response (prod has no SendGrid configured). The throw rejected the \`Promise.all\` wrapping the email + push, which tore down the container mid-flight and killed the FCM push too.

Changelog: https://github.com/aylabyuk/steward/blob/develop/CHANGELOG.md#094--2026-04-24

## What ships

- \`sendEmail\` degrades gracefully when \`SENDGRID_API_KEY\` / \`INVITATION_FROM_EMAIL\` is missing (warns + returns null instead of throwing).
- \`Promise.all\` → \`Promise.allSettled\` on speaker-response side effects so one leg failing doesn't kill the other.

## Test plan

- [x] CI green on develop
- [ ] Manual (after deploy): speaker responds → bishop's web/iOS PWA receives push even though SendGrid still isn't configured.

## Post-merge

- [ ] Tag \`v0.9.4\`
- [ ] Deploy Cloud Functions to \`steward-prod-65a36\` (functions/ changed; rules unchanged)

## Known follow-up (not this PR)

Email receipts still won't send until SendGrid is configured. Separate infra task.