### PR TITLE
Release: v0.9.5 — missing indexes + response-push diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.5] — 2026-04-24
+
+Two fixes surfaced from prod log inspection while chasing the ongoing
+push-delivery issue.
+
+### Fixed
+
+- **Missing Firestore indexes** for two collection-group queries that
+  were failing every execution with `9 FAILED_PRECONDITION`:
+  - `notificationQueue.dispatchAt` — used by `drainNotificationQueue`'s
+    minute-tick scheduled run. Meeting-change push fan-out had been
+    dead silently since the collection-group rewrite.
+  - `speakerInvitations.conversationSid` — used by
+    `onTwilioWebhook.findInvitationByConversation`. Bishop-reply →
+    speaker SMS had been dead too.
+
+  Both added as `fieldOverrides` (the same pattern as the existing
+  `invites.email` override).
+
+### Infrastructure
+
+- **Structured diagnostic logs** in `notifyBishopricOfResponse` so
+  we can see exactly where a response push drops: trigger entry,
+  candidate + recipient counts, token total, and `sendAndPrune`
+  outcome (`successCount` / `failureCount` / `deadTokenCount`).
+  Kept permanently — cheap to run, saves the next debug cycle.
+
 ## [0.9.4] — 2026-04-24
 
 Third push-delivery hotfix in a row. Prod Cloud Function logs revealed
@@ -947,7 +974,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.4...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.5...HEAD
+[0.9.5]: https://github.com/aylabyuk/steward/releases/tag/v0.9.5
 [0.9.4]: https://github.com/aylabyuk/steward/releases/tag/v0.9.4
 [0.9.3]: https://github.com/aylabyuk/steward/releases/tag/v0.9.3
 [0.9.2]: https://github.com/aylabyuk/steward/releases/tag/v0.9.2

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -18,6 +18,24 @@
         { "arrayConfig": "CONTAINS", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "notificationQueue",
+      "fieldPath": "dispatchAt",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "speakerInvitations",
+      "fieldPath": "conversationSid",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }

--- a/functions/src/invitationResponseNotify.ts
+++ b/functions/src/invitationResponseNotify.ts
@@ -77,7 +77,17 @@ export async function notifyBishopricOfResponse(
   after: SpeakerInvitationShape,
 ): Promise<void> {
   const nextAnswer = after.response?.answer;
-  if (!nextAnswer) return;
+  if (!nextAnswer) {
+    logger.info("response push skipped — no nextAnswer", { wardId, invitationId });
+    return;
+  }
+
+  logger.info("response push: start", {
+    wardId,
+    invitationId,
+    prevAnswer: before?.response?.answer ?? null,
+    nextAnswer,
+  });
 
   const wardSnap = await db.doc(`wards/${wardId}`).get();
   const ward = wardSnap.data() as WardDoc | undefined;
@@ -91,6 +101,13 @@ export async function notifyBishopricOfResponse(
     })
     .filter((c): c is RecipientCandidate => c !== null);
   const recipients = filterRecipients(candidates, { now: new Date(), timezone });
+  logger.info("response push: recipients", {
+    wardId,
+    invitationId,
+    bishopricCandidates: candidates.length,
+    recipientsAfterFilter: recipients.length,
+    candidateUids: candidates.map((c) => c.uid),
+  });
   if (recipients.length === 0) return;
 
   const payload = composeResponseNotification({
@@ -102,9 +119,20 @@ export async function notifyBishopricOfResponse(
   });
 
   const tokensByUid = new Map<string, readonly FcmToken[]>();
-  for (const r of recipients) tokensByUid.set(r.uid, r.member.fcmTokens ?? []);
+  let totalTokens = 0;
+  for (const r of recipients) {
+    const tokens = r.member.fcmTokens ?? [];
+    tokensByUid.set(r.uid, tokens);
+    totalTokens += tokens.length;
+  }
+  logger.info("response push: sending", {
+    wardId,
+    invitationId,
+    recipientCount: recipients.length,
+    totalTokens,
+  });
   try {
-    await sendDisplayPush(wardId, tokensByUid, {
+    const outcome = await sendDisplayPush(wardId, tokensByUid, {
       title: payload.title,
       body: payload.body,
       data: {
@@ -113,6 +141,13 @@ export async function notifyBishopricOfResponse(
         meetingDate: after.speakerRef.meetingDate,
         kind: "invitation-response",
       },
+    });
+    logger.info("response push: outcome", {
+      wardId,
+      invitationId,
+      successCount: outcome.successCount,
+      failureCount: outcome.failureCount,
+      deadTokenCount: outcome.deadTokens.length,
     });
   } catch (err) {
     logger.error("response push fan-out failed", {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
Bundled hotfix. Two things surfaced from prod log inspection during the push-delivery debugging.

Changelog: https://github.com/aylabyuk/steward/blob/develop/CHANGELOG.md#095--2026-04-24

## What ships

- **Missing Firestore indexes** added as field overrides for \`notificationQueue.dispatchAt\` and \`speakerInvitations.conversationSid\`. Meeting-change push fan-out + bishop-reply SMS paths were failing every run with \`9 FAILED_PRECONDITION\`.
- **Structured diagnostic logs** in \`notifyBishopricOfResponse\` tracing trigger → recipients → tokens → sendAndPrune outcome. Permanent instrumentation.

## Test plan

- [x] CI green
- [ ] After deploy: speaker flips yes/no → logs show full sequence from \"start\" to \"outcome\"
- [ ] After index build: \`drainNotificationQueue\` runs without FAILED_PRECONDITION
- [ ] Bishop replies in chat → speaker SMS arrives (exercises onTwilioWebhook)

## Post-merge deploy

- [ ] Tag \`v0.9.5\`
- [ ] Deploy Firestore indexes: \`firebase deploy --only firestore:indexes --project=prod\` (async builds, typically seconds)
- [ ] Deploy Cloud Functions: \`firebase deploy --only functions --project=prod\`