### PR TITLE
fix(notifications): unregister leftover /firebase-cloud-messaging-push-scope SW on boot

### DIFF
--- a/src/lib/registerSw.ts
+++ b/src/lib/registerSw.ts
@@ -6,15 +6,47 @@
  *
  * No-op on the server / in tests where `navigator` isn't available.
  */
+
+// Scope Firebase's web SDK uses when nothing passes `serviceWorkerRegistration`
+// to getToken()/deleteToken(). Historical Steward builds (pre-v0.9.3) let this
+// get registered by accident, and browsers keep it alive indefinitely. A fresh
+// token minted against our primary scope-"/" registration can then get
+// invalidated when the ghost's presence triggers FCM's "newer subscription
+// supersedes older" logic — the symptom tracked in issue #106.
+const GHOST_SCOPE_SUFFIX = "/firebase-cloud-messaging-push-scope";
+
+async function unregisterGhostScopeRegistration(): Promise<void> {
+  try {
+    const regs = await navigator.serviceWorker.getRegistrations();
+    for (const reg of regs) {
+      if (reg.scope.endsWith(GHOST_SCOPE_SUFFIX)) {
+        const ok = await reg.unregister();
+        // Surface the event so a clean-slate test can tell us whether the ghost
+        // is a one-time persistent leftover (never logs again) or actively
+        // recreated (logs every reload). Left as console.info — a real logger
+        // doesn't pay its way for a one-shot migration step.
+        console.info(`[steward] unregistered leftover FCM push-scope SW (${reg.scope}) → ${ok}`);
+      }
+    }
+  } catch (err) {
+    console.warn("[steward] ghost FCM SW cleanup failed", err);
+  }
+}
+
 export function registerFcmServiceWorker(): void {
   if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
   // Defer past first paint so we don't block hydration.
   window.addEventListener(
     "load",
     () => {
-      navigator.serviceWorker.register("/firebase-messaging-sw.js").catch((err) => {
-        console.error("FCM service worker registration failed", err);
-      });
+      void (async () => {
+        await unregisterGhostScopeRegistration();
+        try {
+          await navigator.serviceWorker.register("/firebase-messaging-sw.js");
+        } catch (err) {
+          console.error("FCM service worker registration failed", err);
+        }
+      })();
     },
     { once: true },
   );


### PR DESCRIPTION
## Summary

Addresses the core symptom of #106 (FCM tokens dying after 2–4 pushes on one bishopric user). On app boot, enumerate existing service-worker registrations and unregister any at scope `/firebase-cloud-messaging-push-scope` before our own SW registers.

## Why

Diagnostic logs shipped in v0.9.5 + v0.9.6 proved the server side works correctly — FCM rejects the affected user's tokens with `messaging/registration-token-not-registered` shortly after each fresh subscribe (~2–4 sends). DevTools on that user's browser shows a ghost SW at `/firebase-cloud-messaging-push-scope` alongside the legitimate one at `/`, both pointing at our `firebase-messaging-sw.js`.

Deployed-bundle analysis:
- `DEFAULT_SW_SCOPE = "/firebase-cloud-messaging-push-scope"` only appears in Firebase's `registerDefaultSw`, called from:
  - `updateSwReg(messaging, swReg)` — guarded by `!swReg && !messaging.swRegistration`. We always pass `swReg`.
  - `deleteToken(messaging)` — fires if `messaging.swRegistration` unset. Our only caller is `unsubscribeDevice`, which is gated behind a Remove-device click.

User confirmed the ghost appears immediately after fresh load + sign-in, BEFORE any Enable/Remove click. No current code path in this repo can explain that, so the ghost is almost certainly a persistent leftover from pre-v0.9.3 builds (when the SW imported the compat SDK and some subscribe flows didn't hand an explicit `swReg` to `getToken`). Chrome keeps the registration alive indefinitely; manually unregistering from DevTools appears not to stick either.

Even if the hypothesis is off, the ghost's mere existence correlates with FCM's "newer subscription supersedes older" invalidation — so removing it is a worthwhile defensive step.

## What ships

- [src/lib/registerSw.ts](src/lib/registerSw.ts) now:
  1. Enumerates all SW registrations via `navigator.serviceWorker.getRegistrations()`
  2. Unregisters anything with scope ending in `/firebase-cloud-messaging-push-scope`
  3. Logs each removal at `console.info` (signal for the post-ship diagnostic)
  4. Then registers our `/firebase-messaging-sw.js` as before

## How to verify after merge + prod deploy

On the affected browser:
1. Open DevTools Console
2. Visit `https://steward-ten.vercel.app`, sign in
3. Look for `[steward] unregistered leftover FCM push-scope SW (...) → true`

Then:
- **If the message appears once + Application → Service Workers shows only the `/` scope**: fix works, ghost was a persistent leftover. Exercise push — token should live through many sends.
- **If the message appears on EVERY reload**: ghost is being re-created somewhere we haven't found. The log tells us we need to keep digging, but the cleanup still blocks FCM-scope invalidation mid-session.

## Not in scope

- Migration path for the unknown creator (if logs say it re-appears every load). That's a follow-up in #106.
- Touching the subscribe/unsubscribe flows themselves — they remain correct per bundle analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)