### PR TITLE
feat(avatars): render peer bishopric photoURLs in speaker-invitation chat

### DIFF
--- a/src/features/invitations/useBishopAuthors.ts
+++ b/src/features/invitations/useBishopAuthors.ts
@@ -34,6 +34,7 @@ export function useBishopAuthors({
       if (!m.data.active) continue;
       const info: AuthorInfo = { displayName: m.data.displayName, role: m.data.role };
       if (m.data.email) info.email = m.data.email;
+      if (m.data.photoURL) info.photoURL = m.data.photoURL;
       map.set(`uid:${m.id}`, info);
     }
     const speakerInfo: AuthorInfo = { displayName: invitation.speakerName, role: "speaker" };
@@ -46,7 +47,12 @@ export function useBishopAuthors({
         displayName: existing?.displayName ?? user.displayName ?? "You",
       };
       if (existing?.role) info.role = existing.role;
-      if (user.photoURL) info.photoURL = user.photoURL;
+      // Prefer the live Firebase Auth photoURL (freshest) but fall back
+      // to the member-doc-synced value — email sign-ins don't always
+      // carry a photoURL on the auth user even when a historical Google
+      // session back-filled one on the member doc.
+      const photoURL = user.photoURL ?? existing?.photoURL;
+      if (photoURL) info.photoURL = photoURL;
       const email = existing?.email ?? user.email;
       if (email) info.email = email;
       map.set(`uid:${user.uid}`, info);


### PR DESCRIPTION
## What changes
The chat dialog avatars in the bishopric-side speaker conversation now render real Google profile photos for **peer bishopric members**, not just the currently signed-in user.

## Why
\`useMemberProfileSync\` at [auth-gate.tsx:39](src/app/auth-gate.tsx#L39) already back-fills each signed-in user's \`displayName\` + \`photoURL\` onto their Firestore member doc. But [useBishopAuthors](src/features/invitations/useBishopAuthors.ts) was reading \`displayName\` and \`email\` from the member doc while ignoring \`photoURL\` — so only the current user (whose photoURL was read directly from Firebase Auth) got a real picture. Peers always showed initials.

## What's in
1. Read \`m.data.photoURL\` from each active ward member and set it on their \`AuthorInfo\`.
2. In the current-user override branch, fall back to the member doc's photoURL when \`user.photoURL\` is null. Covers email-sign-in users whose Firebase Auth record has no photoURL but whose member doc was synced from a prior Google session.

## What's NOT in
- **Speaker avatar** is intentionally unchanged — speakers don't have Firebase Auth accounts and no photoURL source exists. The existing brass-soft colored initials bubble keeps speakers visually distinct from bishopric bordeaux bubbles.
- No changes to \`ConversationAvatar\` itself — it already supported \`photoURL\` rendering via the \`AuthorInfo\` interface.

## Part of
Three-PR bundle for this session's UI feature work:
- **PR A (this)** — peer bishopric avatars
- PR B — status banner redesign + speaker read-receipt
- PR C — resend SMS confirmation modal

Merge in succession; PR C's branch will carry all three for live testing against its Vercel preview.

## Test plan
- [x] \`pnpm typecheck\` · \`pnpm lint\` (0 errors) · \`pnpm test\` (invitations suite clean)
- [ ] Visual: open the speaker-invitation chat dialog with 2+ active bishopric members who have signed in with Google. Their bubbles should render photos instead of initials. Members without a photoURL still get the initials fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)