### PR TITLE
chore(release): document Cloud Scheduler + Eventarc Admin roles

### DIFF
--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -67,6 +67,15 @@ Create a dedicated service account in the prod project with only the permissions
      value at invoke time, which is a separate binding). Without
      Viewer, deploy fails with `403 Permission
      'secretmanager.secrets.get' denied`.
+   - `Cloud Scheduler Admin` — create / update the Cloud Scheduler
+     jobs that back `scheduledNudges` + `drainNotificationQueue`.
+     Without it, deploy fails near the end with `403 lacks IAM
+     permission "cloudscheduler.jobs.update"` and Firebase skips
+     subsequent deletes.
+   - `Eventarc Admin` — create / update the Eventarc triggers that
+     back Firestore-event functions (`onMeetingWrite`,
+     `onCommentCreate`, `onInvitationWrite`). Gen2 Firestore
+     triggers are Eventarc under the hood.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image


### PR DESCRIPTION
## Summary
- Closes the documentation loop on the release pipeline by listing the final two SA roles discovered during v0.9.7's smoke test
- Release pipeline is now fully green end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)