### PR TITLE
Release: v0.9.12 — prime messaging.vapidKey fixes token-die loop (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.9.12] — 2026-04-24
+
+The real fix for #106. v0.9.9/.10/.11 closed the ghost SW path
+progressively; v0.9.11 verified via DevTools that the ghost is fully
+gone. But FCM tokens kept dying with
+`messaging/registration-token-not-registered` after 2–4 sends — so the
+ghost was necessary-but-insufficient. The remaining loop is a VAPID key
+mismatch inside Firebase's own token cache.
+
+### Fixed
+
+- **Prime `messaging.vapidKey` on boot** (#116). Tracing Firebase's
+  `mke()` (getTokenInternal) revealed the full bug: when
+  `messaging.getToken()` is called with no args (the pattern used by
+  Firebase Functions' shared `contextProvider.getMessagingToken()` on
+  every callable invocation), `Cke(messaging, undefined)` defaults
+  `messaging.vapidKey` to Firebase's built-in sample key (`uee`). The
+  downstream token-lookup builds `subscriptionOptions` with the
+  default VAPID, compares against the IDB-stored token (whose stored
+  `subscriptionOptions.vapidKey` is ours), detects the mismatch in
+  `bke()`, and calls `hee()` to **DELETE our stored token from the FCM
+  backend** before minting a replacement against the default key. The
+  Firestore-persisted token is now dangling; the next server-side push
+  returns `messaging/registration-token-not-registered`; the token
+  gets pruned; the banner reappears.
+
+  Fix is a one-line addition to [src/lib/registerSw.ts](src/lib/registerSw.ts)'s
+  sync prime: assign `messaging.vapidKey = VITE_FIREBASE_VAPID_KEY`
+  alongside the `swRegistration` stub. `Cke`'s default-assignment
+  branch never runs; stored token and live messaging state agree;
+  no `hee()` delete loop.
+
 ## [0.9.11] — 2026-04-24
 
 Third time's the fix for #106. v0.9.10 landed the right idea — prime
@@ -1152,7 +1184,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.11...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.9.12...HEAD
+[0.9.12]: https://github.com/aylabyuk/steward/releases/tag/v0.9.12
 [0.9.11]: https://github.com/aylabyuk/steward/releases/tag/v0.9.11
 [0.9.10]: https://github.com/aylabyuk/steward/releases/tag/v0.9.10
 [0.9.9]: https://github.com/aylabyuk/steward/releases/tag/v0.9.9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.9.11",
+  "version": "0.9.12",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/lib/registerSw.ts
+++ b/src/lib/registerSw.ts
@@ -1,25 +1,45 @@
 /**
  * Registers the Firebase Cloud Messaging service worker on app boot and
- * primes the Firebase messaging singleton's `swRegistration` slot so the
- * SDK never auto-registers a ghost SW at
- * `/firebase-cloud-messaging-push-scope`. See issue #106 for the chase.
+ * primes the Firebase messaging singleton with our SW registration and
+ * VAPID key so the SDK never (a) auto-registers a ghost SW at
+ * `/firebase-cloud-messaging-push-scope` nor (b) mints a stand-in token
+ * against the Firebase default VAPID key. See issue #106 for the chase.
  *
  * Priming happens SYNCHRONOUSLY at module-import time, not deferred. A
  * React effect that fires a Firebase callable (e.g. `TwilioAutoConnect`)
  * mounts in the same tick as hydration, which is earlier than the browser
  * `load` event. Without a synchronous prime, Firebase's
- * `getMessagingToken()` auto-registers the ghost before we can stop it.
+ * `getMessagingToken()` — invoked for every Functions callable — runs
+ * through its token lifecycle against a freshly-constructed messaging
+ * singleton whose `swRegistration` and `vapidKey` slots are both unset,
+ * defaulting the VAPID to Firebase's built-in sample key and
+ * auto-registering the ghost SW.
  *
- * We use a stub object (not a real ServiceWorkerRegistration) for the
- * sync prime because the real registration only arrives after the async
- * `navigator.serviceWorker.register()` call resolves. The stub satisfies
- * the only guard that matters — `Tke(messaging, undefined)`'s
- * `!e.swRegistration` check — and Firebase's
- * Functions-callable path is tolerant of downstream errors when the
- * stub's `pushManager` doesn't exist (`getMessagingToken()` returns
- * undefined on throw). Our own `subscribeDevice` explicitly passes a
- * real SW registration to `getToken`, which replaces the stub via
- * `Tke`'s `e.swRegistration = t` branch.
+ * For `swRegistration`, we use a stub object (not a real
+ * ServiceWorkerRegistration) because the real registration only arrives
+ * after the async `navigator.serviceWorker.register()` call resolves.
+ * The stub satisfies the only guard that matters in
+ * `Tke(messaging, undefined)` (the `!e.swRegistration` check) and
+ * Firebase's callable path tolerates the downstream error when the
+ * stub's `pushManager` doesn't exist — `getMessagingToken()` wraps
+ * `messaging.getToken()` in a try/catch and returns undefined on throw,
+ * causing the callable to proceed without the optional
+ * `Firebase-Instance-ID-Token` header.
+ *
+ * For `vapidKey`, we prime it with ours (`VITE_FIREBASE_VAPID_KEY`) so
+ * that when Firebase's internal token lookup eventually runs
+ * `mke(messaging)` against a real subscription, its
+ * `bke(stored.subscriptionOptions, current.subscriptionOptions)`
+ * equality check passes. Without this, any post-subscribe callable
+ * invocation would see a VAPID mismatch vs the IDB-stored token, call
+ * `hee()` to delete that token from FCM, and mint a new one with the
+ * default key — leaving the Firestore-stored token dangling and
+ * triggering `messaging/registration-token-not-registered` on the
+ * next server-side push.
+ *
+ * Our own `subscribeDevice` explicitly passes a real SW registration
+ * and the same VAPID key to `getToken`, which `Tke`/`Cke` then treat
+ * as idempotent assignments.
  *
  * No-op on the server / in tests where `navigator` isn't available.
  */
@@ -32,6 +52,7 @@ const SW_PATH = "/firebase-messaging-sw.js";
 
 interface MessagingInternal {
   swRegistration?: ServiceWorkerRegistration | { scope: string; __stewardStub: true };
+  vapidKey?: string;
 }
 
 function primeStub(): void {
@@ -39,6 +60,10 @@ function primeStub(): void {
     const messaging = getMessaging(app) as unknown as MessagingInternal;
     if (!messaging.swRegistration) {
       messaging.swRegistration = { scope: "/", __stewardStub: true };
+    }
+    const vapidKey = import.meta.env.VITE_FIREBASE_VAPID_KEY;
+    if (vapidKey && !messaging.vapidKey) {
+      messaging.vapidKey = vapidKey;
     }
   } catch {
     // jsdom / unsupported environments — not actionable.


### PR DESCRIPTION
Ships PR #116. See CHANGELOG §[0.9.12].