### PR TITLE
fix(release): add missing permissions (actions:write + Firebase Admin)

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # `actions: write` lets `gh workflow run` dispatch the Release
+      # workflow after merging a main-bound PR. Without it the
+      # dispatch step fails with HTTP 403 "Resource not accessible by
+      # integration" and the Release workflow never fires.
+      actions: write
     steps:
       - name: Resolve + merge matching PR
         id: merge

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -34,6 +34,10 @@ Create a dedicated service account in the prod project with only the permissions
    - `Cloud Functions Admin` — deploy functions
    - `Cloud Datastore Index Admin` — deploy Firestore indexes
    - `Firebase Rules Admin` — deploy Firestore rules
+   - `Firebase Admin` — needed to read the Firebase Admin SDK config
+     (`firebase.googleapis.com/.../adminSdkConfig`) during functions
+     deploy. Without it, deploy fails with `403 The caller does not
+     have permission` before any function is updated.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image


### PR DESCRIPTION
Two gaps exposed by the v0.9.7 smoke test:

1. **`actions: write` in auto-merge workflow** — so `gh workflow run` can dispatch release.yml. Without it: HTTP 403 on the dispatch step, Release workflow never fires.
2. **Service account needs Firebase Admin role** — the deploy hits `firebase.googleapis.com/.../adminSdkConfig` which requires `firebase.projects.get`, provided by the Firebase Admin role. Missing it killed the Cloud Functions deploy step in the v0.9.7 Release workflow run.

## Your action

After merging this PR, go to https://console.cloud.google.com/iam-admin/iam?project=steward-prod-65a36 and **add the Firebase Admin role** to `github-actions-release@steward-prod-65a36.iam.gserviceaccount.com`.

Once both are in place, the v0.9.8 release will be the real smoke test — I open 2 PRs, everything else runs unattended.