### PR TITLE
chore(release): add Cloud Run Admin + Secret Manager Accessor roles

### DIFF
--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -32,12 +32,17 @@ Create a dedicated service account in the prod project with only the permissions
    - Description: `Used by .github/workflows/release.yml to deploy Firestore rules/indexes + Cloud Functions.`
 2. **Grant these roles** (narrow-as-possible; don't use `Owner`):
    - `Cloud Functions Admin` — deploy functions
+   - `Cloud Run Admin` — update the underlying Cloud Run services (Gen2 functions run on Cloud Run)
    - `Cloud Datastore Index Admin` — deploy Firestore indexes
    - `Firebase Rules Admin` — deploy Firestore rules
-   - `Firebase Admin` — needed to read the Firebase Admin SDK config
+   - `Firebase Admin` — read the Firebase Admin SDK config
      (`firebase.googleapis.com/.../adminSdkConfig`) during functions
      deploy. Without it, deploy fails with `403 The caller does not
      have permission` before any function is updated.
+   - `Secret Manager Secret Accessor` — read Twilio secrets
+     (`TWILIO_ACCOUNT_SID`, etc.) that the Cloud Functions declare
+     via `defineSecret`. Without it, deploy fails with `403
+     Permission 'secretmanager.secrets.get' denied`.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image


### PR DESCRIPTION
## Summary
- v0.9.7's re-dispatched Release workflow surfaced two more missing roles on `github-actions-release@steward-prod-65a36.iam.gserviceaccount.com`
- Functions deploy failed with `403 Permission 'secretmanager.secrets.get' denied on resource .../secrets/TWILIO_ACCOUNT_SID` because functions declare Twilio creds via `defineSecret` — the SA needs Secret Manager Secret Accessor to read them
- Gen2 functions run on Cloud Run, so Cloud Run Admin is also required for the deploy step to update the underlying service

## Required action from user (after merge)

In [Google Cloud Console → IAM for steward-prod-65a36](https://console.cloud.google.com/iam-admin/iam?project=steward-prod-65a36), add these two roles to `github-actions-release@steward-prod-65a36.iam.gserviceaccount.com`:

- [ ] `Cloud Run Admin`
- [ ] `Secret Manager Secret Accessor`

Then re-dispatch the Release workflow (Actions → Release → Run workflow → main) to finish v0.9.7's functions deploy.

## Test plan
- [ ] Merge this PR
- [ ] Add the two GCP roles
- [ ] Re-dispatch Release workflow for v0.9.7
- [ ] Functions deploy succeeds
- [ ] Cut v0.9.8 as real end-to-end smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)