### PR TITLE
Release: v0.9.10 — root-cause fix for FCM ghost SW (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.10] — 2026-04-24
+
+Root-cause fix for #106. v0.9.9 shipped a defensive boot cleanup;
+this release stops the ghost SW from ever being created in the
+first place.
+
+### Fixed
+
+- **Prime `messaging.swRegistration` on boot** (#110). The ghost
+  service worker at `/firebase-cloud-messaging-push-scope` was being
+  registered by Firebase's own SDK during every callable invocation.
+  Trace: `TwilioAutoConnect` (active on `/schedule` for any signed-in
+  bishop) → `callIssueSpeakerSession` → Firebase Functions' shared
+  `contextProvider.getContext()` → `getMessagingToken()` →
+  `messaging.getToken()` with no args → `Tke(messaging, undefined)` →
+  `registerDefaultSw(messaging)` →
+  `navigator.serviceWorker.register("/firebase-messaging-sw.js",
+  { scope: "/firebase-cloud-messaging-push-scope" })`.
+
+  Critically, `getMessagingToken()`'s guard only bails when
+  `Notification.permission !== 'granted'` — and that permission
+  survives "Clear site data" in Chrome. Any user who ever granted
+  notification permission hit the ghost path every time they
+  visited `/schedule`. Two concurrent push subscriptions (one on our
+  scope-`/` SW, one on the ghost) then contended; FCM invalidated
+  one of them and emitted
+  `messaging/registration-token-not-registered` after 2–4 sends.
+  That matches the server-side diagnostic logs captured from v0.9.5
+  onward.
+
+  The fix is a one-liner: after registering our SW on boot,
+  construct the messaging singleton and assign
+  `messaging.swRegistration = swReg` directly. That short-circuits
+  Firebase's internal `registerDefaultSw` call for every future
+  callable-triggered token lookup. No permission prompt, no extra
+  network traffic, no push-subscription churn.
+
+  The defensive boot-time unregister of any existing
+  `/firebase-cloud-messaging-push-scope` registration from v0.9.9
+  stays in place as a backstop for users who already had the ghost
+  on their profile before this release.
+
 ## [0.9.9] — 2026-04-24
 
 Defensive fix targeting the unsubscribe-on-chat bug (#106). Diagnostic
@@ -1079,7 +1121,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.9...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.10...HEAD
+[0.9.10]: https://github.com/aylabyuk/steward/releases/tag/v0.9.10
 [0.9.9]: https://github.com/aylabyuk/steward/releases/tag/v0.9.9
 [0.9.8]: https://github.com/aylabyuk/steward/releases/tag/v0.9.8
 [0.9.7]: https://github.com/aylabyuk/steward/releases/tag/v0.9.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/lib/registerSw.ts
+++ b/src/lib/registerSw.ts
@@ -4,16 +4,27 @@
  * the install prompt). Subscribe + push handling happens in
  * `features/notifications/fcmToken.ts`.
  *
+ * Also primes the Firebase messaging singleton's `swRegistration` to point
+ * at our scope-"/" registration so Firebase's internal
+ * `registerDefaultSw` never fires — see issue #106 for the chase. Without
+ * this, the first callable function invocation (e.g.
+ * `callIssueSpeakerSession` from `TwilioAutoConnect`) triggers
+ * `Functions.contextProvider.getContext()` →
+ * `this.messaging.getToken()` (no args), which calls the SDK's internal
+ * `Tke(messaging, undefined)` → `registerDefaultSw(messaging)` and lands
+ * a ghost SW at scope `/firebase-cloud-messaging-push-scope`. That ghost
+ * then contends with our real registration and FCM invalidates the
+ * primary push subscription (observed as
+ * `messaging/registration-token-not-registered` after 2–4 sends).
+ *
  * No-op on the server / in tests where `navigator` isn't available.
  */
 
-// Scope Firebase's web SDK uses when nothing passes `serviceWorkerRegistration`
-// to getToken()/deleteToken(). Historical Steward builds (pre-v0.9.3) let this
-// get registered by accident, and browsers keep it alive indefinitely. A fresh
-// token minted against our primary scope-"/" registration can then get
-// invalidated when the ghost's presence triggers FCM's "newer subscription
-// supersedes older" logic — the symptom tracked in issue #106.
+import { getMessaging } from "firebase/messaging";
+import { app } from "./firebase";
+
 const GHOST_SCOPE_SUFFIX = "/firebase-cloud-messaging-push-scope";
+const SW_PATH = "/firebase-messaging-sw.js";
 
 async function unregisterGhostScopeRegistration(): Promise<void> {
   try {
@@ -21,15 +32,40 @@ async function unregisterGhostScopeRegistration(): Promise<void> {
     for (const reg of regs) {
       if (reg.scope.endsWith(GHOST_SCOPE_SUFFIX)) {
         const ok = await reg.unregister();
-        // Surface the event so a clean-slate test can tell us whether the ghost
-        // is a one-time persistent leftover (never logs again) or actively
-        // recreated (logs every reload). Left as console.info — a real logger
-        // doesn't pay its way for a one-shot migration step.
         console.info(`[steward] unregistered leftover FCM push-scope SW (${reg.scope}) → ${ok}`);
       }
     }
   } catch (err) {
     console.warn("[steward] ghost FCM SW cleanup failed", err);
+  }
+}
+
+/** Seed the Firebase messaging singleton with our SW registration so its
+ *  internal `updateSwReg(messaging, undefined)` path (reachable via
+ *  `Functions.contextProvider.getMessagingToken()`) skips
+ *  `registerDefaultSw` and never creates a registration at
+ *  `/firebase-cloud-messaging-push-scope`.
+ *
+ *  Direct assignment is the cheapest way to set the property without
+ *  triggering `getToken()`'s permission prompt — we explicitly don't
+ *  want to prompt on boot. `swRegistration` is a non-public field on
+ *  the `MessagingService` class, so we cast; the property has existed
+ *  since messaging was introduced and is what all internal paths read
+ *  and write. */
+async function primeMessagingSwRegistration(swReg: ServiceWorkerRegistration): Promise<void> {
+  try {
+    // getMessaging is safe to call on boot — it just constructs the
+    // service object; nothing is sent over the network and no SW is
+    // registered as a side effect.
+    const messaging = getMessaging(app) as unknown as {
+      swRegistration?: ServiceWorkerRegistration;
+    };
+    messaging.swRegistration = swReg;
+  } catch (err) {
+    // Environments without messaging support (jsdom, some mobile
+    // browsers) throw from getMessaging. Swallow — downstream code
+    // already degrades via getMessagingIfSupported().
+    console.warn("[steward] prime messaging.swRegistration skipped", err);
   }
 }
 
@@ -42,7 +78,8 @@ export function registerFcmServiceWorker(): void {
       void (async () => {
         await unregisterGhostScopeRegistration();
         try {
-          await navigator.serviceWorker.register("/firebase-messaging-sw.js");
+          const swReg = await navigator.serviceWorker.register(SW_PATH);
+          await primeMessagingSwRegistration(swReg);
         } catch (err) {
           console.error("FCM service worker registration failed", err);
         }


### PR DESCRIPTION
Ships PR #110 (prime messaging.swRegistration) + the v0.9.9 defensive cleanup to prod. See CHANGELOG §[0.9.10].