### PR TITLE
fix(notifications): add missing indexes + diagnostic logs

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -18,6 +18,24 @@
         { "arrayConfig": "CONTAINS", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "notificationQueue",
+      "fieldPath": "dispatchAt",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "speakerInvitations",
+      "fieldPath": "conversationSid",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -77,7 +77,17 @@ export async function notifyBishopricOfResponse(
   after: SpeakerInvitationShape,
 ): Promise<void> {
   const nextAnswer = after.response?.answer;
-  if (!nextAnswer) return;
+  if (!nextAnswer) {
+    logger.info("response push skipped — no nextAnswer", { wardId, invitationId });
+    return;
+  }
+
+  logger.info("response push: start", {
+    wardId,
+    invitationId,
+    prevAnswer: before?.response?.answer ?? null,
+    nextAnswer,
+  });
 
   const wardSnap = await db.doc(`wards/${wardId}`).get();
   const ward = wardSnap.data() as WardDoc | undefined;
@@ -91,6 +101,13 @@ export async function notifyBishopricOfResponse(
     })
     .filter((c): c is RecipientCandidate => c !== null);
   const recipients = filterRecipients(candidates, { now: new Date(), timezone });
+  logger.info("response push: recipients", {
+    wardId,
+    invitationId,
+    bishopricCandidates: candidates.length,
+    recipientsAfterFilter: recipients.length,
+    candidateUids: candidates.map((c) => c.uid),
+  });
   if (recipients.length === 0) return;
 
   const payload = composeResponseNotification({
@@ -102,9 +119,20 @@ export async function notifyBishopricOfResponse(
   });
 
   const tokensByUid = new Map<string, readonly FcmToken[]>();
-  for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
+  let totalTokens = 0;
+  for (const r of recipients) {
+    const tokens = r.member.fcmTokens ?? [];
+    tokensByUid.set(r.uid, tokens);
+    totalTokens += tokens.length;
+  }
+  logger.info("response push: sending", {
+    wardId,
+    invitationId,
+    recipientCount: recipients.length,
+    totalTokens,
+  });
   try {
-    await sendDisplayPush(wardId, tokensByUid, {
+    const outcome = await sendDisplayPush(wardId, tokensByUid, {
       title: payload.title,
       body: payload.body,
       data: {
@@ -113,6 +141,13 @@ export async function notifyBishopricOfResponse(
         meetingDate: after.speakerRef.meetingDate,
         kind: "invitation-response",
       },
+    });
+    logger.info("response push: outcome", {
+      wardId,
+      invitationId,
+      successCount: outcome.successCount,
+      failureCount: outcome.failureCount,
+      deadTokenCount: outcome.deadTokens.length,
     });
   } catch (err) {
     logger.error("response push fan-out failed", {


### PR DESCRIPTION
Two bundled fixes surfaced from prod log inspection.

## 1. Missing Firestore indexes (separate incident)

Repeated \`FAILED_PRECONDITION\` errors in prod logs from collectionGroup queries with no COLLECTION_GROUP field override:

- **\`drainNotificationQueue\`** runs \`collectionGroup(\"notificationQueue\").where(\"dispatchAt\", \"<=\", now)\`. Fails every minute. **Meeting-change push fan-out has been dead** since the collection-group rewrite.
- **\`onTwilioWebhook.findInvitationByConversation\`** runs \`collectionGroup(\"speakerInvitations\").where(\"conversationSid\", \"==\", ...)\`. **Bishop-reply → speaker SMS has been dead too**.

Added both as \`fieldOverrides\` alongside the existing \`invites.email\` precedent.

## 2. Silent success path in \`notifyBishopricOfResponse\`

While debugging the active push incident, we noticed \`onInvitationWrite\` logs show no output on the happy path — \`sendAndPrune\` doesn't log its outcome, and \`notifyBishopricOfResponse\` only logs on failure. That makes it impossible to tell from prod whether:

- The trigger fires at all
- Bishopric candidates are found and not filtered out
- FCM accepts the tokens or rejects them

Added structured logs at each stage:

\`\`\`
response push: start           { wardId, invitationId, prevAnswer, nextAnswer }
response push: recipients      { bishopricCandidates, recipientsAfterFilter, candidateUids }
response push: sending         { recipientCount, totalTokens }
response push: outcome         { successCount, failureCount, deadTokenCount }
\`\`\`

Kept permanently. Cheap to run, high value for the next debug cycle.

## Deploy path

- **Firestore rules**: unchanged
- **Firestore indexes**: CHANGED — both new field overrides need deploying via \`firebase deploy --only firestore:indexes --project=prod\`
- **Cloud Functions**: CHANGED (diagnostic logs added to invitationResponseNotify.ts) — need deploying

Index builds run async, typically seconds for small collections.

## Test plan

- [x] \`pnpm --prefix functions test\` — 87 pass
- [x] Typecheck, lint, format
- [ ] Manual after deploy: speaker flips yes/no → logs show the full sequence from \"start\" to \"outcome\"
- [ ] Manual after index build: \`drainNotificationQueue\` next minute-tick runs without FAILED_PRECONDITION
- [ ] Manual: bishop sends a chat reply → speaker's SMS arrives (exercises the onTwilioWebhook path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)