### PR TITLE
ci: skip lint/test/e2e on docs-only changes via path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide which expensive jobs actually need to run. Docs-only PRs
+  # (changelog prose, CLAUDE.md, docs/**, .claude/**) shouldn't pay
+  # for a 10-minute lint + typecheck + Vitest + Playwright cycle.
+  # This job ALWAYS runs and always succeeds, so the overall
+  # workflow conclusion stays `success` for auto-merge + required
+  # status checks, even when the two downstream jobs skip.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      functions: ${{ steps.filter.outputs.functions }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'src/**'
+              - 'public/**'
+              - 'scripts/**'
+              - 'e2e/**'
+              - 'tests/**'
+              - 'functions/**'
+              - 'firestore.rules'
+              - 'firestore.indexes.json'
+              - 'firebase.json'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'vite.config.ts'
+              - 'vitest.config.ts'
+              - 'vitest.rules.config.ts'
+              - 'playwright.config.ts'
+              - 'playwright.emulators.config.ts'
+              - 'tsconfig*.json'
+              - 'biome.json'
+              - 'vercel.json'
+              - 'index.html'
+              - '.github/workflows/ci.yml'
+            functions:
+              - 'functions/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/ci.yml'
+
   ci:
     name: lint · format · typecheck · test · build · e2e
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -77,6 +126,8 @@ jobs:
 
   functions:
     name: functions · build · test
+    needs: changes
+    if: needs.changes.outputs.functions == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    # dorny/paths-filter calls the PR listFiles API for pull_request
+    # events. Needs pull-requests: read because the default
+    # GITHUB_TOKEN scope on this repo doesn't include it.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       app: ${{ steps.filter.outputs.app }}
       functions: ${{ steps.filter.outputs.functions }}


### PR DESCRIPTION
## Summary
- Adds a `changes` gate job using `dorny/paths-filter@v3` to detect whether code paths were touched
- Heavy `ci` + `functions` jobs now skip via `if:` when nothing code-relevant changed
- Gate job always runs + always succeeds → workflow conclusion stays `success`, so required status checks + auto-merge-release's `workflow_run` trigger both still fire on docs-only PRs
- Release PRs always touch `package.json`, so they trip the app filter and run full CI — zero risk of shipping untested code

## Why
Docs-only PRs (e.g. #99's two-line edit to `docs/release-automation.md`) were paying for the full ~10 min lint + format + typecheck + Vitest + rules + Playwright cycle. Pure overhead.

## Filter coverage
**App filter (triggers lint/test/e2e):** src, public, scripts, e2e, tests, functions, firestore.rules/indexes/firebase.json, package.json, pnpm-lock.yaml, pnpm-workspace.yaml, vite/vitest/playwright/tsconfig/biome configs, vercel.json, index.html, .github/workflows/ci.yml

**Functions filter (triggers functions build/test):** functions, pnpm-lock.yaml, pnpm-workspace.yaml, .github/workflows/ci.yml

**Neither triggers:** *.md, docs/**, .claude/**, CLAUDE.md, CHANGELOG.md-only changes, design/**, tasks/**, .github/ISSUE_TEMPLATE/**, .github/workflows/{release,auto-merge-release}.yml

## Test plan
- [ ] CI on this PR runs full pipeline (touches `.github/workflows/ci.yml` → matches both filters)
- [ ] Merge and watch next docs-only PR skip lint/test/e2e but still report success
- [ ] Auto-merge-release still fires on next `chore(release):` PR (verifies workflow_run sees success conclusion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)