### PR TITLE
chore(release): automate tag + Firebase deploy via GHA

### DIFF
--- a/.claude/skills/release-to-main.md
+++ b/.claude/skills/release-to-main.md
@@ -1,14 +1,24 @@
 ---
 name: release-to-main
-description: Promote develop → main for a Steward production release. Handles the PR, the changelog + version bump, tagging, and the Firebase rules/indexes deploys. Use when the user says "ship to prod", "publish to production", "release", or similar.
+description: Promote develop → main for a Steward production release. Handles the PR, the changelog + version bump, and the release-PR auto-merge setup. Tagging + GitHub Release + Firebase deploys run automatically via .github/workflows/release.yml after main merges. Use when the user says "ship to prod", "publish to production", "release", or similar.
 ---
 
 # Release develop → main (Steward)
 
-This skill encodes the release workflow for Steward. It exists
-because the release path touches three systems: GitHub (PR merge),
-Vercel (auto-deploy off `main`), and Firebase (rules + indexes on
-`steward-prod-65a36`, deployed by hand).
+This skill encodes the release workflow for Steward. Most of the
+release path is automated now — see
+[docs/release-automation.md](../../docs/release-automation.md) for
+setup. The human still writes the changelog and opens the release PRs;
+everything post-main-merge is automatic.
+
+**Automation split:**
+
+- **Manual** (via this skill): changelog entry, version bump, opening
+  the `chore(release)` PR and the `develop → main` PR with auto-merge
+  enabled.
+- **Automatic** (`.github/workflows/release.yml`, on push to `main`):
+  tag, GitHub Release, Firestore rules + indexes deploy, Cloud
+  Functions deploy.
 
 ## Branch topology
 
@@ -97,16 +107,26 @@ Do this as a single commit titled `chore(release): vX.Y.Z`:
      [X.Y.Z]: https://github.com/aylabyuk/steward/releases/tag/vX.Y.Z
      ```
 
-4. Commit both files together and push `develop`:
+4. Commit both files on a `chore/release-vX.Y.Z` branch and open a PR
+   into `develop` with auto-merge enabled. Direct pushes to `develop`
+   are blocked by the project's PR-only rule:
    ```bash
+   git checkout -b chore/release-vX.Y.Z
    git add package.json CHANGELOG.md
    git commit -m "chore(release): vX.Y.Z"
-   git push origin develop
+   git push -u origin chore/release-vX.Y.Z
+   gh pr create --base develop --head chore/release-vX.Y.Z \
+     --title "chore(release): vX.Y.Z" \
+     --body "Release-prep commit for vX.Y.Z. Merge this, then the develop → main PR auto-merges on CI pass."
+   gh pr merge --auto --merge  # auto-merges once CI goes green
    ```
 
-5. Wait for develop CI to go green on this commit.
+5. Wait for the PR to auto-merge. Sync develop:
+   ```bash
+   git checkout develop && git pull --ff-only
+   ```
 
-## Open the release PR
+## Open the release PR (develop → main)
 
 Do NOT fast-forward `main` locally. Open a PR so CI runs on the merge
 ref and GitHub enforces the branch's merge strategy.
@@ -115,26 +135,37 @@ ref and GitHub enforces the branch's merge strategy.
 gh pr create --base main --head develop \
   --title "Release: <short summary>" \
   --body "<markdown checklist — features, fixes, test plan>"
+gh pr merge --auto --merge   # auto-merges once CI is green
 ```
 
-Wait for CI to go green on the PR before merging.
+Auto-merge requires **Settings → Pull Requests → Allow auto-merge** to
+be enabled in the repo. If it's disabled, the command errors — flip
+the checkbox and retry.
 
-## Merge
+## What happens after merge
 
-Click Merge on the GitHub UI — the only available method is "Create
-a merge commit" (enforced at the repo level). Confirm with the user
-before the click — this is a high-severity production action.
+**Zero human steps** — the
+[.github/workflows/release.yml](../../.github/workflows/release.yml)
+workflow runs on every push to `main`:
 
