### PR TITLE
chore(release): swap Secret Manager role Accessor → Viewer

### DIFF
--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -39,10 +39,16 @@ Create a dedicated service account in the prod project with only the permissions
      (`firebase.googleapis.com/.../adminSdkConfig`) during functions
      deploy. Without it, deploy fails with `403 The caller does not
      have permission` before any function is updated.
-   - `Secret Manager Secret Accessor` — read Twilio secrets
+   - `Secret Manager Viewer` — read metadata on the Twilio secrets
      (`TWILIO_ACCOUNT_SID`, etc.) that the Cloud Functions declare
-     via `defineSecret`. Without it, deploy fails with `403
-     Permission 'secretmanager.secrets.get' denied`.
+     via `defineSecret`. The Firebase CLI calls `secrets.get` during
+     deploy to verify each secret exists + is versioned; that
+     permission is in **Viewer**, *not* `Secret Manager Secret
+     Accessor` (Accessor only grants `versions.access` — the
+     permission the function's own runtime SA uses to read the
+     value at invoke time, which is a separate binding). Without
+     Viewer, deploy fails with `403 Permission
+     'secretmanager.secrets.get' denied`.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image


### PR DESCRIPTION
## Summary
- PR #99's guidance was incomplete — the deploy path needs `secrets.get`, which lives in `roles/secretmanager.viewer`, not `roles/secretmanager.secretAccessor`
- Accessor grants `versions.access` only — the permission the **runtime SA** uses at invoke time to actually read the value; separate concern from deploy
- Proven empirically: granted Accessor, re-dispatched Release twice, same 403 both times

## Required action (after merge)

In [IAM for steward-prod-65a36](https://console.cloud.google.com/iam-admin/iam?project=steward-prod-65a36), on `github-actions-release@steward-prod-65a36.iam.gserviceaccount.com`:

- [ ] **Add**: `Secret Manager Viewer`
- [ ] **Optionally remove**: `Secret Manager Secret Accessor` (it was not harmful, but it's unused at deploy time — the runtime SA is a different principal, typically `308185652610-compute@developer.gserviceaccount.com`, which already has it implicitly via default Editor)

Then re-dispatch Release → main.

## Test plan
- [ ] Merge this PR (auto-merge title matches)
- [ ] Add Secret Manager Viewer role
- [ ] Re-dispatch Release; functions deploy should complete
- [ ] Cut v0.9.8 as true end-to-end smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)