### PR TITLE
feat(notifications): push other bishopric members when one posts in speaker chat

### DIFF
--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,86 +1,16 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
-import { sendDisplayPush } from "./fcm.js";
 import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
 import { interpolate, readMessageTemplate } from "./messageTemplates.js";
-import { filterRecipients, type RecipientCandidate } from "./recipients.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
 import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
 import { sendEmail } from "./sendgrid/client.js";
 import { sendSmsDirect } from "./twilio/messaging.js";
-import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ResolvedInvitation extends SpeakerInvitationShape {
   wardId: string;
   token: string;
-}
-
-/** Speaker posted in the conversation → FCM push to active
- *  bishopric members of the ward. Reuses the quiet-hours + token
- *  pruning helpers that the mention notifications already use.
- *
- *  The payload carries `webpush.fcmOptions.link` so a tap deep-links
- *  to the speaker's chat dialog on the Schedule page; the SW
- *  `notificationclick` handler reads the same shape for browsers that
- *  don't honor `fcmOptions.link` natively. */
-export async function pushToBishopric(inv: ResolvedInvitation, body: string): Promise<void> {
-  const db = getFirestore();
-  logger.info("reply push: start", { wardId: inv.wardId, invitationId: inv.token });
-
-  const wardSnap = await db.doc(`wards/${inv.wardId}`).get();
-  const ward = wardSnap.data() as WardDoc | undefined;
-  const timezone = ward?.settings?.timezone ?? "UTC";
-  const membersSnap = await db.collection(`wards/${inv.wardId}/members`).get();
-  const candidates: RecipientCandidate[] = membersSnap.docs
-    .map((d) => {
-      const m = d.data() as MemberDoc;
-      return m.role === "bishopric" ? { uid: d.id, member: m } : null;
-    })
-    .filter((c): c is RecipientCandidate => c !== null);
-  const recipients = filterRecipients(candidates, { now: new Date(), timezone });
-  logger.info("reply push: recipients", {
-    wardId: inv.wardId,
-    invitationId: inv.token,
-    bishopricCandidates: candidates.length,
-    recipientsAfterFilter: recipients.length,
-    candidateUids: candidates.map((c) => c.uid),
-  });
-  if (recipients.length === 0) return;
-
-  const tokensByUid = new Map<string, readonly FcmToken[]>();
-  let totalTokens = 0;
-  for (const r of recipients) {
-    const tokens = r.member.fcmTokens ?? [];
-    tokensByUid.set(r.uid, tokens);
-    totalTokens += tokens.length;
-  }
-  logger.info("reply push: sending", {
-    wardId: inv.wardId,
-    invitationId: inv.token,
-    recipientCount: recipients.length,
-    totalTokens,
-  });
-  try {
-    const outcome = await sendDisplayPush(inv.wardId, tokensByUid, {
-      title: `${inv.speakerName} replied`,
-      body: truncate(body, 120),
-      data: { wardId: inv.wardId, invitationId: inv.token, kind: "invitation-reply" },
-    });
-    logger.info("reply push: outcome", {
-      wardId: inv.wardId,
-      invitationId: inv.token,
-      successCount: outcome.successCount,
-      failureCount: outcome.failureCount,
-      deadTokenCount: outcome.deadTokens.length,
-    });
-  } catch (err) {
-    logger.error("reply push fan-out failed", {
-      wardId: inv.wardId,
-      invitationId: inv.token,
-      err: (err as Error).message,
-    });
-  }
 }
 
 /** Max age of the speaker's `speakerLastSeenAt` heartbeat before we

--- a/functions/src/invitationReplyPush.ts
+++ b/functions/src/invitationReplyPush.ts
@@ -1,0 +1,104 @@
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { sendDisplayPush } from "./fcm.js";
+import { filterRecipients, type RecipientCandidate } from "./recipients.js";
+import type { FcmToken, MemberDoc, WardDoc } from "./types.js";
+import type { ResolvedInvitation } from "./invitationReplyNotify.js";
+
+/** A new message was posted in the conversation → FCM push to active
+ *  bishopric members of the ward. Reuses the quiet-hours + token
+ *  pruning helpers that the mention notifications already use.
+ *
+ *  When `senderBishopUid` is supplied (bishop-to-bishop path), the
+ *  sender is filtered out of recipients and the push title carries
+ *  their displayName. When omitted (speaker-posted path), all active
+ *  bishopric members receive the push and the title reflects the
+ *  speaker's invitation-recorded name.
+ *
+ *  The payload carries `webpush.fcmOptions.link` so a tap deep-links
+ *  to the speaker's chat dialog on the Schedule page; the SW
+ *  `notificationclick` handler reads the same shape for browsers that
+ *  don't honor `fcmOptions.link` natively. */
+export async function pushToBishopric(
+  inv: ResolvedInvitation,
+  body: string,
+  options?: { senderBishopUid?: string },
+): Promise<void> {
+  const db = getFirestore();
+  const senderUid = options?.senderBishopUid;
+  logger.info("reply push: start", {
+    wardId: inv.wardId,
+    invitationId: inv.token,
+    senderBishopUid: senderUid ?? null,
+  });
+
+  const wardSnap = await db.doc(`wards/${inv.wardId}`).get();
+  const ward = wardSnap.data() as WardDoc | undefined;
+  const timezone = ward?.settings?.timezone ?? "UTC";
+  const membersSnap = await db.collection(`wards/${inv.wardId}/members`).get();
+  const candidates: RecipientCandidate[] = membersSnap.docs
+    .map((d) => {
+      const m = d.data() as MemberDoc;
+      return m.role === "bishopric" ? { uid: d.id, member: m } : null;
+    })
+    .filter((c): c is RecipientCandidate => c !== null);
+  const senderName = senderUid
+    ? (candidates.find((c) => c.uid === senderUid)?.member.displayName ?? null)
+    : null;
+  const recipients = filterRecipients(candidates, {
+    now: new Date(),
+    timezone,
+    excludeUid: senderUid,
+  });
+  logger.info("reply push: recipients", {
+    wardId: inv.wardId,
+    invitationId: inv.token,
+    bishopricCandidates: candidates.length,
+    recipientsAfterFilter: recipients.length,
+    candidateUids: candidates.map((c) => c.uid),
+    excludeUid: senderUid ?? null,
+  });
+  if (recipients.length === 0) return;
+
+  const tokensByUid = new Map<string, readonly FcmToken[]>();
+  let totalTokens = 0;
+  for (const r of recipients) {
+    const tokens = r.member.fcmTokens ?? [];
+    tokensByUid.set(r.uid, tokens);
+    totalTokens += tokens.length;
+  }
+  logger.info("reply push: sending", {
+    wardId: inv.wardId,
+    invitationId: inv.token,
+    recipientCount: recipients.length,
+    totalTokens,
+  });
+  // Title source depends on who posted. Fallback when a bishop's
+  // displayName is missing — use the ward name so the recipient still
+  // gets recognizable context.
+  const title = senderUid ? `${senderName ?? inv.wardName} replied` : `${inv.speakerName} replied`;
+  try {
+    const outcome = await sendDisplayPush(inv.wardId, tokensByUid, {
+      title,
+      body: truncate(body, 120),
+      data: { wardId: inv.wardId, invitationId: inv.token, kind: "invitation-reply" },
+    });
+    logger.info("reply push: outcome", {
+      wardId: inv.wardId,
+      invitationId: inv.token,
+      successCount: outcome.successCount,
+      failureCount: outcome.failureCount,
+      deadTokenCount: outcome.deadTokens.length,
+    });
+  } catch (err) {
+    logger.error("reply push fan-out failed", {
+      wardId: inv.wardId,
+      invitationId: inv.token,
+      err: (err as Error).message,
+    });
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : `${s.slice(0, max - 1)}…`;
+}

--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -2,12 +2,8 @@ import { getFirestore } from "firebase-admin/firestore";
 import { onRequest, type Request } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
 import twilio from "twilio";
-import {
-  emailSpeaker,
-  pushToBishopric,
-  smsSpeaker,
-  type ResolvedInvitation,
-} from "./invitationReplyNotify.js";
+import { emailSpeaker, smsSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
+import { pushToBishopric } from "./invitationReplyPush.js";
 import {
   TWILIO_ACCOUNT_SID,
   TWILIO_AUTH_TOKEN,
@@ -32,8 +28,9 @@ const WEBHOOK_SECRETS = [
  *  event; we filter to `onMessageAdded` and fan out:
  *
  *   - `speaker:*` authored → FCM push to active bishopric members
- *   - `uid:*` (bishopric) authored → SendGrid email to the speaker
- *     (SMS already delivered by Twilio via the participant binding)
+ *   - `uid:*` (bishopric) authored → SMS + email to the speaker,
+ *     AND FCM push to other active bishopric members in the ward
+ *     (the sender is filtered out)
  *
  *  Post-expiry messages are logged and ignored defensively. */
 export const onTwilioWebhook = onRequest(
@@ -71,9 +68,16 @@ export const onTwilioWebhook = onRequest(
     if (author.startsWith("speaker:")) {
       await pushToBishopric(invitation, body);
     } else if (author.startsWith("uid:")) {
-      // Run both in parallel — SMS is the primary channel, email is
-      // best-effort and no-ops silently when SendGrid isn't wired.
-      await Promise.all([smsSpeaker(invitation, body), emailSpeaker(invitation, body)]);
+      const senderBishopUid = author.slice("uid:".length);
+      // All three run in parallel. SMS is the primary channel for the
+      // speaker, email is best-effort (no-ops when SendGrid isn't
+      // wired), and the bishop-to-bishop push keeps peer bishopric
+      // members in the loop without re-notifying the sender.
+      await Promise.all([
+        smsSpeaker(invitation, body),
+        emailSpeaker(invitation, body),
+        pushToBishopric(invitation, body, { senderBishopUid }),
+      ]);
     }
     res.status(200).send("ok");
   },


### PR DESCRIPTION
## What changes
Closes the fanout gap in the invitation-conversation webhook.

**Before:**
- speaker posts → FCM push to all active bishopric ✓
- bishop posts → SMS + email to speaker; **peer bishopric get nothing**

**After:**
- speaker posts → unchanged
- bishop posts → SMS + email to speaker (unchanged) **AND** FCM push to peer bishopric, with the sender excluded

## Implementation

- [pushToBishopric()](functions/src/invitationReplyPush.ts) grows an optional `senderBishopUid` param. Extracted to its own file to keep [invitationReplyNotify.ts](functions/src/invitationReplyNotify.ts) under the 150 LOC cap.
- Recipients pass through `filterRecipients(candidates, { excludeUid: senderBishopUid })` — the uid filter lives in [recipients.ts:21](functions/src/recipients.ts#L21) and was already plumbed for mention notifications.
- Title is `{senderDisplayName} replied` (speaker path continues to use `{speakerName} replied`). Falls back to ward name if displayName is missing — shouldn't happen per the members doc schema, but fail-soft is cheaper than a blank push.
- [onTwilioWebhook.ts](functions/src/onTwilioWebhook.ts) `uid:*` branch parses `author.slice("uid:".length)`, runs `smsSpeaker` + `emailSpeaker` + `pushToBishopric({ senderBishopUid })` in parallel.

## Speaker is explicitly not wired
Push delivery to the speaker-side invite page isn't implemented, and the speaker already receives the existing SMS + email channels — no need to add a no-op code path.

## Test plan
- [x] `pnpm --filter @steward/functions build` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — 0 errors (file is under 150 LOC after extraction)
- [x] `pnpm --filter @steward/functions test` — 87/87
- [ ] After merge + release: in a live conversation with 2+ active bishopric members, have bishop A post a message. Bishop B receives a push titled "{A.displayName} replied". Bishop A does NOT receive a push for their own message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)