-## Post-merge sync
+1. Reads `package.json` version
+2. Creates + pushes `vX.Y.Z` tag (skips if it already exists)
+3. Creates GitHub Release with the matching CHANGELOG section
+4. Deploys Firestore rules + indexes to `steward-prod-65a36`
+5. Deploys Cloud Functions to `steward-prod-65a36`
 
-Merge-commit preserves develop's SHAs on main, so the post-merge
-state is: `main == develop + one merge commit`. Pull the merge
-commit down onto develop with a fast-forward:
+Vercel handles the frontend redeploy via its own GitHub integration.
+
+Watch the Actions tab (**Actions → Release**) to confirm. Typical
+run-time is 3–5 minutes. If any step fails, the workflow surfaces the
+error and the tag/release may or may not exist depending on where it
+failed — rerun after fixing.
+
+Local post-merge sync:
 
 ```bash
 git fetch origin
-git checkout develop
-git pull --ff-only origin develop    # picks up the merge commit
+git checkout develop && git pull --ff-only origin develop
 ```
 
 If you maintain any long-running local branches (e.g. `version-2`),
@@ -147,53 +178,35 @@ Never force-push to `develop` or `main` as part of this flow. The
 legacy `git reset --hard && git push --force-with-lease` dance is no
 longer needed and is explicitly forbidden — see Guardrails.
 
-## Tag the release
+## Tag + Firebase deploy — automated
 
-Tag the merge commit on `main` with the version from `package.json`.
-Tags drive the compare links in `CHANGELOG.md` and become the source
-of truth for "what's in production right now".
+All of this is handled by
+[.github/workflows/release.yml](../../.github/workflows/release.yml)
+when the `develop → main` PR merges. See
+[docs/release-automation.md](../../docs/release-automation.md) for
+the full pipeline.
 
-```bash
-git checkout main
-git pull --ff-only origin main
-VERSION=$(node -p "require('./package.json').version")
-git tag -a "v$VERSION" -m "Release v$VERSION"
-git push origin "v$VERSION"
-```
+The workflow:
 
-Optionally, create a GitHub Release from the tag with the changelog
-section as the body:
+1. Creates the `vX.Y.Z` tag on the merge commit (skips if already there).
+2. Publishes a GitHub Release with the matching CHANGELOG section.
+3. Deploys Firestore rules + indexes to `steward-prod-65a36`.
+4. Deploys Cloud Functions to `steward-prod-65a36`.
 
-```bash
-gh release create "v$VERSION" --title "v$VERSION" \
-  --notes-file <(awk "/## \[$VERSION\]/,/## \[/{print}" CHANGELOG.md | sed '$d')
-```
+Vercel handles the frontend via its own integration — nothing for us
+to run.
 
-## Deploy Firebase (prod project: steward-prod-65a36)
+If the workflow fails, the Actions tab surfaces the error. Common
+failure modes and their fixes are documented in
+`docs/release-automation.md § Smoke-test the pipeline`.
 
-Only the frontend deploys via Vercel automatically. Firestore rules
-and indexes must be deployed manually. Pause for explicit user
-confirmation before each command.
+### Firestore index caveat
 
-### 1. Rules
-
-```bash
-firebase deploy --only firestore:rules --project=prod
-```
-
-Expect: "rules file firestore.rules compiled successfully" +
-"Rules published successfully". Takes seconds.
-
-### 2. Indexes
-
-```bash
-firebase deploy --only firestore:indexes --project=prod
-```
-
-Caveat: a single-field collectionGroup query needs a **field
-override**, not a composite index. If deploy rejects with "this index
-is not necessary, configure using single field index controls", move
-the entry from `indexes` to `fieldOverrides`:
+Index changes take effect asynchronously. A single-field
+collectionGroup query needs a **field override**, not a composite
+index. If a deploy rejects with "this index is not necessary,
+configure using single field index controls", move the entry from
+`indexes` to `fieldOverrides` in `firestore.indexes.json`:
 
 ```json
 {
@@ -208,29 +221,17 @@ the entry from `indexes` to `fieldOverrides`:
 ```
 
 Indexes build async — expect minutes for small collections, longer
-for millions of docs. Queries may return partial results until
+for millions of docs. Queries may return partial results until the
 build completes.
