### PR TITLE
Release: v0.9.8 — CI path filter + release pipeline docs close-out

### DIFF
--- a/.github/workflows/auto-merge-release.yml
+++ b/.github/workflows/auto-merge-release.yml
@@ -27,6 +27,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      # `actions: write` lets `gh workflow run` dispatch the Release
+      # workflow after merging a main-bound PR. Without it the
+      # dispatch step fails with HTTP 403 "Resource not accessible by
+      # integration" and the Release workflow never fires.
+      actions: write
     steps:
       - name: Resolve + merge matching PR
         id: merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Decide which expensive jobs actually need to run. Docs-only PRs
+  # (changelog prose, CLAUDE.md, docs/**, .claude/**) shouldn't pay
+  # for a 10-minute lint + typecheck + Vitest + Playwright cycle.
+  # This job ALWAYS runs and always succeeds, so the overall
+  # workflow conclusion stays `success` for auto-merge + required
+  # status checks, even when the two downstream jobs skip.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+      functions: ${{ steps.filter.outputs.functions }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'src/**'
+              - 'public/**'
+              - 'scripts/**'
+              - 'e2e/**'
+              - 'tests/**'
+              - 'functions/**'
+              - 'firestore.rules'
+              - 'firestore.indexes.json'
+              - 'firebase.json'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - 'vite.config.ts'
+              - 'vitest.config.ts'
+              - 'vitest.rules.config.ts'
+              - 'playwright.config.ts'
+              - 'playwright.emulators.config.ts'
+              - 'tsconfig*.json'
+              - 'biome.json'
+              - 'vercel.json'
+              - 'index.html'
+              - '.github/workflows/ci.yml'
+            functions:
+              - 'functions/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/ci.yml'
+
   ci:
     name: lint · format · typecheck · test · build · e2e
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:
@@ -77,6 +126,8 @@ jobs:
 
   functions:
     name: functions · build · test
+    needs: changes
+    if: needs.changes.outputs.functions == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
+    # dorny/paths-filter calls the PR listFiles API for pull_request
+    # events. Needs pull-requests: read because the default
+    # GITHUB_TOKEN scope on this repo doesn't include it.
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       app: ${{ steps.filter.outputs.app }}
       functions: ${{ steps.filter.outputs.functions }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.8] — 2026-04-24
