### PR TITLE
fix(notifications): prime messaging.swRegistration on boot to block Firebase ghost SW (#106)

### DIFF
--- a/src/lib/registerSw.ts
+++ b/src/lib/registerSw.ts
@@ -4,16 +4,27 @@
  * the install prompt). Subscribe + push handling happens in
  * `features/notifications/fcmToken.ts`.
  *
+ * Also primes the Firebase messaging singleton's `swRegistration` to point
+ * at our scope-"/" registration so Firebase's internal
+ * `registerDefaultSw` never fires — see issue #106 for the chase. Without
+ * this, the first callable function invocation (e.g.
+ * `callIssueSpeakerSession` from `TwilioAutoConnect`) triggers
+ * `Functions.contextProvider.getContext()` →
+ * `this.messaging.getToken()` (no args), which calls the SDK's internal
+ * `Tke(messaging, undefined)` → `registerDefaultSw(messaging)` and lands
+ * a ghost SW at scope `/firebase-cloud-messaging-push-scope`. That ghost
+ * then contends with our real registration and FCM invalidates the
+ * primary push subscription (observed as
+ * `messaging/registration-token-not-registered` after 2–4 sends).
+ *
  * No-op on the server / in tests where `navigator` isn't available.
  */
 
-// Scope Firebase's web SDK uses when nothing passes `serviceWorkerRegistration`
-// to getToken()/deleteToken(). Historical Steward builds (pre-v0.9.3) let this
-// get registered by accident, and browsers keep it alive indefinitely. A fresh
-// token minted against our primary scope-"/" registration can then get
-// invalidated when the ghost's presence triggers FCM's "newer subscription
-// supersedes older" logic — the symptom tracked in issue #106.
+import { getMessaging } from "firebase/messaging";
+import { app } from "./firebase";
+
 const GHOST_SCOPE_SUFFIX = "/firebase-cloud-messaging-push-scope";