-
-### 3. Cloud Functions (only if functions/ changed)
-
-```bash
-firebase deploy --only functions --project=prod
-```
-
-Check first:
-```bash
-git diff origin/main~N..origin/main -- functions/ | head -5
-```
-where N is the release size. Skip if empty.
 
 ## Verify
 
-After rules + indexes deploy + the Vercel prod build lands:
+After the Release workflow finishes and the Vercel prod build lands:
 
 - Hit the production URL, sign in, confirm the Schedule loads
 - Try one write (e.g. edit a meeting field) to confirm rules accept
   legitimate writes
-- Check Firestore console → Indexes tab: any new indexes should show
+- Check Firestore Console → Indexes tab: any new indexes should show
   "Building" → "Enabled" within a few minutes
 
 ## Guardrails

--- a/.claude/skills/release-to-main.md
+++ b/.claude/skills/release-to-main.md
@@ -108,8 +108,11 @@ Do this as a single commit titled `chore(release): vX.Y.Z`:
      ```
 
 4. Commit both files on a `chore/release-vX.Y.Z` branch and open a PR
-   into `develop` with auto-merge enabled. Direct pushes to `develop`
-   are blocked by the project's PR-only rule:
+   into `develop`. The
+   [auto-merge-release](../../.github/workflows/auto-merge-release.yml)
+   workflow auto-merges it once CI passes, because the title matches
+   `^chore\(release\):`. Direct pushes to `develop` are blocked by the
+   project's PR-only rule:
    ```bash
    git checkout -b chore/release-vX.Y.Z
    git add package.json CHANGELOG.md
@@ -117,11 +120,10 @@ Do this as a single commit titled `chore(release): vX.Y.Z`:
    git push -u origin chore/release-vX.Y.Z
    gh pr create --base develop --head chore/release-vX.Y.Z \
      --title "chore(release): vX.Y.Z" \
-     --body "Release-prep commit for vX.Y.Z. Merge this, then the develop → main PR auto-merges on CI pass."
-   gh pr merge --auto --merge  # auto-merges once CI goes green
+     --body "Release-prep commit for vX.Y.Z."
    ```
 
-5. Wait for the PR to auto-merge. Sync develop:
+5. Wait for the PR to auto-merge (watch Actions tab). Sync develop:
    ```bash
    git checkout develop && git pull --ff-only
    ```
@@ -129,18 +131,19 @@ Do this as a single commit titled `chore(release): vX.Y.Z`:
 ## Open the release PR (develop → main)
 
 Do NOT fast-forward `main` locally. Open a PR so CI runs on the merge
-ref and GitHub enforces the branch's merge strategy.
+ref and GitHub enforces the branch's merge strategy. The auto-merge
+workflow picks up on the `Release:` title prefix.
 
 ```bash
 gh pr create --base main --head develop \
   --title "Release: <short summary>" \
   --body "<markdown checklist — features, fixes, test plan>"