+
+Infrastructure-only release. No user-visible change — this is the
+clean-slate smoke test of the now-fully-automated release pipeline
+after v0.9.7's staged permission rollout, plus a CI-time
+optimization for docs-only changes.
+
+### Infrastructure
+
+- **CI path filter** (#100). A new `changes` gate job uses
+  `dorny/paths-filter` to decide whether the expensive lint +
+  format + typecheck + Vitest + rules + Playwright cycle and the
+  functions build/test job actually need to run. Docs-only PRs
+  (e.g. edits to `docs/**`, `CLAUDE.md`, `.claude/**`, CHANGELOG
+  prose) now finish CI in under ten seconds instead of ~3 minutes.
+  The gate job always runs and always succeeds, so required status
+  checks stay green and `auto-merge-release`'s `workflow_run`
+  trigger still fires — no behaviour change for release flows.
+- **Release pipeline IAM + API documentation completed**
+  (#99, #101, #102, #103). The release service account's role list
+  in `docs/release-automation.md` now reflects what v0.9.7's
+  empirical smoke test actually needed: `Cloud Run Admin` (Gen2
+  functions on Cloud Run), `Secret Manager Viewer` (read metadata
+  on `defineSecret`-declared Twilio creds during deploy — *not*
+  `Secret Manager Secret Accessor`, which is a runtime-SA concern),
+  `Cloud Scheduler Admin` (for `scheduledNudges` +
+  `drainNotificationQueue`), and `Eventarc Admin` (for Firestore-
+  triggered functions). A new setup step also enumerates the
+  `gcloud services enable` list so the Cloud Billing API pre-check
+  doesn't 403 on a fresh SA-driven deploy.
+
 ## [0.9.7] — 2026-04-24
 
 Release-pipeline smoke-test follow-up. v0.9.6 merged to main but the
@@ -1018,7 +1049,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.7...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.8...HEAD
+[0.9.8]: https://github.com/aylabyuk/steward/releases/tag/v0.9.8
 [0.9.7]: https://github.com/aylabyuk/steward/releases/tag/v0.9.7
 [0.9.6]: https://github.com/aylabyuk/steward/releases/tag/v0.9.6
 [0.9.5]: https://github.com/aylabyuk/steward/releases/tag/v0.9.5

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -21,7 +21,25 @@ GitHub's built-in auto-merge is gated behind Pro on private repos, so we roll ou
 
 If GitHub ever flips auto-merge into the free plan, this workflow can be deleted + release-to-main skill reverts to `gh pr merge --auto`. Until then, the self-host is cheaper than $4/mo for Pro.
 
-### 2. GCP service account for deploys
+### 2. Enable required APIs on the prod project
+
+The deploy SA can only act on APIs that are actually enabled on `steward-prod-65a36`. Some of these were enabled when the Firebase project was first provisioned; `cloudbilling.googleapis.com` in particular is often disabled on hobby-tier projects and has to be turned on explicitly before the first GHA-driven deploy.
+
+```bash
+gcloud services enable \
+  cloudbilling.googleapis.com \
+  cloudfunctions.googleapis.com \
+  cloudbuild.googleapis.com \
+  run.googleapis.com \
+  artifactregistry.googleapis.com \
+  secretmanager.googleapis.com \
+  firebaseextensions.googleapis.com \
+  --project=steward-prod-65a36
+```
+
+Firebase CLI will auto-enable most of these on first use when invoked by an Owner, but the SA-driven path can't — it'll 403 with "Cloud Billing API has not been used in project 308185652610 before or it is disabled" on the billing check that runs before function upload.
+
+### 3. GCP service account for deploys
 
 Create a dedicated service account in the prod project with only the permissions needed to deploy.
 
@@ -58,18 +76,18 @@ Create a dedicated service account in the prod project with only the permissions
 
 > **Migration target — Workload Identity Federation (WIF)**: same permissions, no long-lived key, GitHub uses OIDC tokens to impersonate the SA. Better security posture. Worth doing once the project is stable enough that the extra 20 min of IAM config is cheap. See [google-github-actions/auth WIF setup](https://github.com/google-github-actions/auth#setting-up-workload-identity-federation).
 
-### 3. GitHub Actions secrets + variables
+### 4. GitHub Actions secrets + variables
 
 **Settings → Secrets and variables → Actions.**
 
 | Kind | Name | Value |
 | --- | --- | --- |
-| Secret | `FIREBASE_SERVICE_ACCOUNT_JSON` | Paste the full JSON file contents from step 2.3 |
+| Secret | `FIREBASE_SERVICE_ACCOUNT_JSON` | Paste the full JSON file contents from step 3.3 |
 | Variable | `STEWARD_ORIGIN_PROD` | `https://steward-ten.vercel.app` |
 
 The JSON content is multi-line; GitHub handles newlines correctly when pasted into the secret value field.
 
-### 4. Smoke-test the pipeline
+### 5. Smoke-test the pipeline
 
 1. Merge a trivial no-op release (e.g., bump patch, add a CHANGELOG note).
 2. Watch the **Actions** tab for the `Release` workflow.

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -39,10 +39,16 @@ Create a dedicated service account in the prod project with only the permissions
      (`firebase.googleapis.com/.../adminSdkConfig`) during functions
      deploy. Without it, deploy fails with `403 The caller does not
      have permission` before any function is updated.
-   - `Secret Manager Secret Accessor` — read Twilio secrets
+   - `Secret Manager Viewer` — read metadata on the Twilio secrets
      (`TWILIO_ACCOUNT_SID`, etc.) that the Cloud Functions declare
-     via `defineSecret`. Without it, deploy fails with `403
-     Permission 'secretmanager.secrets.get' denied`.
+     via `defineSecret`. The Firebase CLI calls `secrets.get` during
+     deploy to verify each secret exists + is versioned; that
+     permission is in **Viewer**, *not* `Secret Manager Secret
+     Accessor` (Accessor only grants `versions.access` — the
+     permission the function's own runtime SA uses to read the
+     value at invoke time, which is a separate binding). Without
+     Viewer, deploy fails with `403 Permission
+     'secretmanager.secrets.get' denied`.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -67,6 +67,15 @@ Create a dedicated service account in the prod project with only the permissions
      value at invoke time, which is a separate binding). Without
      Viewer, deploy fails with `403 Permission
      'secretmanager.secrets.get' denied`.
+   - `Cloud Scheduler Admin` — create / update the Cloud Scheduler
+     jobs that back `scheduledNudges` + `drainNotificationQueue`.
+     Without it, deploy fails near the end with `403 lacks IAM
+     permission "cloudscheduler.jobs.update"` and Firebase skips
+     subsequent deletes.
+   - `Eventarc Admin` — create / update the Eventarc triggers that
+     back Firestore-event functions (`onMeetingWrite`,
+     `onCommentCreate`, `onInvitationWrite`). Gen2 Firestore
+     triggers are Eventarc under the hood.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -32,12 +32,17 @@ Create a dedicated service account in the prod project with only the permissions
    - Description: `Used by .github/workflows/release.yml to deploy Firestore rules/indexes + Cloud Functions.`
 2. **Grant these roles** (narrow-as-possible; don't use `Owner`):
    - `Cloud Functions Admin` — deploy functions
+   - `Cloud Run Admin` — update the underlying Cloud Run services (Gen2 functions run on Cloud Run)
    - `Cloud Datastore Index Admin` — deploy Firestore indexes
    - `Firebase Rules Admin` — deploy Firestore rules
-   - `Firebase Admin` — needed to read the Firebase Admin SDK config
+   - `Firebase Admin` — read the Firebase Admin SDK config
      (`firebase.googleapis.com/.../adminSdkConfig`) during functions
      deploy. Without it, deploy fails with `403 The caller does not
      have permission` before any function is updated.
+   - `Secret Manager Secret Accessor` — read Twilio secrets
+     (`TWILIO_ACCOUNT_SID`, etc.) that the Cloud Functions declare
+     via `defineSecret`. Without it, deploy fails with `403
+     Permission 'secretmanager.secrets.get' denied`.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image

--- a/docs/release-automation.md
+++ b/docs/release-automation.md
@@ -34,6 +34,10 @@ Create a dedicated service account in the prod project with only the permissions
    - `Cloud Functions Admin` — deploy functions
    - `Cloud Datastore Index Admin` — deploy Firestore indexes
    - `Firebase Rules Admin` — deploy Firestore rules
+   - `Firebase Admin` — needed to read the Firebase Admin SDK config
+     (`firebase.googleapis.com/.../adminSdkConfig`) during functions
+     deploy. Without it, deploy fails with `403 The caller does not
+     have permission` before any function is updated.
    - `Service Account User` — act as the default Cloud Functions runtime SA
    - `Cloud Build Editor` — trigger the build step for function deploys
    - `Artifact Registry Writer` — push the function container image

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",


### PR DESCRIPTION
## Summary
Infrastructure-only release. No user-visible app changes since v0.9.7.

- **CI path filter** (#100): docs-only PRs skip the full lint/format/typecheck/test/build/e2e cycle and finish CI in under 10 seconds. Gate job always runs + succeeds so required checks + auto-merge still work.
- **Release pipeline IAM + API docs** (#99, #101, #102, #103): the release SA's role list in `docs/release-automation.md` now reflects what v0.9.7's empirical smoke test actually needed — Cloud Run Admin, Secret Manager Viewer (not Accessor), Cloud Scheduler Admin, Eventarc Admin, plus a `gcloud services enable` step so the Cloud Billing API pre-check doesn't 403 on a fresh SA-driven deploy.

## Test plan
- [ ] Auto-merge via `^Release:` title prefix
- [ ] Release workflow dispatches, tags v0.9.8, creates GH Release
- [ ] Firestore rules + indexes deploy (no-op since no changes)
- [ ] Cloud Functions deploy (no-op since no functions changes)
- [ ] Verify prod push still works (already verified on v0.9.7)

---

Note: v0.9.8 does NOT address the ongoing unsubscribe-on-chat bug — separate investigation underway with fresh diagnostic data captured 06:00–06:07 UTC today.