+const SW_PATH = "/firebase-messaging-sw.js";
 
 async function unregisterGhostScopeRegistration(): Promise<void> {
   try {
@@ -21,15 +32,40 @@ async function unregisterGhostScopeRegistration(): Promise<void> {
     for (const reg of regs) {
       if (reg.scope.endsWith(GHOST_SCOPE_SUFFIX)) {
         const ok = await reg.unregister();
-        // Surface the event so a clean-slate test can tell us whether the ghost
-        // is a one-time persistent leftover (never logs again) or actively
-        // recreated (logs every reload). Left as console.info — a real logger
-        // doesn't pay its way for a one-shot migration step.
         console.info(`[steward] unregistered leftover FCM push-scope SW (${reg.scope}) → ${ok}`);
       }
     }
   } catch (err) {
     console.warn("[steward] ghost FCM SW cleanup failed", err);
+  }
+}
+
+/** Seed the Firebase messaging singleton with our SW registration so its
+ *  internal `updateSwReg(messaging, undefined)` path (reachable via
+ *  `Functions.contextProvider.getMessagingToken()`) skips
+ *  `registerDefaultSw` and never creates a registration at
+ *  `/firebase-cloud-messaging-push-scope`.
+ *
+ *  Direct assignment is the cheapest way to set the property without
+ *  triggering `getToken()`'s permission prompt — we explicitly don't
+ *  want to prompt on boot. `swRegistration` is a non-public field on
+ *  the `MessagingService` class, so we cast; the property has existed
+ *  since messaging was introduced and is what all internal paths read
+ *  and write. */
+async function primeMessagingSwRegistration(swReg: ServiceWorkerRegistration): Promise<void> {
+  try {
+    // getMessaging is safe to call on boot — it just constructs the
+    // service object; nothing is sent over the network and no SW is
+    // registered as a side effect.
+    const messaging = getMessaging(app) as unknown as {
+      swRegistration?: ServiceWorkerRegistration;
+    };
+    messaging.swRegistration = swReg;
+  } catch (err) {
+    // Environments without messaging support (jsdom, some mobile
+    // browsers) throw from getMessaging. Swallow — downstream code
+    // already degrades via getMessagingIfSupported().
+    console.warn("[steward] prime messaging.swRegistration skipped", err);
   }
 }
 
@@ -42,7 +78,8 @@ export function registerFcmServiceWorker(): void {
       void (async () => {
         await unregisterGhostScopeRegistration();
         try {
-          await navigator.serviceWorker.register("/firebase-messaging-sw.js");
+          const swReg = await navigator.serviceWorker.register(SW_PATH);
+          await primeMessagingSwRegistration(swReg);
         } catch (err) {
           console.error("FCM service worker registration failed", err);
         }


### PR DESCRIPTION
## Root cause for #106 (found!)

Bundle-level trace of what creates the ghost SW at `/firebase-cloud-messaging-push-scope`:

1. [TwilioAutoConnect](src/features/invitations/TwilioAutoConnect.tsx) runs on every `/schedule` mount for a signed-in bishop.
2. It calls `callIssueSpeakerSession` — a Firebase Functions callable.
3. Inside the SDK, `Functions.contextProvider.getContext()` calls `getMessagingToken()` as part of every callable invocation to populate the `Firebase-Instance-ID-Token` header. That function short-circuits only when `Notification.permission !== 'granted'`.
4. **Chrome persists notification permission across "Clear site data".** Any user who ever granted permission falls through to `this.messaging.getToken()` — **with no arguments**.
5. `getToken(messaging, undefined)` → `Tke(messaging, undefined)` → `!t && !e.swRegistration` is true → `registerDefaultSw(messaging)` → `navigator.serviceWorker.register("/firebase-messaging-sw.js", { scope: "/firebase-cloud-messaging-push-scope" })`.
6. The ghost's push subscription then contends with our scope-`/` subscription; FCM invalidates one of them. Observable as `messaging/registration-token-not-registered` after 2–4 sends.

Empirically validated:
- **Incognito** (no persisted notification permission) never produces the ghost — matches the step-3 guard.
- **Affected browser** produces the ghost ~seconds after sign-in + ward load, coinciding with `TwilioAutoConnect` firing the callable.

## Fix

On app boot, after registering our `/firebase-messaging-sw.js` at scope `/`, construct the messaging singleton and assign `messaging.swRegistration` to the fresh registration directly:

```ts
const messaging = getMessaging(app) as unknown as { swRegistration?: ServiceWorkerRegistration };
messaging.swRegistration = swReg;
```

This short-circuits `Tke(messaging, undefined)`:

```js
if (!t && !e.swRegistration && await pee(e), ...)
//      ^^^^^^^^^^^^^^^^^^
//      now false → registerDefaultSw skipped
```

All internal token lookups (Functions callable headers, `deleteToken`, etc.) now reuse our primary registration. Push subscriptions are minted once per user and stay stable.

## Why not `getToken()` instead of direct assignment

Calling `getToken(messaging, { serviceWorkerRegistration: swReg })` would also prime the slot, but it:
- Prompts for notification permission if not already granted (we don't want that on plain boot)
- Creates/refreshes a push subscription as a side effect
- Requires a VAPID key

Direct property assignment is zero-cost, zero-prompt, runs for every user regardless of permission state, and the `swRegistration` field has been the only storage slot since the Firebase web SDK introduced messaging in v9.

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm format:check` · `pnpm test` (273 tests) — all green
- [ ] After merge + release: on the affected browser, clear site data + reload. Verify Application → Service Workers shows only one SW at scope `/`. Fire 10+ pushes and confirm token survives.

## Follow-up

- The defensive boot-time unregister of `/firebase-cloud-messaging-push-scope` scope from v0.9.9 (PR #107) stays in place as a backstop — it will clean up any ghost that made it onto a user's profile before this fix shipped.
- Close #106 once verified in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)