-gh pr merge --auto --merge   # auto-merges once CI is green
 ```
 
-Auto-merge requires **Settings → Pull Requests → Allow auto-merge** to
-be enabled in the repo. If it's disabled, the command errors — flip
-the checkbox and retry.
+Auto-merge is handled by
+[.github/workflows/auto-merge-release.yml](../../.github/workflows/auto-merge-release.yml)
+— no local flag needed. Watch the Actions tab to see CI → merge →
+release workflow run.
 
 ## What happens after merge
 

--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -1,0 +1,59 @@
+name: Auto-merge release PRs
+
+# Self-hosted replacement for GitHub's built-in auto-merge, which is
+# gated behind Pro on private repos. Triggers on CI completion; if the
+# PR's title starts with `chore(release):` or `Release:` AND CI
+# succeeded, merges the PR automatically. Feature PRs are NOT affected
+# — they still need a human review + click.
+#
+# The release workflow (.github/workflows/release.yml) takes over from
+# here once main is pushed.
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+concurrency:
+  group: auto-merge-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    name: Merge release PR on green CI
+    # Only run if CI succeeded. Skip for failure/cancelled/timed-out.
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Resolve + merge matching PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          # Find the open PR for this head branch. There's usually exactly one.
+          PR_JSON=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --head "$HEAD_BRANCH" \
+            --state open \
+            --json number,title,headRefOid,mergeable,mergeStateStatus)
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r \
+            --arg sha "$HEAD_SHA" \
+            '.[] | select(.headRefOid == $sha) |
+             select(.title | test("^chore\\(release\\):|^Release:")) |
+             .number' | head -1)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No matching release PR for branch $HEAD_BRANCH @ $HEAD_SHA — nothing to auto-merge."
+            exit 0
+          fi
+
+          echo "Auto-merging PR #$PR_NUMBER ($HEAD_BRANCH)"
+          gh pr merge "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --merge \
+            --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+# Runs on every push to `main` — which happens only after a
+# develop → main release PR merges. Tags the commit, publishes a
+# GitHub Release, and deploys Firestore rules + indexes + Cloud
+# Functions to the prod project. Vercel handles the frontend via
+# its own GitHub integration.
+#
+# Required secrets (repo Settings → Secrets → Actions):
+#   - FIREBASE_SERVICE_ACCOUNT_JSON : JSON key for a GCP service
+#     account with deploy permissions on steward-prod-65a36.
+#     See docs/release-automation.md for setup.
+#
+# Required variables (repo Settings → Variables → Actions):
+#   - STEWARD_ORIGIN_PROD : the prod web origin, e.g.
+#     https://steward-ten.vercel.app. Baked into Cloud Functions
+#     at deploy time via functions/.env.steward-prod-65a36.
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Tag + release + Firebase deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Read version from package.json
+        id: version
+        run: echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Skip if tag already exists
+        id: tag-check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ steps.version.outputs.version }} already exists — nothing to do."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create + push tag
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v${{ steps.version.outputs.version }}" -m "Release v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Extract changelog section
+        if: steps.tag-check.outputs.exists == 'false'
+        run: |
+          awk '/^## \[${{ steps.version.outputs.version }}\]/,/^## \[/{print}' CHANGELOG.md \
+            | sed '$d' > /tmp/release-notes.md
+          cat /tmp/release-notes.md
+
+      - name: Create GitHub Release
+        if: steps.tag-check.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "v${{ steps.version.outputs.version }}" \
+            --title "v${{ steps.version.outputs.version }}" \
+            --notes-file /tmp/release-notes.md
+
+      # Firebase deploys run on every main push, even if the tag
+      # already exists — lets us redeploy after a manual SA rotation
+      # or an ad-hoc push without bumping version. Cheap; Firebase
+      # CLI's own hash check skips unchanged functions.
+
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Write prod functions env
+        run: |
+          cat > functions/.env.steward-prod-65a36 <<EOF
+          STEWARD_ORIGIN=${{ vars.STEWARD_ORIGIN_PROD }}
+          EOF
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+
+      - name: Build functions
+        run: pnpm --filter @steward/functions build
+
+      - name: Deploy Firestore rules + indexes
+        run: pnpm exec firebase deploy --only firestore:rules,firestore:indexes --project=steward-prod-65a36 --non-interactive
+
+      - name: Deploy Cloud Functions
+        run: pnpm exec firebase deploy --only functions --project=steward-prod-65a36 --non-interactive

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -13,13 +13,13 @@ Vercel handles the frontend redeploy via its own GitHub integration — nothing 
 
 ## One-time setup
 
-### 1. Repo settings — enable auto-merge
+### 1. Auto-merge for release PRs — self-hosted
 
-**Settings → General → Pull Requests → ✅ Allow auto-merge → Save.**
+GitHub's built-in auto-merge is gated behind Pro on private repos, so we roll our own. [`.github/workflows/auto-merge-release.yml`](../.github/workflows/auto-merge-release.yml) triggers on CI completion: if the PR's title starts with `chore(release):` or `Release:` AND CI succeeded, it merges via `gh pr merge`.
 
-Lets me (or anyone opening a release PR) set `--auto --merge` on `gh pr create`. The PR merges automatically once CI goes green; no human click required for the mechanical release PRs (`chore(release): vX.Y.Z` and the `develop → main` one).
+**Nothing to configure** — the workflow uses the default `GITHUB_TOKEN` so it ships working. Feature PRs are untouched by the title filter; they still need a human review + click.
 
-Feature PR review stays manual — those still need a human eyes + merge click.
+If GitHub ever flips auto-merge into the free plan, this workflow can be deleted + release-to-main skill reverts to `gh pr merge --auto`. Until then, the self-host is cheaper than $4/mo for Pro.
 
 ### 2. GCP service account for deploys
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -1,0 +1,100 @@
+# Release automation
+
+After `develop → main` merges, the [`.github/workflows/release.yml`](../.github/workflows/release.yml) workflow:
+
+1. Reads `package.json` version
+2. Creates + pushes the `vX.Y.Z` tag (skips if it already exists)
+3. Creates a GitHub Release with the matching `CHANGELOG.md` section
+4. Writes `functions/.env.steward-prod-65a36` from the `STEWARD_ORIGIN_PROD` variable
+5. Authenticates to GCP with a service-account key
+6. Deploys Firestore rules + indexes + Cloud Functions to `steward-prod-65a36`
+
+Vercel handles the frontend redeploy via its own GitHub integration — nothing in this workflow touches it.
+
+## One-time setup
+
+### 1. Repo settings — enable auto-merge
+
+**Settings → General → Pull Requests → ✅ Allow auto-merge → Save.**
+
+Lets me (or anyone opening a release PR) set `--auto --merge` on `gh pr create`. The PR merges automatically once CI goes green; no human click required for the mechanical release PRs (`chore(release): vX.Y.Z` and the `develop → main` one).
+
+Feature PR review stays manual — those still need a human eyes + merge click.
+
+### 2. GCP service account for deploys
+
+Create a dedicated service account in the prod project with only the permissions needed to deploy.
+
+**In [Google Cloud Console](https://console.cloud.google.com/iam-admin/serviceaccounts?project=steward-prod-65a36):**
+
+1. **Create Service Account**
+   - Name: `github-actions-release`
+   - Description: `Used by .github/workflows/release.yml to deploy Firestore rules/indexes + Cloud Functions.`
+2. **Grant these roles** (narrow-as-possible; don't use `Owner`):
+   - `Cloud Functions Admin` — deploy functions
+   - `Cloud Datastore Index Admin` — deploy Firestore indexes
+   - `Firebase Rules Admin` — deploy Firestore rules
+   - `Service Account User` — act as the default Cloud Functions runtime SA
+   - `Cloud Build Editor` — trigger the build step for function deploys
+   - `Artifact Registry Writer` — push the function container image
+   - `Logs Writer` — emit deploy-time logs
+3. **Create key → JSON → download.** Store the downloaded file safely; you'll paste its contents into the GitHub secret below, then **delete the local copy**.
+4. Rotate the key yearly. Calendar reminder helps.
+
+> **Migration target — Workload Identity Federation (WIF)**: same permissions, no long-lived key, GitHub uses OIDC tokens to impersonate the SA. Better security posture. Worth doing once the project is stable enough that the extra 20 min of IAM config is cheap. See [google-github-actions/auth WIF setup](https://github.com/google-github-actions/auth#setting-up-workload-identity-federation).
+
+### 3. GitHub Actions secrets + variables
+
+**Settings → Secrets and variables → Actions.**
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Secret | `FIREBASE_SERVICE_ACCOUNT_JSON` | Paste the full JSON file contents from step 2.3 |
+| Variable | `STEWARD_ORIGIN_PROD` | `https://steward-ten.vercel.app` |
+
+The JSON content is multi-line; GitHub handles newlines correctly when pasted into the secret value field.
+
+### 4. Smoke-test the pipeline
+
+1. Merge a trivial no-op release (e.g., bump patch, add a CHANGELOG note).
+2. Watch the **Actions** tab for the `Release` workflow.
+3. Expected outcome:
+   - Tag `vX.Y.Z` pushed
+   - GitHub Release appears with the changelog section as its body
+   - `firestore:rules,indexes` deploy succeeds (check Firebase Console)
+   - `functions` deploy succeeds
+
+If any step fails, the workflow logs will show the exact error. Common issues:
+- **SA missing a role** → re-read the permission list above
+- **`CHANGELOG.md` section not found** → the awk regex expects `## [X.Y.Z]` with literal brackets. Match that shape.
+- **Vercel env variable missing** → set `STEWARD_ORIGIN_PROD` as a **Variable**, not a **Secret** (the workflow reads `vars.`, not `secrets.`)
+
+## What the new release flow looks like
+
+Before:
+
+1. Open `chore(release): vX.Y.Z` PR → CI → **manually merge**
+2. Open `develop → main` PR → CI → **manually merge + pause for prod approval**
+3. Sync main → tag → push tag → GitHub release
+4. `firebase deploy --only firestore:rules,firestore:indexes --project=prod` ← you paste output
+5. `firebase deploy --only functions --project=prod` ← you paste output
+
+After:
+
+1. Open `chore(release): vX.Y.Z` PR with `--auto --merge` → CI → **auto-merges**
+2. Open `develop → main` PR with `--auto --merge` → CI → **auto-merges**
+3. GHA workflow does steps 3–5 automatically
+
+You only need to:
+- Review + merge feature PRs (as always)
+- Watch the Release workflow run after each release PR lands on main
+- Respond to Actions failure notifications if anything breaks
+
+## Rollback
+
+If a release ships a bug:
+
+1. Revert the offending PR on `develop`, open a release PR immediately.
+2. Or, for an emergency: deploy the previous functions revision from the Firebase Console (**Cloud Functions → [function] → Source → Redeploy**).
+
+The GHA workflow does not delete anything, so a rollback by re-deploy is safe. It also won't overwrite a manually-deployed newer version unless someone pushes a newer version tag — the `concurrency: release` + `cancel-in-progress: false` settings queue workflow runs rather than interleave them.


