### PR TITLE
fix(notifications): prime messaging.vapidKey on boot to stop token-delete loop (#106)

### DIFF
--- a/src/lib/registerSw.ts
+++ b/src/lib/registerSw.ts
@@ -1,25 +1,45 @@
 /**
  * Registers the Firebase Cloud Messaging service worker on app boot and
- * primes the Firebase messaging singleton's `swRegistration` slot so the
- * SDK never auto-registers a ghost SW at
- * `/firebase-cloud-messaging-push-scope`. See issue #106 for the chase.
+ * primes the Firebase messaging singleton with our SW registration and
+ * VAPID key so the SDK never (a) auto-registers a ghost SW at
+ * `/firebase-cloud-messaging-push-scope` nor (b) mints a stand-in token
+ * against the Firebase default VAPID key. See issue #106 for the chase.
  *
  * Priming happens SYNCHRONOUSLY at module-import time, not deferred. A
  * React effect that fires a Firebase callable (e.g. `TwilioAutoConnect`)
  * mounts in the same tick as hydration, which is earlier than the browser
  * `load` event. Without a synchronous prime, Firebase's
- * `getMessagingToken()` auto-registers the ghost before we can stop it.
+ * `getMessagingToken()` — invoked for every Functions callable — runs
+ * through its token lifecycle against a freshly-constructed messaging
+ * singleton whose `swRegistration` and `vapidKey` slots are both unset,
+ * defaulting the VAPID to Firebase's built-in sample key and
+ * auto-registering the ghost SW.
  *
- * We use a stub object (not a real ServiceWorkerRegistration) for the
- * sync prime because the real registration only arrives after the async
- * `navigator.serviceWorker.register()` call resolves. The stub satisfies
- * the only guard that matters — `Tke(messaging, undefined)`'s
- * `!e.swRegistration` check — and Firebase's
- * Functions-callable path is tolerant of downstream errors when the
- * stub's `pushManager` doesn't exist (`getMessagingToken()` returns
- * undefined on throw). Our own `subscribeDevice` explicitly passes a
- * real SW registration to `getToken`, which replaces the stub via
- * `Tke`'s `e.swRegistration = t` branch.
+ * For `swRegistration`, we use a stub object (not a real
+ * ServiceWorkerRegistration) because the real registration only arrives
+ * after the async `navigator.serviceWorker.register()` call resolves.
+ * The stub satisfies the only guard that matters in
+ * `Tke(messaging, undefined)` (the `!e.swRegistration` check) and
+ * Firebase's callable path tolerates the downstream error when the
+ * stub's `pushManager` doesn't exist — `getMessagingToken()` wraps
+ * `messaging.getToken()` in a try/catch and returns undefined on throw,
+ * causing the callable to proceed without the optional
+ * `Firebase-Instance-ID-Token` header.
+ *
+ * For `vapidKey`, we prime it with ours (`VITE_FIREBASE_VAPID_KEY`) so
+ * that when Firebase's internal token lookup eventually runs
+ * `mke(messaging)` against a real subscription, its
+ * `bke(stored.subscriptionOptions, current.subscriptionOptions)`
+ * equality check passes. Without this, any post-subscribe callable
+ * invocation would see a VAPID mismatch vs the IDB-stored token, call
+ * `hee()` to delete that token from FCM, and mint a new one with the
+ * default key — leaving the Firestore-stored token dangling and
+ * triggering `messaging/registration-token-not-registered` on the
+ * next server-side push.
+ *
+ * Our own `subscribeDevice` explicitly passes a real SW registration
+ * and the same VAPID key to `getToken`, which `Tke`/`Cke` then treat
+ * as idempotent assignments.
  *
  * No-op on the server / in tests where `navigator` isn't available.
  */
@@ -32,6 +52,7 @@ const SW_PATH = "/firebase-messaging-sw.js";
 
 interface MessagingInternal {
   swRegistration?: ServiceWorkerRegistration | { scope: string; __stewardStub: true };
+  vapidKey?: string;
 }
 
 function primeStub(): void {
@@ -39,6 +60,10 @@ function primeStub(): void {
     const messaging = getMessaging(app) as unknown as MessagingInternal;
     if (!messaging.swRegistration) {
       messaging.swRegistration = { scope: "/", __stewardStub: true };
+    }
+    const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
+    if (vapidKey && !messaging.vapidKey) {
+      messaging.vapidKey = vapidKey;
     }
   } catch {
     // jsdom / unsupported environments — not actionable.


### PR DESCRIPTION
## Why v0.9.11 wasn't enough

v0.9.11's sync stub prime **successfully blocks the ghost SW** — verified by the user in DevTools (only one SW at scope \`/\`, no ghost). But FCM tokens still died after 2–4 pushes with \`messaging/registration-token-not-registered\`. The ghost wasn't the only invalidator.

## Full root cause

Tracing \`mke()\` (Firebase's \`getTokenInternal\`) in the deployed bundle:

\`\`\`js
async function mke(e) {
  const t = await yke(e.swRegistration, e.vapidKey);     // reuse existing push subscription
  const n = {vapidKey: e.vapidKey, swScope, endpoint, auth, p256dh};  // build current options
  const r = await fee(e.firebaseDependencies);            // read stored token from IDB
  if (r) {
    if (bke(r.subscriptionOptions, n)) return r.token;    // match → reuse
    await hee(e.firebaseDependencies, r.token);           // MISMATCH → DELETE stored token from FCM
    return E7(e.firebaseDependencies, n);                 // mint replacement
  }
  return E7(e.firebaseDependencies, n);
}
\`\`\`

The \`bke()\` equality check compares \`vapidKey\`, \`endpoint\`, \`auth\`, and \`p256dh\`.

**The loop:**
1. Boot: \`primeStub\` sets \`messaging.swRegistration = stub\`. \`messaging.vapidKey\` stays undefined.
2. Functions callable fires (TwilioAutoConnect mount) → \`getMessagingToken\` → \`messaging.getToken()\` no args.
3. \`Cke(messaging, undefined)\` → \`e.vapidKey || (e.vapidKey = uee)\` — **defaults \`messaging.vapidKey\` to Firebase's built-in sample key.** The stub-path error then fires and \`getMessagingToken\` swallows it, but the vapidKey assignment already happened.
4. User clicks Enable → \`subscribeDevice\` → \`getToken(messaging, {vapidKey: OUR, swReg: realReg})\`. Push subscription minted with OUR VAPID, token T1 saved to IDB (with \`subscriptionOptions.vapidKey = OUR\`) and Firestore.
5. **Another callable invocation** (e.g. ward switch, re-mount, a second TwilioAutoConnect cycle). \`messaging.getToken()\` no args → \`Cke\` finds vapidKey already set (OUR, from step 4, or DEFAULT on a subsequent page load). On a fresh page load though, messaging is a new singleton with no vapidKey — step 3 fires first.
6. With \`messaging.vapidKey = DEFAULT\` and the stored T1 carrying OUR VAPID, \`bke()\` returns false. Firebase calls \`hee()\` to **DELETE T1 from the FCM backend** and mints a replacement against DEFAULT. T1 is now dead.
7. Firestore still holds T1. Next server-side push → \`registration-token-not-registered\` → prune → banner reappears.

## Fix

Prime \`messaging.vapidKey = VITE_FIREBASE_VAPID_KEY\` synchronously alongside the \`swRegistration\` stub, so \`Cke\`'s default-assignment branch never runs. The stored token's vapidKey always matches what Firebase will compare against — no more \`hee()\` delete loop.

## Test plan

- [x] \`pnpm typecheck\` · \`pnpm lint\` · \`pnpm format:check\` · \`pnpm test\` (273 tests) — all green
- [ ] After merge + release: clear site data on affected browser, reload, sign in, enable push. Fire 10+ pushes (speaker response, chat reply). Token stays alive.
- [ ] DevTools → Application → Service Workers: still only scope \`/\` (previous fix unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)