### PR TITLE
fix(release): dispatch Release workflow explicitly from auto-merge

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -29,6 +29,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Resolve + merge matching PR
+        id: merge
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
@@ -39,21 +40,42 @@ jobs:
             --repo "${{ github.repository }}" \
             --head "$HEAD_BRANCH" \
             --state open \
-            --json number,title,headRefOid,mergeable,mergeStateStatus)
+            --json number,title,baseRefName,headRefOid,mergeable,mergeStateStatus)
 
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r \
+          MATCH=$(echo "$PR_JSON" | jq -r \
             --arg sha "$HEAD_SHA" \
-            '.[] | select(.headRefOid == $sha) |
-             select(.title | test("^chore\\(release\\):|^Release:")) |
-             .number' | head -1)
+            '[.[] | select(.headRefOid == $sha) |
+              select(.title | test("^chore\\(release\\):|^Release:"))]
+             | .[0]')
 
-          if [ -z "$PR_NUMBER" ]; then
+          if [ "$MATCH" = "null" ] || [ -z "$MATCH" ]; then
             echo "No matching release PR for branch $HEAD_BRANCH @ $HEAD_SHA — nothing to auto-merge."
+            echo "merged=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "Auto-merging PR #$PR_NUMBER ($HEAD_BRANCH)"
+          PR_NUMBER=$(echo "$MATCH" | jq -r '.number')
+          BASE=$(echo "$MATCH" | jq -r '.baseRefName')
+
+          echo "Auto-merging PR #$PR_NUMBER ($HEAD_BRANCH → $BASE)"
           gh pr merge "$PR_NUMBER" \
             --repo "${{ github.repository }}" \
             --merge \
             --delete-branch
+
+          echo "merged=true" >> "$GITHUB_OUTPUT"
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+
+      # The merge above was performed by GITHUB_TOKEN, which suppresses
+      # downstream push-trigger workflows. Explicitly dispatch the
+      # Release workflow when the merged PR targeted main — that's the
+      # one that tags + deploys.
+      - name: Trigger Release workflow
+        if: steps.merge.outputs.merged == 'true' && steps.merge.outputs.base == 'main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Dispatching Release workflow on main"
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,14 @@ name: Release
 #     at deploy time via functions/.env.steward-prod-65a36.
 
 on:
+  # Chained from auto-merge-release via `gh workflow run`. Needed
+  # because GitHub suppresses downstream workflow triggers for events
+  # driven by the default GITHUB_TOKEN — a `push` trigger would never
+  # fire on an auto-merge. workflow_dispatch is explicitly allowed.
+  workflow_dispatch:
+  # Fallback for human-driven merges (manual merge via the UI, direct
+  # push recovery, etc.). Harmless if both fire — the tag-check step
+  # makes the re-run idempotent.
   push:
     branches: [main]
 

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -15,7 +15,7 @@ Vercel handles the frontend redeploy via its own GitHub integration — nothing 
 
 ### 1. Auto-merge for release PRs — self-hosted
 
-GitHub's built-in auto-merge is gated behind Pro on private repos, so we roll our own. [`.github/workflows/auto-merge-release.yml`](../.github/workflows/auto-merge-release.yml) triggers on CI completion: if the PR's title starts with `chore(release):` or `Release:` AND CI succeeded, it merges via `gh pr merge`.
+GitHub's built-in auto-merge is gated behind Pro on private repos, so we roll our own. [`.github/workflows/auto-merge-release.yml`](../.github/workflows/auto-merge-release.yml) triggers on CI completion: if the PR's title starts with `chore(release):` or `Release:` AND CI succeeded, it merges via `gh pr merge`. After merging a PR that targets `main`, it then **explicitly dispatches** the Release workflow via `gh workflow run` (necessary because GitHub suppresses downstream `push` triggers for events driven by the default `GITHUB_TOKEN` — a `push: branches: [main]` trigger alone would never fire on an auto-merge).
 
 **Nothing to configure** — the workflow uses the default `GITHUB_TOKEN` so it ships working. Feature PRs are untouched by the title filter; they still need a human review + click.
 


### PR DESCRIPTION
Smoke-test exposed: auto-merge via GITHUB_TOKEN doesn't cascade to push-triggered workflows (GitHub safety rule). Release workflow never fired on v0.9.6 merge.

Fix: add `workflow_dispatch` trigger to release.yml + have auto-merge call `gh workflow run` after merging main-bound PRs. GITHUB_TOKEN IS allowed to trigger workflow_dispatch — sanctioned escape hatch.

Once merged, I'll cut v0.9.7 as the re-test. If the full chain works, we're done with automation setup.

This PR title is not `chore(release):`/`Release:` prefixed — it's a regular feature PR, needs human merge.