### PR DESCRIPTION
Automates the 5 manual steps per release that have been slowing down the past day of hotfixes. **Feature PRs still require human review** — only the mechanical release PRs auto-merge and the post-merge tag + deploy runs unattended.

## Tier 1 — auto-merge on release PRs

Release-to-main skill now uses \`gh pr merge --auto --merge\` on:
- \`chore(release): vX.Y.Z\` (release-prep)
- \`develop → main\` (release PR)

Both auto-merge once CI goes green. No more \"I merged / now open the next PR\" round-trips.

**Requires repo setting**: Settings → Pull Requests → ✅ Allow auto-merge. I tried enabling via \`gh\` API but it didn't stick — probably needs a manual flip through the UI. Documented in the new doc.

## Tier 2 — GHA workflow on main push

New [.github/workflows/release.yml](.github/workflows/release.yml) does on every main push:

1. Read \`package.json\` version
2. Create + push \`vX.Y.Z\` tag (idempotent)
3. Create GitHub Release with CHANGELOG section as body
4. \`firebase deploy --only firestore:rules,firestore:indexes --project=steward-prod-65a36\`
5. \`firebase deploy --only functions --project=steward-prod-65a36\`

Vercel handles the frontend via its own integration — untouched.

**Auth**: service-account JSON in a repo secret. Future migration to Workload Identity Federation (OIDC) noted in the doc — same permissions, no long-lived key.

## One-time setup you'll need to do

All in [docs/release-automation.md](docs/release-automation.md):

1. Enable auto-merge in repo Settings
2. Create GCP service account \`github-actions-release\` with these roles:
   - Cloud Functions Admin
   - Cloud Datastore Index Admin
   - Firebase Rules Admin
   - Service Account User
   - Cloud Build Editor
   - Artifact Registry Writer
   - Logs Writer
3. Generate JSON key → paste into \`FIREBASE_SERVICE_ACCOUNT_JSON\` secret → **delete local copy**
4. Add \`STEWARD_ORIGIN_PROD\` variable = \`https://steward-ten.vercel.app\`

Setup takes ~15 min. One-time.

## Test plan

- [x] Typecheck, lint, format, 273 tests pass
- [ ] After merge: enable auto-merge in repo Settings
- [ ] Complete the GCP service account + secrets setup per the doc
- [ ] Smoke-test with a trivial release (bump patch to v0.9.6, small changelog note) and watch the Actions tab

## What the new flow looks like

Before: 5 manual steps per release.

After: **review + merge feature PRs** (unchanged). Releases happen automatically once I open the \`chore(release)\` + \`develop → main\` PRs with \`--auto --merge\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)