### PR TITLE
feat(ui): eight UI polish changes bundled across the invitation flow

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"cf8abc62-d1cb-4809-8c00-d388f9fa029c","pid":85761,"acquiredAt":1777008753253}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"cf8abc62-d1cb-4809-8c00-d388f9fa029c","pid":85761,"acquiredAt":1777008753253}

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ Thumbs.db
 
 # Claude Code
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Vercel
 .vercel

--- a/src/app/routes/PrepareInvitationHeader.tsx
+++ b/src/app/routes/PrepareInvitationHeader.tsx
@@ -3,6 +3,8 @@ import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitati
 
 interface Props {
   speakerName: string;
+  speakerEmail: string;
+  speakerPhone: string;
   email: string;
   hasEmail: boolean;
   busy: boolean;
@@ -15,8 +17,8 @@ interface Props {
   onRevert: () => void;
   onMarkInvited: () => void;
   onPrint: () => void;
-  onSend: () => void;
-  onSendSms: () => void;
+  onSend: (email: string) => void;
+  onSendSms: (phone: string) => void;
 }
 
 /** Sticky page header for the Prepare Invitation page: title block on
@@ -55,6 +57,8 @@ export function PrepareInvitationHeader(props: Props) {
           canSmsReason={props.canSmsReason}
           hasOverride={props.hasOverride}
           speakerName={props.speakerName}
+          speakerEmail={props.speakerEmail}
+          speakerPhone={props.speakerPhone}
           onRevert={props.onRevert}
           onMarkInvited={props.onMarkInvited}
           onPrint={props.onPrint}

--- a/src/app/routes/invite-speaker-states.tsx
+++ b/src/app/routes/invite-speaker-states.tsx
@@ -70,10 +70,11 @@ export function PrintToolbar(): React.ReactElement {
       <button
         type="button"
         onClick={() => window.print()}
-        className="inline-flex items-center gap-1.5 rounded-md border border-walnut bg-walnut px-3.5 py-2 font-mono text-[11px] uppercase tracking-[0.14em] text-chalk hover:bg-walnut-2 shadow-elev-2"
+        title="Print · Save as PDF"
+        aria-label="Print · Save as PDF"
+        className="inline-flex items-center justify-center rounded-md border border-walnut bg-walnut w-9 h-9 text-chalk hover:bg-walnut-2 shadow-elev-2"
       >
         <PrinterIcon />
-        Print · Save as PDF
       </button>
     </div>
   );
@@ -82,8 +83,8 @@ export function PrintToolbar(): React.ReactElement {
 function PrinterIcon() {
   return (
     <svg
-      width="12"
-      height="12"
+      width="14"
+      height="14"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -122,6 +122,7 @@ function InviteLandingContent({
               speakerName={invitation.speakerName}
               bishopricParticipants={invitation.bishopricParticipants}
               hasResponse={!!invitation.response}
+              responseAnswer={invitation.response?.answer ?? null}
               onClose={() => setChatOpen(false)}
               fillHeight
             />

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -122,6 +122,7 @@ function InviteLandingContent({
               speakerName={invitation.speakerName}
               bishopricParticipants={invitation.bishopricParticipants}
               hasResponse={!!invitation.response}
+              meetingDate={invitation.speakerRef.meetingDate}
               responseAnswer={invitation.response?.answer ?? null}
               currentStatus={invitation.currentSpeakerStatus ?? null}
               onClose={() => setChatOpen(false)}

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -123,6 +123,7 @@ function InviteLandingContent({
               bishopricParticipants={invitation.bishopricParticipants}
               hasResponse={!!invitation.response}
               responseAnswer={invitation.response?.answer ?? null}
+              currentStatus={invitation.currentSpeakerStatus ?? null}
               onClose={() => setChatOpen(false)}
               fillHeight
             />

--- a/src/app/routes/prepare-invitation-validation.ts
+++ b/src/app/routes/prepare-invitation-validation.ts
@@ -12,20 +12,38 @@ export interface SendValidation {
 }
 
 /** Per-speaker send-readiness flags + user-facing copy explaining
- *  why a channel is unavailable. Keeps the Prepare route body small
- *  enough to fit the 150-LOC ceiling. */
+ *  why a channel is unavailable. The reason strings pivot on what
+ *  other channels are actually available so we never suggest "text"
+ *  when there's no phone or "email" when there's no address. Keeps
+ *  the Prepare route body small enough to fit the 150-LOC ceiling. */
 export function computeSendValidation(speaker: Speaker): SendValidation {
   const email = (speaker.email ?? "").trim();
   const hasEmail = email.length > 0;
   const emailValid = isValidEmail(email);
   const canSend = hasEmail && emailValid;
-  const canSendReason = !hasEmail
-    ? "No email on file — print, text, or mark invited instead."
-    : !emailValid
-      ? "Invalid email format."
-      : null;
   const phone = (speaker.phone ?? "").trim();
   const canSms = isPlausiblePhone(phone);
-  const canSmsReason = canSend || canSms ? null : !phone ? "No phone on file." : null;
+  const canSendReason = canSendHint({ hasEmail, emailValid, canSms });
+  const canSmsReason = canSmsHint({ canSend, canSms, hasPhone: phone.length > 0 });
   return { email, hasEmail, canSend, canSendReason, canSms, canSmsReason };
+}
+
+function canSendHint(args: {
+  hasEmail: boolean;
+  emailValid: boolean;
+  canSms: boolean;
+}): string | null {
+  if (!args.hasEmail) {
+    return args.canSms
+      ? "No email on file — text, print, or mark invited instead."
+      : "No email or phone on file — print the invitation or mark invited.";
+  }
+  if (!args.emailValid) return "Invalid email format.";
+  return null;
+}
+
+function canSmsHint(args: { canSend: boolean; canSms: boolean; hasPhone: boolean }): string | null {
+  if (args.canSend || args.canSms) return null;
+  if (!args.hasPhone) return "No phone on file.";
+  return null;
 }

--- a/src/app/routes/prepare-invitation.tsx
+++ b/src/app/routes/prepare-invitation.tsx
@@ -105,6 +105,8 @@ export function PrepareInvitationPage() {
     canSmsReason,
     hasOverride: form.letterHasOverride,
     speakerName: speaker.data.name,
+    speakerEmail: speaker.data.email ?? "",
+    speakerPhone: speaker.data.phone ?? "",
     onRevert: () => void form.clearLetterOverride(),
     onMarkInvited: actions.markInvited,
     // Global `@media print` rules pin the preview's LetterCanvas to

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -9,6 +9,7 @@ import { InvitationStatusBanner } from "./InvitationStatusBanner";
 import { TypingIndicator } from "./TypingIndicator";
 import { applyResponseToSpeaker } from "./invitationActions";
 import { callIssueSpeakerSession } from "./invitationsCallable";
+import { noteBishopStatusChange } from "./statusChangeNotice";
 import { useBishopAuthors } from "./useBishopAuthors";
 import { useConversation } from "./useConversation";
 import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
@@ -65,6 +66,7 @@ export function BishopInvitationChat({
     setApplyError(null);
     try {
       await updateSpeaker(wardId, date, speakerId, { status: next });
+      await noteBishopStatusChange({ wardId, invitationId, status: next, conversation });
     } catch (err) {
       setApplyError((err as Error).message);
     }
@@ -99,6 +101,13 @@ export function BishopInvitationChat({
     setApplyError(null);
     try {
       await applyResponseToSpeaker({ wardId, invitationId, bishopUid: user.uid });
+      const applied = invitation.response?.answer === "yes" ? "confirmed" : "declined";
+      await noteBishopStatusChange({
+        wardId,
+        invitationId,
+        status: applied,
+        conversation,
+      });
     } catch (err) {
       setApplyError((err as Error).message);
     } finally {

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -66,7 +66,13 @@ export function BishopInvitationChat({
     setApplyError(null);
     try {
       await updateSpeaker(wardId, date, speakerId, { status: next });
-      await noteBishopStatusChange({ wardId, invitationId, status: next, conversation });
+      await noteBishopStatusChange({
+        wardId,
+        invitationId,
+        meetingDate: date,
+        status: next,
+        conversation,
+      });
     } catch (err) {
       setApplyError((err as Error).message);
     }
@@ -105,6 +111,7 @@ export function BishopInvitationChat({
       await noteBishopStatusChange({
         wardId,
         invitationId,
+        meetingDate: date,
         status: applied,
         conversation,
       });

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -9,6 +9,7 @@ import { InvitationStatusBanner } from "./InvitationStatusBanner";
 import { TypingIndicator } from "./TypingIndicator";
 import { applyResponseToSpeaker } from "./invitationActions";
 import { callIssueSpeakerSession } from "./invitationsCallable";
+import { removeMessage, updateMessageBody } from "./messageMutations";
 import { noteBishopStatusChange } from "./statusChangeNotice";
 import { useBishopAuthors } from "./useBishopAuthors";
 import { useConversation } from "./useConversation";
@@ -143,6 +144,8 @@ export function BishopInvitationChat({
         firstUnreadIndex={firstUnreadIndex}
         readHorizonIndex={readHorizon}
         fillHeight
+        onDeleteMessage={(sid) => removeMessage(conversation, sid)}
+        onEditMessage={(sid, next) => updateMessageBody(conversation, sid, next)}
       />
 
       <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />

--- a/src/features/invitations/BishopInvitationChat.tsx
+++ b/src/features/invitations/BishopInvitationChat.tsx
@@ -116,6 +116,7 @@ export function BishopInvitationChat({
         applying={applying}
         applyError={applyError}
         onStatusChange={onStatusChange}
+        currentUserUid={user?.uid}
       />
 
       <ConversationThread

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -100,6 +100,7 @@ export function BishopInvitationDialog({
           />
         ) : (
           <NoInvitationPlaceholder
+            wardId={wardId}
             speaker={speaker}
             speakerId={speakerId}
             date={date}

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -64,7 +64,7 @@ export function BishopInvitationDialog({
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="bg-chalk flex flex-col w-full max-w-xl h-[100dvh] sm:h-auto sm:max-h-[94vh] sm:rounded-[14px] sm:border sm:border-border-strong sm:shadow-elev-3 overflow-hidden">
+      <div className="bg-chalk flex flex-col w-full max-w-xl h-[100dvh] sm:h-auto sm:min-h-140 sm:max-h-[94vh] sm:rounded-[14px] sm:border sm:border-border-strong sm:shadow-elev-3 overflow-hidden">
         <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
           <div className="flex-1 min-w-0">
             <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -99,7 +99,12 @@ export function BishopInvitationDialog({
             speakerId={speakerId}
           />
         ) : (
-          <NoInvitationPlaceholder speaker={speaker} />
+          <NoInvitationPlaceholder
+            speaker={speaker}
+            speakerId={speakerId}
+            date={date}
+            onNavigate={onClose}
+          />
         )}
       </div>
     </div>

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -3,13 +3,18 @@ import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
 import { InvitationLinkActions } from "./InvitationLinkActions";
+import { NoInvitationPlaceholder } from "./NoInvitationPlaceholder";
 
 interface Props {
   open: boolean;
   onClose: () => void;
   wardId: string;
-  invitationId: string;
-  invitation: SpeakerInvitation;
+  /** Null when the speaker hasn't been invited yet. The dialog still
+   *  opens so the bishopric has a single place to see the speaker's
+   *  current state; the body renders a "contact them directly"
+   *  placeholder in that case. */
+  invitationId: string | null;
+  invitation: SpeakerInvitation | null;
   /** Speaker doc + its path coordinates — threaded so the chat's
    *  status banner can render the bishopric-set status and apply
    *  manual overrides via updateSpeaker. */
@@ -66,14 +71,16 @@ export function BishopInvitationDialog({
               Conversation
             </div>
             <div className="font-display text-xl font-semibold text-walnut tracking-[-0.01em] leading-tight mt-0.5">
-              {invitation.speakerName}
+              {speaker.name}
             </div>
           </div>
-          <InvitationLinkActions
-            wardId={wardId}
-            invitationId={invitationId}
-            invitation={invitation}
-          />
+          {invitation && invitationId && (
+            <InvitationLinkActions
+              wardId={wardId}
+              invitationId={invitationId}
+              invitation={invitation}
+            />
+          )}
           <button
             onClick={onClose}
             className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
@@ -82,14 +89,18 @@ export function BishopInvitationDialog({
             Close
           </button>
         </div>
-        <BishopInvitationChat
-          wardId={wardId}
-          invitationId={invitationId}
-          invitation={invitation}
-          speaker={speaker}
-          date={date}
-          speakerId={speakerId}
-        />
+        {invitation && invitationId ? (
+          <BishopInvitationChat
+            wardId={wardId}
+            invitationId={invitationId}
+            invitation={invitation}
+            speaker={speaker}
+            date={date}
+            speakerId={speakerId}
+          />
+        ) : (
+          <NoInvitationPlaceholder speaker={speaker} />
+        )}
       </div>
     </div>
   );

--- a/src/features/invitations/BubbleActions.tsx
+++ b/src/features/invitations/BubbleActions.tsx
@@ -1,34 +1,38 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { cn } from "@/lib/cn";
 
 interface Props {
+  open: boolean;
   mine: boolean;
   canEdit: boolean;
   canDelete: boolean;
   onEdit: () => void;
   onDelete: () => void;
+  onClose: () => void;
 }
 
-/** Small overflow menu that appears on hover (desktop) or always
- *  (mobile, via -group- parent), letting participants edit or delete
- *  their own recent messages. Permissions resolved by the parent. */
+/** Floating menu of edit / delete actions for a single bubble.
+ *  Parent decides when to open it (via long-press); this component
+ *  just handles dismissal — outside-click + Escape — and the
+ *  per-item rendering. */
 export function BubbleActions({
+  open,
   mine,
   canEdit,
   canDelete,
   onEdit,
   onDelete,
+  onClose,
 }: Props): React.ReactElement | null {
-  const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!open) return;
     function onDocClick(e: MouseEvent) {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) onClose();
     }
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") onClose();
     }
     document.addEventListener("mousedown", onDocClick);
     document.addEventListener("keydown", onKey);
@@ -36,53 +40,37 @@ export function BubbleActions({
       document.removeEventListener("mousedown", onDocClick);
       document.removeEventListener("keydown", onKey);
     };
-  }, [open]);
+  }, [open, onClose]);
 
-  if (!canEdit && !canDelete) return null;
+  if (!open || (!canEdit && !canDelete)) return null;
 
   return (
     <div
       ref={rootRef}
-      className="relative opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+      role="menu"
+      className={cn(
+        "absolute z-10 bottom-full mb-1 min-w-30 rounded-md border border-border-strong bg-chalk shadow-elev-2 py-1",
+        mine ? "right-0" : "left-0",
+      )}
     >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-label="Message actions"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        className="flex items-center justify-center w-7 h-7 rounded-full text-walnut-3 hover:text-walnut hover:bg-parchment-2"
-      >
-        <KebabIcon />
-      </button>
-      {open && (
-        <div
-          role="menu"
-          className={cn(
-            "absolute z-10 bottom-full mb-1 min-w-[7.5rem] rounded-md border border-border-strong bg-chalk shadow-elev-2 py-1",
-            mine ? "right-0" : "left-0",
-          )}
-        >
-          {canEdit && (
-            <MenuItem
-              onClick={() => {
-                setOpen(false);
-                onEdit();
-              }}
-              label="Edit"
-            />
-          )}
-          {canDelete && (
-            <MenuItem
-              onClick={() => {
-                setOpen(false);
-                onDelete();
-              }}
-              label="Delete"
-              danger
-            />
-          )}
-        </div>
+      {canEdit && (
+        <MenuItem
+          onClick={() => {
+            onClose();
+            onEdit();
+          }}
+          label="Edit"
+        />
+      )}
+      {canDelete && (
+        <MenuItem
+          onClick={() => {
+            onClose();
+            onDelete();
+          }}
+          label="Delete"
+          danger
+        />
       )}
     </div>
   );
@@ -109,15 +97,5 @@ function MenuItem({
     >
       {label}
     </button>
-  );
-}
-
-function KebabIcon() {
-  return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <circle cx="12" cy="5" r="1.6" fill="currentColor" />
-      <circle cx="12" cy="12" r="1.6" fill="currentColor" />
-      <circle cx="12" cy="19" r="1.6" fill="currentColor" />
-    </svg>
   );
 }

--- a/src/features/invitations/BubbleActions.tsx
+++ b/src/features/invitations/BubbleActions.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/cn";
+
+interface Props {
+  mine: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+/** Small overflow menu that appears on hover (desktop) or always
+ *  (mobile, via -group- parent), letting participants edit or delete
+ *  their own recent messages. Permissions resolved by the parent. */
+export function BubbleActions({
+  mine,
+  canEdit,
+  canDelete,
+  onEdit,
+  onDelete,
+}: Props): React.ReactElement | null {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onDocClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onDocClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  if (!canEdit && !canDelete) return null;
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity"
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-label="Message actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="flex items-center justify-center w-7 h-7 rounded-full text-walnut-3 hover:text-walnut hover:bg-parchment-2"
+      >
+        <KebabIcon />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          className={cn(
+            "absolute z-10 bottom-full mb-1 min-w-[7.5rem] rounded-md border border-border-strong bg-chalk shadow-elev-2 py-1",
+            mine ? "right-0" : "left-0",
+          )}
+        >
+          {canEdit && (
+            <MenuItem
+              onClick={() => {
+                setOpen(false);
+                onEdit();
+              }}
+              label="Edit"
+            />
+          )}
+          {canDelete && (
+            <MenuItem
+              onClick={() => {
+                setOpen(false);
+                onDelete();
+              }}
+              label="Delete"
+              danger
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MenuItem({
+  label,
+  danger,
+  onClick,
+}: {
+  label: string;
+  danger?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      role="menuitem"
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "w-full text-left px-3 py-1.5 font-sans text-[12.5px] transition-colors",
+        danger ? "text-bordeaux hover:bg-danger-soft/50" : "text-walnut hover:bg-parchment-2",
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function KebabIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <circle cx="12" cy="5" r="1.6" fill="currentColor" />
+      <circle cx="12" cy="12" r="1.6" fill="currentColor" />
+      <circle cx="12" cy="19" r="1.6" fill="currentColor" />
+    </svg>
+  );
+}

--- a/src/features/invitations/BubbleEditForm.tsx
+++ b/src/features/invitations/BubbleEditForm.tsx
@@ -1,0 +1,81 @@
+import { cn } from "@/lib/cn";
+
+interface Props {
+  draft: string;
+  setDraft: (v: string) => void;
+  onCancel: () => void;
+  onSave: () => void;
+  saving: boolean;
+  mine: boolean;
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>;
+}
+
+/** Inline textarea form that replaces the bubble body while the user
+ *  is editing one of their messages. Enter saves, Shift+Enter inserts
+ *  a newline, Escape cancels. Colour tokens pivot on `mine` so the
+ *  contrast still passes on the bordeaux "mine" bubble. */
+export function BubbleEditForm({
+  draft,
+  setDraft,
+  onCancel,
+  onSave,
+  saving,
+  mine,
+  textareaRef,
+}: Props) {
+  return (
+    <div className="flex flex-col gap-1.5 min-w-48">
+      <textarea
+        ref={textareaRef}
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        disabled={saving}
+        rows={2}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            onSave();
+          }
+          if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        className={cn(
+          "font-sans text-[14px] leading-snug rounded-md p-2 resize-none focus:outline-none",
+          mine
+            ? "bg-bordeaux-deep text-parchment border border-bordeaux-deep focus:border-parchment/40"
+            : "bg-chalk text-walnut border border-border-strong focus:border-bordeaux",
+        )}
+      />
+      <div className="flex items-center justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={saving}
+          className={cn(
+            "font-mono text-[10px] uppercase tracking-[0.14em] px-2 py-1 rounded-md transition-colors",
+            mine
+              ? "text-parchment/75 hover:text-parchment hover:bg-bordeaux-deep"
+              : "text-walnut-3 hover:text-walnut hover:bg-parchment-2",
+          )}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className={cn(
+            "font-mono text-[10px] uppercase tracking-[0.14em] px-2.5 py-1 rounded-md font-semibold transition-colors",
+            mine
+              ? "bg-parchment text-bordeaux hover:bg-chalk disabled:opacity-60"
+              : "bg-bordeaux text-parchment hover:bg-bordeaux-deep disabled:opacity-60",
+          )}
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/invitations/BubbleEditForm.tsx
+++ b/src/features/invitations/BubbleEditForm.tsx
@@ -24,7 +24,21 @@ export function BubbleEditForm({
   textareaRef,
 }: Props) {
   return (
-    <div className="flex flex-col gap-1.5 min-w-48">
+    <div className="relative flex flex-col gap-1.5 min-w-48">
+      <button
+        type="button"
+        onClick={onCancel}
+        disabled={saving}
+        aria-label="Cancel edit"
+        className={cn(
+          "absolute top-1 right-1 z-10 w-6 h-6 flex items-center justify-center rounded-full transition-colors disabled:opacity-50",
+          mine
+            ? "text-parchment/80 hover:text-parchment hover:bg-bordeaux/60"
+            : "text-walnut-3 hover:text-walnut hover:bg-parchment-2",
+        )}
+      >
+        <CloseIcon />
+      </button>
       <textarea
         ref={textareaRef}
         value={draft}
@@ -42,26 +56,13 @@ export function BubbleEditForm({
           }
         }}
         className={cn(
-          "font-sans text-[14px] leading-snug rounded-md p-2 resize-none focus:outline-none",
+          "font-sans text-[14px] leading-snug rounded-md p-2 pr-8 resize-none focus:outline-none",
           mine
             ? "bg-bordeaux-deep text-parchment border border-bordeaux-deep focus:border-parchment/40"
             : "bg-chalk text-walnut border border-border-strong focus:border-bordeaux",
         )}
       />
-      <div className="flex items-center justify-end gap-2">
-        <button
-          type="button"
-          onClick={onCancel}
-          disabled={saving}
-          className={cn(
-            "font-mono text-[10px] uppercase tracking-[0.14em] px-2 py-1 rounded-md transition-colors",
-            mine
-              ? "text-parchment/75 hover:text-parchment hover:bg-bordeaux-deep"
-              : "text-walnut-3 hover:text-walnut hover:bg-parchment-2",
-          )}
-        >
-          Cancel
-        </button>
+      <div className="flex items-center justify-end">
         <button
           type="button"
           onClick={onSave}
@@ -77,5 +78,13 @@ export function BubbleEditForm({
         </button>
       </div>
     </div>
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+      <path d="M6 6L18 18M6 18L18 6" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/src/features/invitations/ConversationBubble.tsx
+++ b/src/features/invitations/ConversationBubble.tsx
@@ -1,12 +1,11 @@
+import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/cn";
+import { BubbleActions } from "./BubbleActions";
+import { BubbleEditForm } from "./BubbleEditForm";
 import type { ChatMessage } from "./useConversation";
 
 export type BubblePosition = "single" | "first" | "middle" | "last";
 
-/** Derives a group position from (index, total). Used by the thread
- *  to shape each bubble's border-radius so that consecutive bubbles
- *  in a group read as one connected shape on the avatar-facing
- *  side. */
 export function bubblePositionOf(index: number, total: number): BubblePosition {
   if (total === 1) return "single";
   if (index === 0) return "first";
@@ -32,14 +31,58 @@ interface Props {
   message: ChatMessage;
   mine: boolean;
   position: BubblePosition;
+  canEdit?: boolean;
+  canDelete?: boolean;
+  onEdit?: (nextBody: string) => Promise<void> | void;
+  onDelete?: () => Promise<void> | void;
 }
 
-/** A single Messenger-style speech bubble. Response-type messages
- *  carry a small "Response · Yes/No" eyebrow above the bubble body
+/** A single Messenger-style speech bubble with optional hover-actions
+ *  (edit / delete) on the avatar-opposite side. Response-type
+ *  messages keep a small "Response · Yes/No" eyebrow above the body
  *  and a colored 2px border. */
-export function ConversationBubble({ message, mine, position }: Props): React.ReactElement {
+export function ConversationBubble({
+  message,
+  mine,
+  position,
+  canEdit,
+  canDelete,
+  onEdit,
+  onDelete,
+}: Props): React.ReactElement {
   const responseType = message.attributes?.responseType as "yes" | "no" | undefined;
   const radius = mine ? MINE_RADIUS[position] : THEIRS_RADIUS[position];
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(message.body);
+  const [saving, setSaving] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (!editing) return;
+    setDraft(message.body);
+    const el = textareaRef.current;
+    if (el) {
+      el.focus();
+      el.setSelectionRange(el.value.length, el.value.length);
+    }
+  }, [editing, message.body]);
+
+  async function save() {
+    if (!onEdit) return;
+    const next = draft.trim();
+    if (!next || next === message.body) {
+      setEditing(false);
+      return;
+    }
+    setSaving(true);
+    try {
+      await onEdit(next);
+      setEditing(false);
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <div className={cn("flex flex-col", mine ? "items-end" : "items-start")}>
       {responseType && (
@@ -47,17 +90,54 @@ export function ConversationBubble({ message, mine, position }: Props): React.Re
           {responseType === "yes" ? "Response · Yes" : "Response · No"}
         </span>
       )}
-      <div
-        className={cn(
-          "px-3.5 py-2 text-[14px] leading-snug whitespace-pre-wrap wrap-break-word shadow-[0_1px_0_rgba(35,24,21,0.04)]",
-          radius,
-          mine ? "bg-bordeaux text-parchment" : "bg-parchment-2 border border-border text-walnut",
-          responseType === "yes" && "border-success border-2",
-          responseType === "no" && "border-bordeaux border-2",
+      <div className={cn("group flex items-center gap-1", mine ? "flex-row" : "flex-row-reverse")}>
+        {!editing && (
+          <BubbleActions
+            mine={mine}
+            canEdit={Boolean(canEdit && onEdit)}
+            canDelete={Boolean(canDelete && onDelete)}
+            onEdit={() => setEditing(true)}
+            onDelete={() => {
+              if (onDelete) void onDelete();
+            }}
+          />
         )}
-      >
-        {message.body}
+        <div
+          className={cn(
+            "px-3.5 py-2 text-[14px] leading-snug whitespace-pre-wrap wrap-break-word shadow-[0_1px_0_rgba(35,24,21,0.04)] min-w-0",
+            radius,
+            mine ? "bg-bordeaux text-parchment" : "bg-parchment-2 border border-border text-walnut",
+            responseType === "yes" && "border-success border-2",
+            responseType === "no" && "border-bordeaux border-2",
+          )}
+        >
+          {editing ? (
+            <BubbleEditForm
+              draft={draft}
+              setDraft={setDraft}
+              onCancel={() => setEditing(false)}
+              onSave={save}
+              saving={saving}
+              mine={mine}
+              textareaRef={textareaRef}
+            />
+          ) : (
+            message.body
+          )}
+        </div>
       </div>
+      {message.dateUpdated &&
+        message.dateCreated &&
+        message.dateUpdated.getTime() > message.dateCreated.getTime() && (
+          <span
+            className={cn(
+              "font-mono text-[9px] uppercase tracking-[0.14em] text-walnut-3 mt-0.5",
+              mine ? "pr-1" : "pl-1",
+            )}
+          >
+            Edited
+          </span>
+        )}
     </div>
   );
 }

--- a/src/features/invitations/ConversationBubble.tsx
+++ b/src/features/invitations/ConversationBubble.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { useLongPress } from "@/hooks/useLongPress";
 import { cn } from "@/lib/cn";
 import { BubbleActions } from "./BubbleActions";
 import { BubbleEditForm } from "./BubbleEditForm";
@@ -37,10 +38,10 @@ interface Props {
   onDelete?: () => Promise<void> | void;
 }
 
-/** A single Messenger-style speech bubble with optional hover-actions
- *  (edit / delete) on the avatar-opposite side. Response-type
- *  messages keep a small "Response · Yes/No" eyebrow above the body
- *  and a colored 2px border. */
+/** A single Messenger-style speech bubble. Long-press the bubble to
+ *  reveal an edit/delete menu when the viewer has permission; the
+ *  press itself shows a brass-coloured halo + slight scale-down so
+ *  the gesture is discoverable. */
 export function ConversationBubble({
   message,
   mine,
@@ -55,7 +56,17 @@ export function ConversationBubble({
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(message.body);
   const [saving, setSaving] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const editAvailable = Boolean(canEdit && onEdit);
+  const deleteAvailable = Boolean(canDelete && onDelete);
+  const actionsAvailable = editAvailable || deleteAvailable;
+
+  const { pressing, bind } = useLongPress({
+    enabled: actionsAvailable && !editing,
+    onLongPress: () => setMenuOpen(true),
+  });
 
   useEffect(() => {
     if (!editing) return;
@@ -90,41 +101,47 @@ export function ConversationBubble({
           {responseType === "yes" ? "Response · Yes" : "Response · No"}
         </span>
       )}
-      <div className={cn("group flex items-center gap-1", mine ? "flex-row" : "flex-row-reverse")}>
-        {!editing && (
-          <BubbleActions
+      <div className="relative">
+        {editing ? (
+          <BubbleEditForm
+            draft={draft}
+            setDraft={setDraft}
+            onCancel={() => setEditing(false)}
+            onSave={save}
+            saving={saving}
             mine={mine}
-            canEdit={Boolean(canEdit && onEdit)}
-            canDelete={Boolean(canDelete && onDelete)}
-            onEdit={() => setEditing(true)}
-            onDelete={() => {
-              if (onDelete) void onDelete();
-            }}
+            textareaRef={textareaRef}
           />
+        ) : (
+          <div
+            {...(actionsAvailable ? bind : {})}
+            className={cn(
+              "px-3.5 py-2 text-[14px] leading-snug whitespace-pre-wrap wrap-break-word shadow-[0_1px_0_rgba(35,24,21,0.04)] min-w-0",
+              radius,
+              mine
+                ? "bg-bordeaux text-parchment"
+                : "bg-parchment-2 border border-border text-walnut",
+              responseType === "yes" && "border-success border-2",
+              responseType === "no" && "border-bordeaux border-2",
+              actionsAvailable &&
+                "select-none transition-[transform,box-shadow] duration-500 ease-out touch-manipulation",
+              pressing && "scale-[0.97] shadow-[0_0_0_3px_rgba(193,140,35,0.55)]",
+            )}
+          >
+            {message.body}
+          </div>
         )}
-        <div
-          className={cn(
-            "px-3.5 py-2 text-[14px] leading-snug whitespace-pre-wrap wrap-break-word shadow-[0_1px_0_rgba(35,24,21,0.04)] min-w-0",
-            radius,
-            mine ? "bg-bordeaux text-parchment" : "bg-parchment-2 border border-border text-walnut",
-            responseType === "yes" && "border-success border-2",
-            responseType === "no" && "border-bordeaux border-2",
-          )}
-        >
-          {editing ? (
-            <BubbleEditForm
-              draft={draft}
-              setDraft={setDraft}
-              onCancel={() => setEditing(false)}
-              onSave={save}
-              saving={saving}
-              mine={mine}
-              textareaRef={textareaRef}
-            />
-          ) : (
-            message.body
-          )}
-        </div>
+        <BubbleActions
+          open={menuOpen}
+          mine={mine}
+          canEdit={editAvailable}
+          canDelete={deleteAvailable}
+          onClose={() => setMenuOpen(false)}
+          onEdit={() => setEditing(true)}
+          onDelete={() => {
+            if (onDelete) void onDelete();
+          }}
+        />
       </div>
       {message.dateUpdated &&
         message.dateCreated &&

--- a/src/features/invitations/ConversationGroup.tsx
+++ b/src/features/invitations/ConversationGroup.tsx
@@ -1,6 +1,7 @@
 import { cn } from "@/lib/cn";
 import { ConversationAvatar } from "./ConversationAvatar";
 import { ConversationBubble, bubblePositionOf } from "./ConversationBubble";
+import type { Permissions } from "./messageActions";
 import type { MessageGroup } from "./threadItems";
 
 interface Props {
@@ -8,13 +9,29 @@ interface Props {
   /** When true, the last mine=true bubble in the group is the latest
    *  message the other side has marked as read — show "Read" under it. */
   readByOther?: boolean;
+  /** Per-message delete/edit permissions computed by the thread.
+   *  When omitted, bubble actions stay hidden regardless of handlers. */
+  permissions?: Permissions;
+  /** Opens the thread-level delete-confirm dialog for the given
+   *  message sid. Thread owns the dialog so one shared instance
+   *  covers every bubble. */
+  onRequestDelete?: (sid: string) => void;
+  /** Called when a bubble's inline edit form saves. The thread
+   *  forwards to Twilio `Message.updateBody`. */
+  onEditMessage?: (sid: string, nextBody: string) => Promise<void> | void;
 }
 
 /** Renders one author's run of consecutive messages as a connected
  *  stack with a single avatar + trailing timestamp. Read receipt is
  *  a small "Read" label under the last bubble on mine=true groups
  *  when the other participant has read up to that index. */
-export function ConversationGroup({ group, readByOther }: Props): React.ReactElement {
+export function ConversationGroup({
+  group,
+  readByOther,
+  permissions,
+  onRequestDelete,
+  onEditMessage,
+}: Props): React.ReactElement {
   const last = group.messages.at(-1)!;
   const timestamp = last.dateCreated?.toLocaleTimeString(undefined, {
     hour: "numeric",
@@ -48,14 +65,26 @@ export function ConversationGroup({ group, readByOther }: Props): React.ReactEle
         <div
           className={cn("flex flex-col gap-0.5 min-w-0", group.mine ? "items-end" : "items-start")}
         >
-          {group.messages.map((m, i) => (
-            <ConversationBubble
-              key={m.sid}
-              message={m}
-              mine={group.mine}
-              position={bubblePositionOf(i, group.messages.length)}
-            />
-          ))}
+          {group.messages.map((m, i) => {
+            const canEdit = Boolean(permissions?.canEdit(m) && onEditMessage);
+            const canDelete = Boolean(permissions?.canDelete(m) && onRequestDelete);
+            return (
+              <ConversationBubble
+                key={m.sid}
+                message={m}
+                mine={group.mine}
+                position={bubblePositionOf(i, group.messages.length)}
+                canEdit={canEdit}
+                canDelete={canDelete}
+                {...(canEdit && onEditMessage
+                  ? { onEdit: (nextBody: string) => onEditMessage(m.sid, nextBody) }
+                  : {})}
+                {...(canDelete && onRequestDelete
+                  ? { onDelete: () => onRequestDelete(m.sid) }
+                  : {})}
+              />
+            );
+          })}
         </div>
       </div>
       {timestamp && (

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { cn } from "@/lib/cn";
 import { ConversationGroup } from "./ConversationGroup";
 import { JumpToLatest } from "./JumpToLatest";
+import { SystemNotice } from "./SystemNotice";
 import { DayDivider, UnreadDivider } from "./ThreadDividers";
+import { buildMessagePermissions, findLastMineIndex } from "./messageActions";
 import { buildThreadItems } from "./threadItems";
 import type { AuthorMap, ChatMessage } from "./useConversation";
 
@@ -24,6 +27,11 @@ interface Props {
    *  is capped at 60vh — right for the speaker landing page where the
    *  thread sits inside a naturally-stacking scroll column. */
   fillHeight?: boolean;
+  /** Per-message action handlers. When omitted, edit/delete UI is
+   *  hidden even if permissions would otherwise allow it (the
+   *  action isn't wired into the embedding chat). */
+  onEditMessage?: (sid: string, nextBody: string) => Promise<void> | void;
+  onDeleteMessage?: (sid: string) => Promise<void> | void;
 }
 
 /** Bubble list styled after Messenger. Consecutive messages by the
@@ -38,11 +46,20 @@ export function ConversationThread({
   firstUnreadIndex,
   readHorizonIndex,
   fillHeight,
+  onEditMessage,
+  onDeleteMessage,
 }: Props): React.ReactElement {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [atBottom, setAtBottom] = useState(true);
   const [unseenCount, setUnseenCount] = useState(0);
+  const [pendingDeleteSid, setPendingDeleteSid] = useState<string | null>(null);
+  const [deleting, setDeleting] = useState(false);
   const lastSeenIndexRef = useRef<number | null>(null);
+
+  const permissions = useMemo(
+    () => buildMessagePermissions(currentIdentity, messages),
+    [currentIdentity, messages],
+  );
 
   const items = useMemo(
     () =>
@@ -72,6 +89,17 @@ export function ConversationThread({
     const el = scrollRef.current;
     if (!el) return;
     el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }
+
+  async function handleDeleteConfirm() {
+    if (!pendingDeleteSid || !onDeleteMessage) return;
+    setDeleting(true);
+    try {
+      await onDeleteMessage(pendingDeleteSid);
+      setPendingDeleteSid(null);
+    } finally {
+      setDeleting(false);
+    }
   }
 
   if (loading) {
@@ -123,44 +151,24 @@ export function ConversationThread({
                 readByOtherAt !== null &&
                 item.group.messages.some((m) => m.index === readByOtherAt)
               }
+              permissions={permissions}
+              {...(onEditMessage ? { onEditMessage } : {})}
+              {...(onDeleteMessage ? { onRequestDelete: setPendingDeleteSid } : {})}
             />
           );
         })}
       </div>
       {!atBottom && <JumpToLatest unseenCount={unseenCount} onJump={jumpToBottom} />}
-    </div>
-  );
-}
-
-function findLastMineIndex(
-  messages: readonly ChatMessage[],
-  currentIdentity: string | null,
-): number | null {
-  if (!currentIdentity) return null;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i]!.author === currentIdentity) return messages[i]!.index;
-  }
-  return null;
-}
-
-/** Centered one-line system notice for status-change messages,
- *  mirroring the DayDivider rule-label-rule pattern so it reads as
- *  a thread event rather than a message. Text + rule colour pivot
- *  on status: green for confirmed, red for declined. */
-function SystemNotice({ body, status }: { body: string; status: "confirmed" | "declined" }) {
-  const textCls = status === "confirmed" ? "text-success" : "text-bordeaux";
-  const ruleCls = status === "confirmed" ? "bg-success/40" : "bg-bordeaux/40";
-  return (
-    <div className="flex items-center gap-2 -my-1" role="status" aria-label={body}>
-      <div aria-hidden="true" className={`flex-1 h-px ${ruleCls}`} />
-      <span
-        aria-hidden="true"
-        className={`font-serif italic text-[12px] ${textCls} truncate`}
-        title={body}
-      >
-        {body}
-      </span>
-      <div aria-hidden="true" className={`flex-1 h-px ${ruleCls}`} />
+      <ConfirmDialog
+        open={pendingDeleteSid !== null}
+        title="Delete this message?"
+        body="The message will be removed for everyone in this conversation. This can't be undone."
+        confirmLabel="Delete"
+        danger
+        busy={deleting}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setPendingDeleteSid(null)}
+      />
     </div>
   );
 }

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -112,6 +112,7 @@ export function ConversationThread({
         {items.map((item) => {
           if (item.kind === "day") return <DayDivider key={item.key} label={item.label} />;
           if (item.kind === "unread") return <UnreadDivider key={item.key} />;
+          if (item.kind === "system") return <SystemNotice key={item.key} body={item.body} />;
           return (
             <ConversationGroup
               key={item.key}
@@ -139,4 +140,18 @@ function findLastMineIndex(
     if (messages[i]!.author === currentIdentity) return messages[i]!.index;
   }
   return null;
+}
+
+/** Centered pill used for system-posted status-change lines
+ *  ("Assignment confirmed — thank you for speaking this Sunday.").
+ *  Kept visually distinct from participant bubbles so the change
+ *  reads as a record update, not as a message from either side. */
+function SystemNotice({ body }: { body: string }) {
+  return (
+    <div className="flex justify-center" role="status">
+      <span className="inline-block px-3.5 py-1.5 rounded-full border border-border bg-parchment-2 font-serif italic text-[12.5px] text-walnut-2 max-w-[88%] text-center">
+        {body}
+      </span>
+    </div>
+  );
 }

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -142,16 +142,18 @@ function findLastMineIndex(
   return null;
 }
 
-/** Centered pill used for system-posted status-change lines
+/** Plain centered line for system-posted status-change messages
  *  ("Assignment confirmed — thank you for speaking this Sunday.").
- *  Kept visually distinct from participant bubbles so the change
- *  reads as a record update, not as a message from either side. */
+ *  No container, no padding, no wrap — reads as a quiet event
+ *  between regular participant groups. */
 function SystemNotice({ body }: { body: string }) {
   return (
-    <div className="flex justify-center" role="status">
-      <span className="inline-block px-3.5 py-1.5 rounded-full border border-border bg-parchment-2 font-serif italic text-[12.5px] text-walnut-2 max-w-[88%] text-center">
-        {body}
-      </span>
-    </div>
+    <p
+      role="status"
+      title={body}
+      className="font-serif italic text-[12px] text-walnut-3 text-center truncate"
+    >
+      {body}
+    </p>
   );
 }

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -112,7 +112,8 @@ export function ConversationThread({
         {items.map((item) => {
           if (item.kind === "day") return <DayDivider key={item.key} label={item.label} />;
           if (item.kind === "unread") return <UnreadDivider key={item.key} />;
-          if (item.kind === "system") return <SystemNotice key={item.key} body={item.body} />;
+          if (item.kind === "system")
+            return <SystemNotice key={item.key} body={item.body} status={item.status} />;
           return (
             <ConversationGroup
               key={item.key}
@@ -142,18 +143,24 @@ function findLastMineIndex(
   return null;
 }
 
-/** Plain centered line for system-posted status-change messages
- *  ("Assignment confirmed — thank you for speaking this Sunday.").
- *  No container, no padding, no wrap — reads as a quiet event
- *  between regular participant groups. */
-function SystemNotice({ body }: { body: string }) {
+/** Centered one-line system notice for status-change messages,
+ *  mirroring the DayDivider rule-label-rule pattern so it reads as
+ *  a thread event rather than a message. Text + rule colour pivot
+ *  on status: green for confirmed, red for declined. */
+function SystemNotice({ body, status }: { body: string; status: "confirmed" | "declined" }) {
+  const textCls = status === "confirmed" ? "text-success" : "text-bordeaux";
+  const ruleCls = status === "confirmed" ? "bg-success/40" : "bg-bordeaux/40";
   return (
-    <p
-      role="status"
-      title={body}
-      className="font-serif italic text-[12px] text-walnut-3 text-center truncate"
-    >
-      {body}
-    </p>
+    <div className="flex items-center gap-2 -my-1" role="status" aria-label={body}>
+      <div aria-hidden="true" className={`flex-1 h-px ${ruleCls}`} />
+      <span
+        aria-hidden="true"
+        className={`font-serif italic text-[12px] ${textCls} truncate`}
+        title={body}
+      >
+        {body}
+      </span>
+      <div aria-hidden="true" className={`flex-1 h-px ${ruleCls}`} />
+    </div>
   );
 }

--- a/src/features/invitations/ConversationThread.tsx
+++ b/src/features/invitations/ConversationThread.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { useMinuteTick } from "@/hooks/useMinuteTick";
 import { cn } from "@/lib/cn";
 import { ConversationGroup } from "./ConversationGroup";
 import { JumpToLatest } from "./JumpToLatest";
@@ -55,10 +56,13 @@ export function ConversationThread({
   const [pendingDeleteSid, setPendingDeleteSid] = useState<string | null>(null);
   const [deleting, setDeleting] = useState(false);
   const lastSeenIndexRef = useRef<number | null>(null);
+  // Drives the 30-min edit/delete cutoff — the long-press menu must
+  // disappear once a message expires, even if no new traffic arrives.
+  const nowMinute = useMinuteTick();
 
   const permissions = useMemo(
-    () => buildMessagePermissions(currentIdentity, messages),
-    [currentIdentity, messages],
+    () => buildMessagePermissions(currentIdentity, messages, nowMinute * 60_000),
+    [currentIdentity, messages, nowMinute],
   );
 
   const items = useMemo(

--- a/src/features/invitations/InvitationStatusBanner.tsx
+++ b/src/features/invitations/InvitationStatusBanner.tsx
@@ -21,6 +21,10 @@ interface Props {
    *  to `updateSpeaker({ status })` which stamps
    *  `statusSource=manual` + `statusSetBy` + `statusSetAt`. */
   onStatusChange: (status: SpeakerStatus) => void;
+  /** Current signed-in user's uid. Used by the pills' confirm dialog
+   *  to suppress the "someone else set this" context line when the
+   *  same user is overriding their own earlier choice. */
+  currentUserUid?: string | undefined;
 }
 
 /** Bishop-side banner above the invitation chat thread. Replaces the
@@ -36,6 +40,7 @@ export function InvitationStatusBanner({
   applying,
   applyError,
   onStatusChange,
+  currentUserUid,
 }: Props) {
   const view = deriveBannerView(speaker, invitation);
   const lastSeen = formatLastSeen(invitation.speakerLastSeenAt);
@@ -72,7 +77,14 @@ export function InvitationStatusBanner({
       </div>
       {applyError && <p className="font-sans text-[11.5px] text-bordeaux mt-2">{applyError}</p>}
       <div className="mt-3">
-        <SpeakerStatusPills status={speaker.status ?? "planned"} onChange={onStatusChange} />
+        <SpeakerStatusPills
+          status={speaker.status ?? "planned"}
+          onChange={onStatusChange}
+          currentStatusSource={speaker.statusSource}
+          currentStatusSetBy={speaker.statusSetBy}
+          members={members}
+          currentUserUid={currentUserUid}
+        />
         {provenance && (
           <p className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 -mt-1">
             {provenance}

--- a/src/features/invitations/NoInvitationPlaceholder.tsx
+++ b/src/features/invitations/NoInvitationPlaceholder.tsx
@@ -1,6 +1,13 @@
-import type { Speaker } from "@/lib/types";
+import { useState } from "react";
+import { SpeakerStatusPills } from "@/features/schedule/SpeakerStatusPills";
+import { statusProvenanceLabel } from "@/features/schedule/statusProvenance";
+import { updateSpeaker } from "@/features/speakers/speakerActions";
+import { useWardMembers } from "@/hooks/useWardMembers";
+import { useAuthStore } from "@/stores/authStore";
+import type { Speaker, SpeakerStatus } from "@/lib/types";
 
 interface Props {
+  wardId: string;
   speaker: Speaker;
   speakerId: string;
   date: string;
@@ -8,18 +15,27 @@ interface Props {
 }
 
 /** Renders inside the BishopInvitationDialog when no in-app invitation
- *  has been provisioned yet (or the one that was wiped). Copy pivots
- *  on the speaker's current status so a bishop who just printed the
- *  letter and marked the speaker invited doesn't see a contradictory
- *  "no invitation has been sent yet" message. */
+ *  has been provisioned yet. The top strip mirrors the chat banner's
+ *  slot — status pills + audit provenance — so the bishop can correct
+ *  status without leaving the dialog. The body below carries the
+ *  "invitation not sent yet" / "out-of-band invited" explanation and
+ *  the CTA to open the Prepare Invitation page. Parity with the chat
+ *  layout prevents the eye-movement jump when toggling between the
+ *  two surfaces for adjacent speakers on the schedule. */
 export function NoInvitationPlaceholder({
+  wardId,
   speaker,
   speakerId,
   date,
   onNavigate,
 }: Props): React.ReactElement {
+  const user = useAuthStore((s) => s.user);
+  const members = useWardMembers();
+  const [statusError, setStatusError] = useState<string | null>(null);
   const prepareHref = `/week/${encodeURIComponent(date)}/speaker/${encodeURIComponent(speakerId)}/prepare`;
   const view = deriveView(speaker);
+  const provenance = statusProvenanceLabel(speaker, members);
+
   function openPrepare() {
     // Open in a new tab to match the rest of the app (SpeakerLockedBand
     // uses the same pattern). The Prepare page's own Cancel button
@@ -28,36 +44,64 @@ export function NoInvitationPlaceholder({
     window.open(prepareHref, "_blank", "noopener,noreferrer");
     onNavigate?.();
   }
+
+  async function onStatusChange(next: SpeakerStatus) {
+    setStatusError(null);
+    try {
+      await updateSpeaker(wardId, date, speakerId, { status: next });
+    } catch (err) {
+      setStatusError((err as Error).message);
+    }
+  }
+
   return (
-    <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 py-10 bg-chalk overflow-y-auto">
-      <div className="w-12 h-12 rounded-full bg-parchment-2 flex items-center justify-center text-walnut-3">
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="1.75"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-          aria-hidden="true"
+    <div className="flex-1 flex flex-col min-h-0 overflow-hidden bg-chalk">
+      <div className="px-4 py-3.5 border-b border-border bg-parchment-2">
+        <SpeakerStatusPills
+          status={speaker.status ?? "planned"}
+          onChange={onStatusChange}
+          currentStatusSource={speaker.statusSource}
+          currentStatusSetBy={speaker.statusSetBy}
+          members={members}
+          currentUserUid={user?.uid}
+        />
+        {provenance && (
+          <p className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 -mt-1">
+            {provenance}
+          </p>
+        )}
+        {statusError && <p className="font-sans text-[11.5px] text-bordeaux mt-2">{statusError}</p>}
+      </div>
+      <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 py-10 overflow-y-auto">
+        <div className="w-12 h-12 rounded-full bg-parchment-2 flex items-center justify-center text-walnut-3">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+        </div>
+        <div className="text-center max-w-sm">
+          <p className="font-sans text-[15px] font-semibold text-walnut">{view.title}</p>
+          <p className="font-serif italic text-[13.5px] text-walnut-2 mt-1.5 leading-relaxed">
+            {view.body}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openPrepare}
+          className="font-sans text-[13px] font-semibold px-4 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
         >
-          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-        </svg>
+          {view.ctaLabel}
+        </button>
       </div>
-      <div className="text-center max-w-sm">
-        <p className="font-sans text-[15px] font-semibold text-walnut">{view.title}</p>
-        <p className="font-serif italic text-[13.5px] text-walnut-2 mt-1.5 leading-relaxed">
-          {view.body}
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={openPrepare}
-        className="font-sans text-[13px] font-semibold px-4 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
-      >
-        {view.ctaLabel}
-      </button>
     </div>
   );
 }

--- a/src/features/invitations/NoInvitationPlaceholder.tsx
+++ b/src/features/invitations/NoInvitationPlaceholder.tsx
@@ -8,13 +8,11 @@ interface Props {
   onNavigate?: () => void;
 }
 
-/** Renders inside the BishopInvitationDialog when the speaker hasn't
- *  been invited through Steward yet — the in-app chat channel isn't
- *  available because no Twilio conversation has been provisioned. We
- *  tell the bishopric that directly and offer a direct path to the
- *  Prepare Invitation page where they can send or print the letter
- *  (print works even when the speaker has no phone or email on
- *  file — see prepare-invitation.tsx's action bar). */
+/** Renders inside the BishopInvitationDialog when no in-app invitation
+ *  has been provisioned yet (or the one that was wiped). Copy pivots
+ *  on the speaker's current status so a bishop who just printed the
+ *  letter and marked the speaker invited doesn't see a contradictory
+ *  "no invitation has been sent yet" message. */
 export function NoInvitationPlaceholder({
   speaker,
   speakerId,
@@ -22,6 +20,7 @@ export function NoInvitationPlaceholder({
   onNavigate,
 }: Props): React.ReactElement {
   const prepareHref = `/week/${date}/speaker/${speakerId}/prepare`;
+  const view = deriveView(speaker);
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 py-10 bg-chalk overflow-y-auto">
       <div className="w-12 h-12 rounded-full bg-parchment-2 flex items-center justify-center text-walnut-3">
@@ -40,13 +39,9 @@ export function NoInvitationPlaceholder({
         </svg>
       </div>
       <div className="text-center max-w-sm">
-        <p className="font-sans text-[15px] font-semibold text-walnut">
-          Chat is available once you've sent an invitation
-        </p>
+        <p className="font-sans text-[15px] font-semibold text-walnut">{view.title}</p>
         <p className="font-serif italic text-[13.5px] text-walnut-2 mt-1.5 leading-relaxed">
-          No Steward invitation has been sent to {speaker.name} yet, so there's no in-app
-          conversation to open. Prepare the invitation to send or print it — the chat opens
-          automatically once an invitation is on file.
+          {view.body}
         </p>
       </div>
       <Link
@@ -54,8 +49,44 @@ export function NoInvitationPlaceholder({
         onClick={onNavigate}
         className="font-sans text-[13px] font-semibold px-4 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
       >
-        Prepare invitation
+        {view.ctaLabel}
       </Link>
     </div>
   );
+}
+
+interface View {
+  title: string;
+  body: string;
+  ctaLabel: string;
+}
+
+function deriveView(speaker: Speaker): View {
+  const status = speaker.status ?? "planned";
+  if (status === "planned") {
+    return {
+      title: "Chat is available once you've sent an invitation",
+      body: `No Steward invitation has been sent to ${speaker.name} yet, so there's no in-app conversation to open. Prepare the invitation to send or print it — the chat opens automatically once an invitation is on file.`,
+      ctaLabel: "Prepare invitation",
+    };
+  }
+  if (status === "invited") {
+    return {
+      title: `${speaker.name} was invited outside Steward`,
+      body: `Their status is set to "invited" but no in-app invitation was sent (likely because you printed the letter or marked them invited by hand). The chat only works for invitations sent through Steward with an email or phone on file — follow up directly for now, or re-prepare an in-app invitation if contact details are added later.`,
+      ctaLabel: "Prepare invitation anyway",
+    };
+  }
+  if (status === "confirmed") {
+    return {
+      title: `${speaker.name} is confirmed`,
+      body: `Their status was set outside the in-app invitation flow, so there's no Steward conversation to open here. You can still prepare and send an in-app invitation if you want chat on record — otherwise reach out directly.`,
+      ctaLabel: "Prepare invitation anyway",
+    };
+  }
+  return {
+    title: `${speaker.name} declined`,
+    body: `Their status was set outside the in-app invitation flow, so there's no Steward conversation to open here. Reach out directly to follow up, or prepare a fresh invitation for a replacement speaker.`,
+    ctaLabel: "Prepare invitation anyway",
+  };
 }

--- a/src/features/invitations/NoInvitationPlaceholder.tsx
+++ b/src/features/invitations/NoInvitationPlaceholder.tsx
@@ -1,19 +1,27 @@
+import { Link } from "react-router";
 import type { Speaker } from "@/lib/types";
 
 interface Props {
   speaker: Speaker;
+  speakerId: string;
+  date: string;
+  onNavigate?: () => void;
 }
 
 /** Renders inside the BishopInvitationDialog when the speaker hasn't
  *  been invited through Steward yet — the in-app chat channel isn't
  *  available because no Twilio conversation has been provisioned. We
- *  tell the bishopric that directly and suggest external contact
- *  methods they can use right now, so the dialog is still useful as
- *  a consolidated "this is the speaker's state" surface. */
-export function NoInvitationPlaceholder({ speaker }: Props): React.ReactElement {
-  const email = speaker.email;
-  const phone = speaker.phone;
-  const hasContact = Boolean(email || phone);
+ *  tell the bishopric that directly and offer a direct path to the
+ *  Prepare Invitation page where they can send or print the letter
+ *  (print works even when the speaker has no phone or email on
+ *  file — see prepare-invitation.tsx's action bar). */
+export function NoInvitationPlaceholder({
+  speaker,
+  speakerId,
+  date,
+  onNavigate,
+}: Props): React.ReactElement {
+  const prepareHref = `/week/${date}/speaker/${speakerId}/prepare`;
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 py-10 bg-chalk overflow-y-auto">
       <div className="w-12 h-12 rounded-full bg-parchment-2 flex items-center justify-center text-walnut-3">
@@ -37,46 +45,17 @@ export function NoInvitationPlaceholder({ speaker }: Props): React.ReactElement 
         </p>
         <p className="font-serif italic text-[13.5px] text-walnut-2 mt-1.5 leading-relaxed">
           No Steward invitation has been sent to {speaker.name} yet, so there's no in-app
-          conversation to open. In the meantime, reach out directly using the details below, then
-          come back here to send the formal invitation.
+          conversation to open. Prepare the invitation to send or print it — the chat opens
+          automatically once an invitation is on file.
         </p>
       </div>
-      {hasContact ? (
-        <div className="w-full max-w-sm bg-parchment-2 border border-border rounded-lg p-3.5">
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium mb-2">
-            Contact directly
-          </div>
-          <ul className="flex flex-col gap-1.5 font-sans text-[13.5px] text-walnut">
-            {phone && (
-              <li>
-                <a
-                  href={`tel:${phone}`}
-                  className="underline decoration-border hover:text-bordeaux"
-                >
-                  {phone}
-                </a>
-              </li>
-            )}
-            {email && (
-              <li>
-                <a
-                  href={`mailto:${email}`}
-                  className="underline decoration-border hover:text-bordeaux break-all"
-                >
-                  {email}
-                </a>
-              </li>
-            )}
-          </ul>
-        </div>
-      ) : (
-        <div className="w-full max-w-sm bg-parchment-2 border border-border rounded-lg p-3.5 text-center">
-          <p className="font-serif italic text-[13px] text-walnut-2">
-            No phone or email on file. Add contact details on the speaker's card to enable direct
-            outreach.
-          </p>
-        </div>
-      )}
+      <Link
+        to={prepareHref}
+        onClick={onNavigate}
+        className="font-sans text-[13px] font-semibold px-4 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
+      >
+        Prepare invitation
+      </Link>
     </div>
   );
 }

--- a/src/features/invitations/NoInvitationPlaceholder.tsx
+++ b/src/features/invitations/NoInvitationPlaceholder.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import type { Speaker } from "@/lib/types";
 
 interface Props {
@@ -19,8 +18,16 @@ export function NoInvitationPlaceholder({
   date,
   onNavigate,
 }: Props): React.ReactElement {
-  const prepareHref = `/week/${date}/speaker/${speakerId}/prepare`;
+  const prepareHref = `/week/${encodeURIComponent(date)}/speaker/${encodeURIComponent(speakerId)}/prepare`;
   const view = deriveView(speaker);
+  function openPrepare() {
+    // Open in a new tab to match the rest of the app (SpeakerLockedBand
+    // uses the same pattern). The Prepare page's own Cancel button
+    // calls window.close(), which only works when the page was opened
+    // via window.open — same-tab navigation would break that button.
+    window.open(prepareHref, "_blank", "noopener,noreferrer");
+    onNavigate?.();
+  }
   return (
     <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 py-10 bg-chalk overflow-y-auto">
       <div className="w-12 h-12 rounded-full bg-parchment-2 flex items-center justify-center text-walnut-3">
@@ -44,13 +51,13 @@ export function NoInvitationPlaceholder({
           {view.body}
         </p>
       </div>
-      <Link
-        to={prepareHref}
-        onClick={onNavigate}
+      <button
+        type="button"
+        onClick={openPrepare}
         className="font-sans text-[13px] font-semibold px-4 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
       >
         {view.ctaLabel}
-      </Link>
+      </button>
     </div>
   );
 }

--- a/src/features/invitations/NoInvitationPlaceholder.tsx
+++ b/src/features/invitations/NoInvitationPlaceholder.tsx
@@ -4,7 +4,9 @@ import { statusProvenanceLabel } from "@/features/schedule/statusProvenance";
 import { updateSpeaker } from "@/features/speakers/speakerActions";
 import { useWardMembers } from "@/hooks/useWardMembers";
 import { useAuthStore } from "@/stores/authStore";
+import { cn } from "@/lib/cn";
 import type { Speaker, SpeakerStatus } from "@/lib/types";
+import { statusStripBg } from "./statusStripBg";
 
 interface Props {
   wardId: string;
@@ -56,7 +58,12 @@ export function NoInvitationPlaceholder({
 
   return (
     <div className="flex-1 flex flex-col min-h-0 overflow-hidden bg-chalk">
-      <div className="px-4 py-3.5 border-b border-border bg-parchment-2">
+      <div
+        className={cn(
+          "px-4 py-3.5 border-b border-border",
+          statusStripBg(speaker.status ?? "planned"),
+        )}
+      >
         <SpeakerStatusPills
           status={speaker.status ?? "planned"}
           onChange={onStatusChange}

--- a/src/features/invitations/NoInvitationPlaceholder.tsx
+++ b/src/features/invitations/NoInvitationPlaceholder.tsx
@@ -1,0 +1,82 @@
+import type { Speaker } from "@/lib/types";
+
+interface Props {
+  speaker: Speaker;
+}
+
+/** Renders inside the BishopInvitationDialog when the speaker hasn't
+ *  been invited through Steward yet — the in-app chat channel isn't
+ *  available because no Twilio conversation has been provisioned. We
+ *  tell the bishopric that directly and suggest external contact
+ *  methods they can use right now, so the dialog is still useful as
+ *  a consolidated "this is the speaker's state" surface. */
+export function NoInvitationPlaceholder({ speaker }: Props): React.ReactElement {
+  const email = speaker.email;
+  const phone = speaker.phone;
+  const hasContact = Boolean(email || phone);
+  return (
+    <div className="flex-1 flex flex-col items-center justify-center gap-4 px-6 py-10 bg-chalk overflow-y-auto">
+      <div className="w-12 h-12 rounded-full bg-parchment-2 flex items-center justify-center text-walnut-3">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.75"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+        </svg>
+      </div>
+      <div className="text-center max-w-sm">
+        <p className="font-sans text-[15px] font-semibold text-walnut">
+          Chat is available once you've sent an invitation
+        </p>
+        <p className="font-serif italic text-[13.5px] text-walnut-2 mt-1.5 leading-relaxed">
+          No Steward invitation has been sent to {speaker.name} yet, so there's no in-app
+          conversation to open. In the meantime, reach out directly using the details below, then
+          come back here to send the formal invitation.
+        </p>
+      </div>
+      {hasContact ? (
+        <div className="w-full max-w-sm bg-parchment-2 border border-border rounded-lg p-3.5">
+          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium mb-2">
+            Contact directly
+          </div>
+          <ul className="flex flex-col gap-1.5 font-sans text-[13.5px] text-walnut">
+            {phone && (
+              <li>
+                <a
+                  href={`tel:${phone}`}
+                  className="underline decoration-border hover:text-bordeaux"
+                >
+                  {phone}
+                </a>
+              </li>
+            )}
+            {email && (
+              <li>
+                <a
+                  href={`mailto:${email}`}
+                  className="underline decoration-border hover:text-bordeaux break-all"
+                >
+                  {email}
+                </a>
+              </li>
+            )}
+          </ul>
+        </div>
+      ) : (
+        <div className="w-full max-w-sm bg-parchment-2 border border-border rounded-lg p-3.5 text-center">
+          <p className="font-serif italic text-[13px] text-walnut-2">
+            No phone or email on file. Add contact details on the speaker's card to enable direct
+            outreach.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/invitations/QuickActionButtons.tsx
+++ b/src/features/invitations/QuickActionButtons.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Conversation } from "@twilio/conversations";
+import { formatShortSunday } from "@/features/schedule/dateFormat";
 import { cn } from "@/lib/cn";
 
 interface Props {
@@ -8,6 +9,10 @@ interface Props {
   /** Called with the submitted answer so the caller can mirror it
    *  into `invitation.response` in Firestore (bishop-visible badge). */
   onSubmit: (answer: "yes" | "no", reason?: string) => Promise<void>;
+  /** ISO `YYYY-MM-DD` of the meeting — substituted into the prompt
+   *  ("Can you speak on Sun May 20?") instead of the ambiguous
+   *  "this Sunday". */
+  meetingDate: string;
 }
 
 type Mode = "idle" | "noReason";
@@ -28,6 +33,7 @@ export function QuickActionButtons({
   conversation,
   ensureReady,
   onSubmit,
+  meetingDate,
 }: Props): React.ReactElement {
   const [mode, setMode] = useState<Mode>("idle");
   const [reason, setReason] = useState("");
@@ -94,7 +100,9 @@ export function QuickActionButtons({
 
   return (
     <div className="flex flex-col gap-2 p-3 border-t border-border bg-chalk">
-      <p className="font-serif text-[13.5px] text-walnut-2">Can you speak on this Sunday?</p>
+      <p className="font-serif text-[13.5px] text-walnut-2">
+        Can you speak on {formatShortSunday(meetingDate)}?
+      </p>
       <div className="flex gap-2">
         <button
           type="button"

--- a/src/features/invitations/SpeakerChatHeader.tsx
+++ b/src/features/invitations/SpeakerChatHeader.tsx
@@ -1,0 +1,32 @@
+interface Props {
+  onClose?: (() => void) | undefined;
+}
+
+/** Speaker-side chat pane header: a small eyebrow/subheading strip
+ *  with an optional Close button on the right. The Close button is
+ *  only rendered when the parent (the floating drawer on the invite
+ *  page) supplies a handler — the inline layout omits it. */
+export function SpeakerChatHeader({ onClose }: Props) {
+  return (
+    <header className="flex items-start gap-3 px-4 py-3 border-b border-border bg-parchment">
+      <div className="flex-1 min-w-0">
+        <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+          Conversation with the bishopric
+        </div>
+        <p className="font-serif text-[12.5px] text-walnut-2 mt-0.5">
+          This is a group conversation — the bishop, counselors, and clerks can all see and reply.
+        </p>
+      </div>
+      {onClose && (
+        <button
+          type="button"
+          onClick={onClose}
+          className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
+          aria-label="Close conversation"
+        >
+          Close
+        </button>
+      )}
+    </header>
+  );
+}

--- a/src/features/invitations/SpeakerChatLauncher.tsx
+++ b/src/features/invitations/SpeakerChatLauncher.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
+import type { Speaker } from "@/lib/types";
+import { BishopInvitationDialog } from "./BishopInvitationDialog";
+import { useConversationUnread } from "./useConversationUnread";
+import { useLatestInvitation } from "./useLatestInvitation";
+
+interface Props {
+  wardId: string;
+  date: string;
+  speaker: Speaker;
+  speakerId: string;
+}
+
+/** A speaker-row chat affordance: a small chat icon that opens the
+ *  bishop-side invitation/chat dialog for one speaker, with a dot
+ *  badge when there's something to attend to (unread reply or an
+ *  unacknowledged response). Auto-opens the dialog when a URL hint
+ *  arrives — `?chat=<invitationId>` (push-notification deep links)
+ *  or `?chatSpeaker=<speakerId>` (the assign modal's "open
+ *  conversation" button). Each rendered launcher checks its own
+ *  match independently and clears the matching key from the query. */
+export function SpeakerChatLauncher({ wardId, date, speaker, speakerId }: Props) {
+  const [open, setOpen] = useState(false);
+  const latest = useLatestInvitation(wardId || null, date, speakerId);
+  const invitation = latest.invitation;
+  const response = invitation?.response;
+  const needsApply = Boolean(response && !response.acknowledgedAt);
+  const unreadCount = useConversationUnread(invitation?.conversationSid);
+  const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  useEffect(() => {
+    const chatKey = searchParams.get("chat");
+    const speakerKey = searchParams.get("chatSpeaker");
+    const invitationMatches = invitation && chatKey === invitation.invitationId;
+    const speakerMatches = speakerKey === speakerId;
+    if (!invitationMatches && !speakerMatches) return;
+    setOpen(true);
+    const next = new URLSearchParams(searchParams);
+    if (invitationMatches) next.delete("chat");
+    if (speakerMatches) next.delete("chatSpeaker");
+    setSearchParams(next, { replace: true });
+  }, [invitation, speakerId, searchParams, setSearchParams]);
+
+  return (
+    <>
+      <ChatIconButton
+        badge={needsApply || hasUnread}
+        onClick={() => setOpen(true)}
+        speakerName={speaker.name}
+      />
+      <BishopInvitationDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        wardId={wardId}
+        invitationId={invitation?.invitationId ?? null}
+        invitation={invitation ?? null}
+        speaker={speaker}
+        date={date}
+        speakerId={speakerId}
+      />
+    </>
+  );
+}
+
+interface ChatIconButtonProps {
+  badge: boolean;
+  onClick: () => void;
+  speakerName: string;
+}
+
+function ChatIconButton({ badge, onClick, speakerName }: ChatIconButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`Open conversation with ${speakerName}`}
+      title="Open conversation"
+      className="relative inline-flex items-center justify-center w-8 h-8 rounded-md border border-border-strong bg-chalk text-walnut hover:bg-parchment-2 hover:border-bordeaux transition-colors"
+    >
+      <ChatIcon />
+      {badge && (
+        <span
+          aria-hidden="true"
+          className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-bordeaux border border-chalk"
+        />
+      )}
+    </button>
+  );
+}
+
+function ChatIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+    </svg>
+  );
+}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -28,6 +28,11 @@ interface Props {
     email?: string | undefined;
   }[];
   hasResponse: boolean;
+  /** ISO `YYYY-MM-DD` of the meeting the speaker is assigned to —
+   *  substituted into QuickAction prompts and the response banner so
+   *  copy reads "speak on Sun May 20" instead of the ambiguous
+   *  "this Sunday". */
+  meetingDate: string;
   /** The speaker's own answer. Drives the "You accepted / declined"
    *  banner above the thread so they always see their committed
    *  answer after submission. Null before they reply. */
@@ -146,6 +151,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
 
       <SpeakerResponseBanner
         answer={props.responseAnswer}
+        meetingDate={props.meetingDate}
         {...(props.currentStatus !== undefined ? { currentStatus: props.currentStatus } : {})}
       />
 
@@ -166,6 +172,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
           conversation={conversation}
           ensureReady={ensureReady}
           onSubmit={submitResponse}
+          meetingDate={props.meetingDate}
         />
       )}
 

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -32,6 +32,12 @@ interface Props {
    *  banner above the thread so they always see their committed
    *  answer after submission. Null before they reply. */
   responseAnswer?: "yes" | "no" | null;
+  /** Mirror of the speaker doc's current status, written onto the
+   *  invitation by the bishop's client when they confirm / decline.
+   *  Takes precedence over `responseAnswer` in the banner so a
+   *  speaker who said yes but then asked to bow out (and the bishop
+   *  flipped status to declined) sees the accurate outcome. */
+  currentStatus?: import("@/lib/types").SpeakerStatus | null;
   /** When present, the chat's header renders a small close affordance
    *  that invokes this callback. Used by the invite page's floating
    *  drawer so the speaker can dismiss the chat back over the letter. */
@@ -138,7 +144,10 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
     >
       <SpeakerChatHeader onClose={props.onClose} />
 
-      <SpeakerResponseBanner answer={props.responseAnswer} />
+      <SpeakerResponseBanner
+        answer={props.responseAnswer}
+        {...(props.currentStatus !== undefined ? { currentStatus: props.currentStatus } : {})}
+      />
 
       <ConversationThread
         messages={messages}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -4,6 +4,8 @@ import { inviteAuth } from "@/lib/firebase";
 import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
 import { QuickActionButtons } from "./QuickActionButtons";
+import { SpeakerChatHeader } from "./SpeakerChatHeader";
+import { SpeakerResponseBanner } from "./SpeakerResponseBanner";
 import { TypingIndicator } from "./TypingIndicator";
 import { useConversation } from "./useConversation";
 import { useFirstUnreadIndex } from "./useFirstUnreadIndex";
@@ -26,6 +28,10 @@ interface Props {
     email?: string | undefined;
   }[];
   hasResponse: boolean;
+  /** The speaker's own answer. Drives the "You accepted / declined"
+   *  banner above the thread so they always see their committed
+   *  answer after submission. Null before they reply. */
+  responseAnswer?: "yes" | "no" | null;
   /** When present, the chat's header renders a small close affordance
    *  that invokes this callback. Used by the invite page's floating
    *  drawer so the speaker can dismiss the chat back over the letter. */
@@ -130,26 +136,9 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
           : "bg-chalk border border-border rounded-lg shadow-elev-1 flex flex-col overflow-hidden"
       }
     >
-      <header className="flex items-start gap-3 px-4 py-3 border-b border-border bg-parchment">
-        <div className="flex-1 min-w-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
-            Conversation with the bishopric
-          </div>
-          <p className="font-serif text-[12.5px] text-walnut-2 mt-0.5">
-            This is a group conversation — the bishop, counselors, and clerks can all see and reply.
-          </p>
-        </div>
-        {props.onClose && (
-          <button
-            type="button"
-            onClick={props.onClose}
-            className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
-            aria-label="Close conversation"
-          >
-            Close
-          </button>
-        )}
-      </header>
+      <SpeakerChatHeader onClose={props.onClose} />
+
+      <SpeakerResponseBanner answer={props.responseAnswer} />
 
       <ConversationThread
         messages={messages}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -14,6 +14,7 @@ import { useTypingParticipants } from "./useTypingParticipants";
 import { useSpeakerHeartbeat } from "./useSpeakerHeartbeat";
 import { useTwilioChat } from "./twilioClientProvider";
 import { writeSpeakerResponse } from "./invitationActions";
+import { removeMessage, updateMessageBody } from "./messageMutations";
 import { buildSpeakerAuthorMap } from "./speakerAuthorMap";
 
 interface Props {
@@ -163,6 +164,8 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         firstUnreadIndex={firstUnreadIndex}
         readHorizonIndex={readHorizon}
         {...(props.fillHeight ? { fillHeight: true } : {})}
+        onDeleteMessage={(sid) => removeMessage(conversation, sid)}
+        onEditMessage={(sid, next) => updateMessageBody(conversation, sid, next)}
       />
 
       <TypingIndicator typingIdentities={typing} authors={resolvedAuthors} />

--- a/src/features/invitations/SpeakerResponseBanner.tsx
+++ b/src/features/invitations/SpeakerResponseBanner.tsx
@@ -1,36 +1,88 @@
+import type { SpeakerStatus } from "@/lib/types";
+
 interface Props {
+  /** The speaker's own Yes/No reply (null until they submit). Used as
+   *  the fallback when no bishop-driven transition has landed yet. */
   answer: "yes" | "no" | null | undefined;
+  /** The authoritative current status, mirrored from the speaker doc
+   *  by the bishop's client when they apply a response or change the
+   *  status via the chat-banner pills. When present, this drives the
+   *  banner; when absent we fall back to `answer`. */
+  currentStatus?: SpeakerStatus | null;
 }
 
 /** Speaker-side confirmation banner rendered under the conversation
- *  header once the speaker has submitted their Yes/No reply. Mirrors
- *  the bishop-side status banner (colour + gradient) so the speaker
- *  always sees their committed answer without having to re-read the
- *  quick-action buttons (which hide after submission). */
-export function SpeakerResponseBanner({ answer }: Props): React.ReactElement | null {
+ *  header. Pivots through three layers in priority order:
+ *
+ *    1. Bishop-applied terminal state (`currentStatus`) wins — once
+ *       the bishopric has confirmed or declined, the speaker sees
+ *       the effective outcome even if it differs from their reply.
+ *       This covers the "changed my mind mid-conversation" path
+ *       where the speaker originally said yes but asked to bow out
+ *       in chat, and the bishop flipped status to declined.
+ *    2. Fallback to the speaker's own Yes/No submission. Shown while
+ *       the bishop hasn't acknowledged yet, or for pre-rollout
+ *       invitations that predate the `currentSpeakerStatus` mirror.
+ *    3. Nothing before the speaker has replied (keeps the chat
+ *       header quiet while Quick-Action buttons are visible). */
+export function SpeakerResponseBanner({ answer, currentStatus }: Props): React.ReactElement | null {
+  if (currentStatus === "confirmed") {
+    return (
+      <Banner
+        tone="success"
+        title="Your assignment is confirmed. Thank you!"
+        subtitle="The bishopric will follow up with any remaining details in the chat below."
+      />
+    );
+  }
+  if (currentStatus === "declined") {
+    return (
+      <Banner
+        tone="danger"
+        title="Your assignment has been updated to declined."
+        subtitle="You are no longer scheduled to speak this Sunday. See the chat below for any follow-up."
+      />
+    );
+  }
   if (answer === "yes") {
     return (
-      <div className="px-4 py-3 border-b border-border bg-gradient-to-br from-success-soft to-success-soft/60">
-        <p className="font-sans text-[13.5px] font-semibold text-success leading-snug">
-          You accepted this invitation. Thank you!
-        </p>
-        <p className="font-serif italic text-[12.5px] text-walnut-2 mt-1">
-          The bishopric will follow up with any remaining details in the chat below.
-        </p>
-      </div>
+      <Banner
+        tone="success"
+        title="You accepted this invitation. Thank you!"
+        subtitle="The bishopric will follow up with any remaining details in the chat below."
+      />
     );
   }
   if (answer === "no") {
     return (
-      <div className="px-4 py-3 border-b border-border bg-gradient-to-br from-danger-soft to-danger-soft/60">
-        <p className="font-sans text-[13.5px] font-semibold text-bordeaux leading-snug">
-          You declined this invitation.
-        </p>
-        <p className="font-serif italic text-[12.5px] text-walnut-2 mt-1">
-          The bishopric has been notified and will respond in the chat below if needed.
-        </p>
-      </div>
+      <Banner
+        tone="danger"
+        title="You declined this invitation."
+        subtitle="The bishopric has been notified and will respond in the chat below if needed."
+      />
     );
   }
   return null;
+}
+
+function Banner({
+  tone,
+  title,
+  subtitle,
+}: {
+  tone: "success" | "danger";
+  title: string;
+  subtitle: string;
+}) {
+  const bg =
+    tone === "success"
+      ? "bg-gradient-to-br from-success-soft to-success-soft/60"
+      : "bg-gradient-to-br from-danger-soft to-danger-soft/60";
+  const text = tone === "success" ? "text-success" : "text-bordeaux";
+  return (
+    <div className={`px-4 py-3 border-b border-border ${bg}`}>
+      <p className={`font-sans text-[13.5px] font-semibold leading-snug ${text}`}>{title}</p>
+      <p className="font-serif italic text-[12.5px] text-walnut-2 mt-1">{subtitle}</p>
+    </div>
+  );
 }

--- a/src/features/invitations/SpeakerResponseBanner.tsx
+++ b/src/features/invitations/SpeakerResponseBanner.tsx
@@ -1,3 +1,4 @@
+import { formatShortSunday } from "@/features/schedule/dateFormat";
 import type { SpeakerStatus } from "@/lib/types";
 
 interface Props {
@@ -9,6 +10,10 @@ interface Props {
    *  status via the chat-banner pills. When present, this drives the
    *  banner; when absent we fall back to `answer`. */
   currentStatus?: SpeakerStatus | null;
+  /** ISO `YYYY-MM-DD` of the meeting the speaker is assigned to.
+   *  Substituted into the subtitle copy instead of the ambiguous
+   *  "this Sunday" so the date is unambiguous. */
+  meetingDate: string;
 }
 
 /** Speaker-side confirmation banner rendered under the conversation
@@ -25,12 +30,17 @@ interface Props {
  *       invitations that predate the `currentSpeakerStatus` mirror.
  *    3. Nothing before the speaker has replied (keeps the chat
  *       header quiet while Quick-Action buttons are visible). */
-export function SpeakerResponseBanner({ answer, currentStatus }: Props): React.ReactElement | null {
+export function SpeakerResponseBanner({
+  answer,
+  currentStatus,
+  meetingDate,
+}: Props): React.ReactElement | null {
+  const when = formatShortSunday(meetingDate);
   if (currentStatus === "confirmed") {
     return (
       <Banner
         tone="success"
-        title="Your assignment is confirmed. Thank you!"
+        title={`Your assignment is confirmed for ${when}. Thank you!`}
         subtitle="The bishopric will follow up with any remaining details in the chat below."
       />
     );
@@ -40,7 +50,7 @@ export function SpeakerResponseBanner({ answer, currentStatus }: Props): React.R
       <Banner
         tone="danger"
         title="Your assignment has been updated to declined."
-        subtitle="You are no longer scheduled to speak this Sunday. See the chat below for any follow-up."
+        subtitle={`You are no longer scheduled to speak on ${when}. See the chat below for any follow-up.`}
       />
     );
   }
@@ -48,7 +58,7 @@ export function SpeakerResponseBanner({ answer, currentStatus }: Props): React.R
     return (
       <Banner
         tone="success"
-        title="You accepted this invitation. Thank you!"
+        title={`You accepted the invitation to speak on ${when}. Thank you!`}
         subtitle="The bishopric will follow up with any remaining details in the chat below."
       />
     );
@@ -57,7 +67,7 @@ export function SpeakerResponseBanner({ answer, currentStatus }: Props): React.R
     return (
       <Banner
         tone="danger"
-        title="You declined this invitation."
+        title={`You declined the invitation to speak on ${when}.`}
         subtitle="The bishopric has been notified and will respond in the chat below if needed."
       />
     );

--- a/src/features/invitations/SpeakerResponseBanner.tsx
+++ b/src/features/invitations/SpeakerResponseBanner.tsx
@@ -1,0 +1,36 @@
+interface Props {
+  answer: "yes" | "no" | null | undefined;
+}
+
+/** Speaker-side confirmation banner rendered under the conversation
+ *  header once the speaker has submitted their Yes/No reply. Mirrors
+ *  the bishop-side status banner (colour + gradient) so the speaker
+ *  always sees their committed answer without having to re-read the
+ *  quick-action buttons (which hide after submission). */
+export function SpeakerResponseBanner({ answer }: Props): React.ReactElement | null {
+  if (answer === "yes") {
+    return (
+      <div className="px-4 py-3 border-b border-border bg-gradient-to-br from-success-soft to-success-soft/60">
+        <p className="font-sans text-[13.5px] font-semibold text-success leading-snug">
+          You accepted this invitation. Thank you!
+        </p>
+        <p className="font-serif italic text-[12.5px] text-walnut-2 mt-1">
+          The bishopric will follow up with any remaining details in the chat below.
+        </p>
+      </div>
+    );
+  }
+  if (answer === "no") {
+    return (
+      <div className="px-4 py-3 border-b border-border bg-gradient-to-br from-danger-soft to-danger-soft/60">
+        <p className="font-sans text-[13.5px] font-semibold text-bordeaux leading-snug">
+          You declined this invitation.
+        </p>
+        <p className="font-serif italic text-[12.5px] text-walnut-2 mt-1">
+          The bishopric has been notified and will respond in the chat below if needed.
+        </p>
+      </div>
+    );
+  }
+  return null;
+}

--- a/src/features/invitations/SystemNotice.tsx
+++ b/src/features/invitations/SystemNotice.tsx
@@ -1,0 +1,26 @@
+interface Props {
+  body: string;
+  status: "confirmed" | "declined";
+}
+
+/** Centered one-line system notice for status-change messages,
+ *  mirroring the DayDivider rule-label-rule pattern so it reads as
+ *  a thread event rather than a message. Text + rule colour pivot
+ *  on status: green for confirmed, red for declined. */
+export function SystemNotice({ body, status }: Props) {
+  const textCls = status === "confirmed" ? "text-success" : "text-bordeaux";
+  const ruleCls = status === "confirmed" ? "bg-success/40" : "bg-bordeaux/40";
+  return (
+    <div className="flex items-center gap-2 -my-1" role="status" aria-label={body}>
+      <div aria-hidden="true" className={`flex-1 h-px ${ruleCls}`} />
+      <span
+        aria-hidden="true"
+        className={`font-serif italic text-[12px] ${textCls} truncate`}
+        title={body}
+      >
+        {body}
+      </span>
+      <div aria-hidden="true" className={`flex-1 h-px ${ruleCls}`} />
+    </div>
+  );
+}

--- a/src/features/invitations/conversationHelpers.ts
+++ b/src/features/invitations/conversationHelpers.ts
@@ -11,6 +11,7 @@ export function toChatMessage(m: Message): ChatMessage {
     author: m.author ?? "",
     body: m.body ?? "",
     dateCreated: m.dateCreated ?? null,
+    dateUpdated: m.dateUpdated ?? null,
     attributes,
   };
 }

--- a/src/features/invitations/invitationBannerView.test.ts
+++ b/src/features/invitations/invitationBannerView.test.ts
@@ -61,7 +61,10 @@ describe("deriveBannerView", () => {
   });
 
   it("unacknowledged yes reply surfaces Apply button with Confirm label", () => {
-    const view = deriveBannerView(speakerWith("invited"), invitationWith({ responseAnswer: "yes" }));
+    const view = deriveBannerView(
+      speakerWith("invited"),
+      invitationWith({ responseAnswer: "yes" }),
+    );
     expect(view.message).toMatch(/accepted.*confirm first/);
     expect(view.showApply).toBe(true);
     expect(view.applyLabel).toBe("Confirm");

--- a/src/features/invitations/messageActions.test.ts
+++ b/src/features/invitations/messageActions.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import { buildMessagePermissions, findLastMineIndex } from "./messageActions";
+import type { ChatMessage } from "./useConversation";
+
+function msg(overrides: Partial<ChatMessage> & Pick<ChatMessage, "sid" | "author">): ChatMessage {
+  return {
+    index: 0,
+    body: "",
+    dateCreated: null,
+    dateUpdated: null,
+    attributes: null,
+    ...overrides,
+  };
+}
+
+const BISHOP_A = "uid:bishop-a";
+const BISHOP_B = "uid:bishop-b";
+const SPEAKER = "speaker:abc123";
+
+describe("buildMessagePermissions", () => {
+  it("returns a no-op when currentIdentity is null", () => {
+    const { canDelete, canEdit } = buildMessagePermissions(null, [
+      msg({ sid: "1", author: BISHOP_A }),
+    ]);
+    expect(canDelete(msg({ sid: "1", author: BISHOP_A }))).toBe(false);
+    expect(canEdit(msg({ sid: "1", author: BISHOP_A }))).toBe(false);
+  });
+
+  it("bishop can delete another bishop's message within the last 5 thread messages", () => {
+    const messages = [
+      msg({ sid: "1", author: SPEAKER }),
+      msg({ sid: "2", author: BISHOP_B }),
+      msg({ sid: "3", author: SPEAKER }),
+      msg({ sid: "4", author: BISHOP_B }),
+      msg({ sid: "5", author: BISHOP_A }),
+    ];
+    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    expect(canDelete(messages[3]!)).toBe(true); // bishop_b within window
+    expect(canDelete(messages[4]!)).toBe(true); // bishop_a's own
+  });
+
+  it("bishop cannot delete a speaker's message (cross-side)", () => {
+    const messages = [
+      msg({ sid: "1", author: SPEAKER }),
+      msg({ sid: "2", author: BISHOP_A }),
+    ];
+    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    expect(canDelete(messages[0]!)).toBe(false);
+  });
+
+  it("speaker can only delete their own messages", () => {
+    const messages = [
+      msg({ sid: "1", author: BISHOP_A }),
+      msg({ sid: "2", author: SPEAKER }),
+    ];
+    const { canDelete } = buildMessagePermissions(SPEAKER, messages);
+    expect(canDelete(messages[0]!)).toBe(false);
+    expect(canDelete(messages[1]!)).toBe(true);
+  });
+
+  it("structural messages (status-change, invitation, quick-action) are never deletable", () => {
+    const messages = [
+      msg({
+        sid: "1",
+        author: BISHOP_A,
+        attributes: { kind: "status-change", status: "confirmed" },
+      }),
+      msg({ sid: "2", author: BISHOP_A, attributes: { kind: "invitation" } }),
+      msg({ sid: "3", author: SPEAKER, attributes: { responseType: "yes" } }),
+      msg({ sid: "4", author: BISHOP_A }),
+    ];
+    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    expect(canDelete(messages[0]!)).toBe(false);
+    expect(canDelete(messages[1]!)).toBe(false);
+    expect(canDelete(messages[2]!)).toBe(false);
+    expect(canDelete(messages[3]!)).toBe(true);
+  });
+
+  it("delete window is the last 5 messages of the thread", () => {
+    const messages = Array.from({ length: 10 }, (_, i) =>
+      msg({ sid: `${i + 1}`, author: BISHOP_A }),
+    );
+    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    expect(canDelete(messages[4]!)).toBe(false); // index 4 = 5th from end of 10 → out
+    expect(canDelete(messages[5]!)).toBe(true); // index 5 = within last 5
+    expect(canDelete(messages[9]!)).toBe(true);
+  });
+
+  it("edit is restricted to the author's own last 5 (not the thread's last 5)", () => {
+    // Viewer has sent 7 messages interleaved with 8 from others; only
+    // the viewer's trailing 5 should be editable, even though the
+    // author's earliest two are still within the thread's last 12.
+    const messages: ChatMessage[] = [];
+    for (let i = 0; i < 7; i++) {
+      messages.push(msg({ sid: `mine-${i}`, author: BISHOP_A, index: i * 2 }));
+      messages.push(msg({ sid: `theirs-${i}`, author: BISHOP_B, index: i * 2 + 1 }));
+    }
+    const { canEdit } = buildMessagePermissions(BISHOP_A, messages);
+    // mine-0 and mine-1 are outside the author's last-5 window
+    expect(canEdit(messages[0]!)).toBe(false);
+    expect(canEdit(messages[2]!)).toBe(false);
+    // mine-2..mine-6 are the author's last 5
+    expect(canEdit(messages[4]!)).toBe(true);
+    expect(canEdit(messages[12]!)).toBe(true);
+    // Another bishop's messages are never editable by BISHOP_A
+    expect(canEdit(messages[1]!)).toBe(false);
+  });
+
+  it("structural mine-messages do not consume an edit slot and are not editable", () => {
+    const messages = [
+      msg({
+        sid: "1",
+        author: BISHOP_A,
+        attributes: { kind: "status-change", status: "confirmed" },
+      }),
+      msg({ sid: "2", author: BISHOP_A }),
+    ];
+    const { canEdit } = buildMessagePermissions(BISHOP_A, messages);
+    expect(canEdit(messages[0]!)).toBe(false);
+    expect(canEdit(messages[1]!)).toBe(true);
+  });
+});
+
+describe("findLastMineIndex", () => {
+  it("returns null when currentIdentity is null", () => {
+    expect(findLastMineIndex([msg({ sid: "1", author: BISHOP_A, index: 3 })], null)).toBeNull();
+  });
+
+  it("returns the Twilio index of the latest matching message", () => {
+    const messages = [
+      msg({ sid: "1", author: SPEAKER, index: 0 }),
+      msg({ sid: "2", author: BISHOP_A, index: 1 }),
+      msg({ sid: "3", author: SPEAKER, index: 2 }),
+      msg({ sid: "4", author: BISHOP_A, index: 3 }),
+    ];
+    expect(findLastMineIndex(messages, BISHOP_A)).toBe(3);
+  });
+
+  it("returns null when no messages match", () => {
+    expect(findLastMineIndex([msg({ sid: "1", author: SPEAKER })], BISHOP_A)).toBeNull();
+  });
+});

--- a/src/features/invitations/messageActions.test.ts
+++ b/src/features/invitations/messageActions.test.ts
@@ -1,17 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { buildMessagePermissions, findLastMineIndex } from "./messageActions";
+import {
+  buildMessagePermissions,
+  EDIT_DELETE_WINDOW_MS,
+  findLastMineIndex,
+} from "./messageActions";
 import type { ChatMessage } from "./useConversation";
+
+const NOW = new Date("2026-04-24T12:00:00Z").getTime();
 
 function msg(overrides: Partial<ChatMessage> & Pick<ChatMessage, "sid" | "author">): ChatMessage {
   return {
     index: 0,
     body: "",
-    dateCreated: null,
+    // Default to a fresh message so the 30-min window gate doesn't
+    // accidentally suppress the predicate under test.
+    dateCreated: new Date(NOW),
     dateUpdated: null,
     attributes: null,
     ...overrides,
   };
 }
+
+const buildAt = (
+  identity: string | null,
+  messages: readonly ChatMessage[],
+): ReturnType<typeof buildMessagePermissions> => buildMessagePermissions(identity, messages, NOW);
 
 const BISHOP_A = "uid:bishop-a";
 const BISHOP_B = "uid:bishop-b";
@@ -19,9 +32,7 @@ const SPEAKER = "speaker:abc123";
 
 describe("buildMessagePermissions", () => {
   it("returns a no-op when currentIdentity is null", () => {
-    const { canDelete, canEdit } = buildMessagePermissions(null, [
-      msg({ sid: "1", author: BISHOP_A }),
-    ]);
+    const { canDelete, canEdit } = buildAt(null, [msg({ sid: "1", author: BISHOP_A })]);
     expect(canDelete(msg({ sid: "1", author: BISHOP_A }))).toBe(false);
     expect(canEdit(msg({ sid: "1", author: BISHOP_A }))).toBe(false);
   });
@@ -34,26 +45,20 @@ describe("buildMessagePermissions", () => {
       msg({ sid: "4", author: BISHOP_B }),
       msg({ sid: "5", author: BISHOP_A }),
     ];
-    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    const { canDelete } = buildAt(BISHOP_A, messages);
     expect(canDelete(messages[3]!)).toBe(true); // bishop_b within window
     expect(canDelete(messages[4]!)).toBe(true); // bishop_a's own
   });
 
   it("bishop cannot delete a speaker's message (cross-side)", () => {
-    const messages = [
-      msg({ sid: "1", author: SPEAKER }),
-      msg({ sid: "2", author: BISHOP_A }),
-    ];
-    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    const messages = [msg({ sid: "1", author: SPEAKER }), msg({ sid: "2", author: BISHOP_A })];
+    const { canDelete } = buildAt(BISHOP_A, messages);
     expect(canDelete(messages[0]!)).toBe(false);
   });
 
   it("speaker can only delete their own messages", () => {
-    const messages = [
-      msg({ sid: "1", author: BISHOP_A }),
-      msg({ sid: "2", author: SPEAKER }),
-    ];
-    const { canDelete } = buildMessagePermissions(SPEAKER, messages);
+    const messages = [msg({ sid: "1", author: BISHOP_A }), msg({ sid: "2", author: SPEAKER })];
+    const { canDelete } = buildAt(SPEAKER, messages);
     expect(canDelete(messages[0]!)).toBe(false);
     expect(canDelete(messages[1]!)).toBe(true);
   });
@@ -69,7 +74,7 @@ describe("buildMessagePermissions", () => {
       msg({ sid: "3", author: SPEAKER, attributes: { responseType: "yes" } }),
       msg({ sid: "4", author: BISHOP_A }),
     ];
-    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    const { canDelete } = buildAt(BISHOP_A, messages);
     expect(canDelete(messages[0]!)).toBe(false);
     expect(canDelete(messages[1]!)).toBe(false);
     expect(canDelete(messages[2]!)).toBe(false);
@@ -80,7 +85,7 @@ describe("buildMessagePermissions", () => {
     const messages = Array.from({ length: 10 }, (_, i) =>
       msg({ sid: `${i + 1}`, author: BISHOP_A }),
     );
-    const { canDelete } = buildMessagePermissions(BISHOP_A, messages);
+    const { canDelete } = buildAt(BISHOP_A, messages);
     expect(canDelete(messages[4]!)).toBe(false); // index 4 = 5th from end of 10 → out
     expect(canDelete(messages[5]!)).toBe(true); // index 5 = within last 5
     expect(canDelete(messages[9]!)).toBe(true);
@@ -95,7 +100,7 @@ describe("buildMessagePermissions", () => {
       messages.push(msg({ sid: `mine-${i}`, author: BISHOP_A, index: i * 2 }));
       messages.push(msg({ sid: `theirs-${i}`, author: BISHOP_B, index: i * 2 + 1 }));
     }
-    const { canEdit } = buildMessagePermissions(BISHOP_A, messages);
+    const { canEdit } = buildAt(BISHOP_A, messages);
     // mine-0 and mine-1 are outside the author's last-5 window
     expect(canEdit(messages[0]!)).toBe(false);
     expect(canEdit(messages[2]!)).toBe(false);
@@ -104,6 +109,35 @@ describe("buildMessagePermissions", () => {
     expect(canEdit(messages[12]!)).toBe(true);
     // Another bishop's messages are never editable by BISHOP_A
     expect(canEdit(messages[1]!)).toBe(false);
+  });
+
+  it("a message older than 30 minutes is neither editable nor deletable", () => {
+    const stale = msg({
+      sid: "1",
+      author: BISHOP_A,
+      dateCreated: new Date(NOW - EDIT_DELETE_WINDOW_MS - 1),
+    });
+    const { canDelete, canEdit } = buildAt(BISHOP_A, [stale]);
+    expect(canDelete(stale)).toBe(false);
+    expect(canEdit(stale)).toBe(false);
+  });
+
+  it("a message exactly at the 30-minute boundary is still editable + deletable", () => {
+    const onTheLine = msg({
+      sid: "1",
+      author: BISHOP_A,
+      dateCreated: new Date(NOW - EDIT_DELETE_WINDOW_MS),
+    });
+    const { canDelete, canEdit } = buildAt(BISHOP_A, [onTheLine]);
+    expect(canDelete(onTheLine)).toBe(true);
+    expect(canEdit(onTheLine)).toBe(true);
+  });
+
+  it("a message with no dateCreated falls outside the window", () => {
+    const undated = msg({ sid: "1", author: BISHOP_A, dateCreated: null });
+    const { canDelete, canEdit } = buildAt(BISHOP_A, [undated]);
+    expect(canDelete(undated)).toBe(false);
+    expect(canEdit(undated)).toBe(false);
   });
 
   it("structural mine-messages do not consume an edit slot and are not editable", () => {
@@ -115,7 +149,7 @@ describe("buildMessagePermissions", () => {
       }),
       msg({ sid: "2", author: BISHOP_A }),
     ];
-    const { canEdit } = buildMessagePermissions(BISHOP_A, messages);
+    const { canEdit } = buildAt(BISHOP_A, messages);
     expect(canEdit(messages[0]!)).toBe(false);
     expect(canEdit(messages[1]!)).toBe(true);
   });

--- a/src/features/invitations/messageActions.ts
+++ b/src/features/invitations/messageActions.ts
@@ -1,0 +1,93 @@
+import type { ChatMessage } from "./useConversation";
+
+/** Index of the viewer's latest sent message, or null if they haven't
+ *  spoken yet. Used by the thread to anchor the "Read" receipt under
+ *  the last mine=true bubble. */
+export function findLastMineIndex(
+  messages: readonly ChatMessage[],
+  currentIdentity: string | null,
+): number | null {
+  if (!currentIdentity) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.author === currentIdentity) return messages[i]!.index;
+  }
+  return null;
+}
+
+/** Size of the "recent" window that gates delete + edit affordances.
+ *  Delete uses last-N of the whole thread; edit uses last-N of the
+ *  current user's own messages. */
+export const RECENT_EDITABLE_WINDOW = 5;
+
+export interface Permissions {
+  canDelete: (message: ChatMessage) => boolean;
+  canEdit: (message: ChatMessage) => boolean;
+}
+
+/** Build delete/edit permission predicates for the current viewer.
+ *
+ *  Delete:
+ *   - Speaker identity may delete their own messages.
+ *   - Bishopric identity (uid:<...>) may delete any bishopric message
+ *     — their own + other bishopric members'. Never cross-side.
+ *   - Only within the last `RECENT_EDITABLE_WINDOW` messages in the
+ *     thread (any author). Keeps the history immutable past the
+ *     recency window so accidentally-deep deletes don't rewrite
+ *     older context.
+ *   - Structured quick-action responses (`responseType`) and
+ *     status-change system notices (`kind: "status-change"`) are
+ *     never deletable — the yes/no flow + status audit depend on
+ *     them staying on the record.
+ *
+ *  Edit:
+ *   - Own messages only.
+ *   - Within the author's last `RECENT_EDITABLE_WINDOW` sent
+ *     messages (not the thread's last N).
+ *   - Same structural exclusions as delete.
+ */
+export function buildMessagePermissions(
+  currentIdentity: string | null,
+  messages: readonly ChatMessage[],
+): Permissions {
+  if (!currentIdentity) {
+    return { canDelete: () => false, canEdit: () => false };
+  }
+
+  const deletableSids = new Set<string>();
+  for (const m of messages.slice(-RECENT_EDITABLE_WINDOW)) {
+    if (!isStructural(m)) deletableSids.add(m.sid);
+  }
+
+  const mineRecent: string[] = [];
+  for (let i = messages.length - 1; i >= 0 && mineRecent.length < RECENT_EDITABLE_WINDOW; i--) {
+    const m = messages[i]!;
+    if (m.author !== currentIdentity) continue;
+    if (isStructural(m)) continue;
+    mineRecent.push(m.sid);
+  }
+  const editableSids = new Set(mineRecent);
+
+  const sameSide = (author: string): boolean => {
+    if (currentIdentity.startsWith("uid:")) return author.startsWith("uid:");
+    return author === currentIdentity;
+  };
+
+  return {
+    canDelete(m: ChatMessage): boolean {
+      if (!deletableSids.has(m.sid)) return false;
+      return sameSide(m.author);
+    },
+    canEdit(m: ChatMessage): boolean {
+      if (!editableSids.has(m.sid)) return false;
+      return m.author === currentIdentity;
+    },
+  };
+}
+
+function isStructural(m: ChatMessage): boolean {
+  if (!m.attributes) return false;
+  if (m.attributes.kind === "status-change") return true;
+  if (m.attributes.kind === "invitation") return true;
+  if (m.attributes.responseType === "yes" || m.attributes.responseType === "no") return true;
+  return false;
+}

--- a/src/features/invitations/messageActions.ts
+++ b/src/features/invitations/messageActions.ts
@@ -19,6 +19,12 @@ export function findLastMineIndex(
  *  current user's own messages. */
 export const RECENT_EDITABLE_WINDOW = 5;
 
+/** After this many milliseconds from creation, edit + delete become
+ *  unavailable on a message. Matches the "can retract" window most
+ *  messengers use — long enough to fix a typo, short enough that
+ *  older context stays stable for everyone else reading the thread. */
+export const EDIT_DELETE_WINDOW_MS = 30 * 60 * 1000;
+
 export interface Permissions {
   canDelete: (message: ChatMessage) => boolean;
   canEdit: (message: ChatMessage) => boolean;
@@ -44,10 +50,16 @@ export interface Permissions {
  *   - Within the author's last `RECENT_EDITABLE_WINDOW` sent
  *     messages (not the thread's last N).
  *   - Same structural exclusions as delete.
+ *
+ *  Both predicates additionally require the message to be within
+ *  `EDIT_DELETE_WINDOW_MS` of `dateCreated` — older messages return
+ *  false even if they're in-window by count, so the affordance
+ *  disappears once the message has settled.
  */
 export function buildMessagePermissions(
   currentIdentity: string | null,
   messages: readonly ChatMessage[],
+  nowMs: number = Date.now(),
 ): Permissions {
   if (!currentIdentity) {
     return { canDelete: () => false, canEdit: () => false };
@@ -72,13 +84,20 @@ export function buildMessagePermissions(
     return author === currentIdentity;
   };
 
+  const isWithinWindow = (m: ChatMessage): boolean => {
+    if (!m.dateCreated) return false;
+    return nowMs - m.dateCreated.getTime() <= EDIT_DELETE_WINDOW_MS;
+  };
+
   return {
     canDelete(m: ChatMessage): boolean {
       if (!deletableSids.has(m.sid)) return false;
+      if (!isWithinWindow(m)) return false;
       return sameSide(m.author);
     },
     canEdit(m: ChatMessage): boolean {
       if (!editableSids.has(m.sid)) return false;
+      if (!isWithinWindow(m)) return false;
       return m.author === currentIdentity;
     },
   };

--- a/src/features/invitations/messageMutations.ts
+++ b/src/features/invitations/messageMutations.ts
@@ -1,0 +1,35 @@
+import type { Conversation, Message } from "@twilio/conversations";
+
+/** Look up a Twilio Message by sid. Pulls the most recent 1000
+ *  messages — the edit/delete affordances are gated to the last five
+ *  so the sid is always in-window. */
+async function findMessage(conversation: Conversation, sid: string): Promise<Message> {
+  const page = await conversation.getMessages(1000);
+  const found = page.items.find((m) => m.sid === sid);
+  if (!found) throw new Error("Message not found.");
+  return found;
+}
+
+/** Hard-delete a single message. Twilio fires `messageRemoved` on
+ *  the conversation, which `useConversation` listens for — the
+ *  bubble disappears from every live subscriber without extra
+ *  plumbing. */
+export async function removeMessage(conversation: Conversation | null, sid: string): Promise<void> {
+  if (!conversation) throw new Error("Conversation not connected.");
+  const message = await findMessage(conversation, sid);
+  await message.remove();
+}
+
+/** Update a message body in place. `messageUpdated` fires on the
+ *  conversation and `useConversation` replaces the existing
+ *  `ChatMessage`. `dateUpdated` moves past `dateCreated`, which the
+ *  bubble uses to render the "Edited" indicator. */
+export async function updateMessageBody(
+  conversation: Conversation | null,
+  sid: string,
+  nextBody: string,
+): Promise<void> {
+  if (!conversation) throw new Error("Conversation not connected.");
+  const message = await findMessage(conversation, sid);
+  await message.updateBody(nextBody);
+}

--- a/src/features/invitations/statusChangeNotice.ts
+++ b/src/features/invitations/statusChangeNotice.ts
@@ -1,0 +1,45 @@
+import type { Conversation } from "@twilio/conversations";
+import { doc, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { SpeakerStatus } from "@/lib/types";
+
+/** Wording for the neutral status-change chat messages. Kept free of
+ *  "the bishopric" framing so the line reads as a calm record update
+ *  rather than a rebuke — the message author bubble already carries
+ *  the specific bishop's name via the existing uid:<uid> identity. */
+const BODY_BY_STATUS: Partial<Record<SpeakerStatus, string>> = {
+  confirmed: "Your assignment is confirmed — thank you for speaking this Sunday.",
+  declined: "Your assignment has been updated to declined. Thank you for letting us know.",
+};
+
+/** After an authoritative bishop-driven status transition
+ *  (invited/planned → confirmed or declined), mirror the new value
+ *  onto the invitation doc and — if the Twilio Conversation is
+ *  already online for this session — post a plain-English status
+ *  line into the thread. The speaker page's response banner reads
+ *  `invitation.currentSpeakerStatus` to switch its wording (green
+ *  "confirmed" / neutral "updated to declined") even if the speaker
+ *  originally replied the opposite. */
+export async function noteBishopStatusChange(args: {
+  wardId: string;
+  invitationId: string;
+  status: SpeakerStatus;
+  conversation: Conversation | null;
+}): Promise<void> {
+  const { wardId, invitationId, status, conversation } = args;
+  await updateDoc(doc(db, "wards", wardId, "speakerInvitations", invitationId), {
+    currentSpeakerStatus: status,
+  }).catch((err) => {
+    // Non-fatal — the speaker page falls back to the response-based
+    // banner when the field is missing. Log and keep going so the
+    // chat message still posts.
+    console.warn("[steward] currentSpeakerStatus mirror failed", err);
+  });
+  const body = BODY_BY_STATUS[status];
+  if (!body || !conversation) return;
+  try {
+    await conversation.sendMessage(body);
+  } catch (err) {
+    console.warn("[steward] status-change chat message failed", err);
+  }
+}

--- a/src/features/invitations/statusChangeNotice.ts
+++ b/src/features/invitations/statusChangeNotice.ts
@@ -3,14 +3,22 @@ import { doc, updateDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import type { SpeakerStatus } from "@/lib/types";
 
-/** Wording for the neutral status-change chat messages. Kept free of
+/** Wording for the neutral status-change messages. Kept free of
  *  "the bishopric" framing so the line reads as a calm record update
- *  rather than a rebuke — the message author bubble already carries
- *  the specific bishop's name via the existing uid:<uid> identity. */
+ *  rather than a rebuke — the message is rendered as a centered
+ *  system notice in the thread, not attributed to any participant. */
 const BODY_BY_STATUS: Partial<Record<SpeakerStatus, string>> = {
-  confirmed: "Your assignment is confirmed — thank you for speaking this Sunday.",
-  declined: "Your assignment has been updated to declined. Thank you for letting us know.",
+  confirmed: "Assignment confirmed — thank you for speaking this Sunday.",
+  declined: "Assignment updated to declined. Thank you for letting us know.",
 };
+
+/** Marker on the Twilio Message's attributes subtree. The thread
+ *  renderer keys off this and drops the message out of the normal
+ *  grouped-bubble flow, rendering it as a muted system line instead. */
+export interface StatusChangeAttributes {
+  kind: "status-change";
+  status: Exclude<SpeakerStatus, "planned" | "invited">;
+}
 
 /** After an authoritative bishop-driven status transition
  *  (invited/planned → confirmed or declined), mirror the new value
@@ -37,8 +45,10 @@ export async function noteBishopStatusChange(args: {
   });
   const body = BODY_BY_STATUS[status];
   if (!body || !conversation) return;
+  if (status !== "confirmed" && status !== "declined") return;
+  const attributes: StatusChangeAttributes = { kind: "status-change", status };
   try {
-    await conversation.sendMessage(body);
+    await conversation.sendMessage(body, attributes);
   } catch (err) {
     console.warn("[steward] status-change chat message failed", err);
   }

--- a/src/features/invitations/statusChangeNotice.ts
+++ b/src/features/invitations/statusChangeNotice.ts
@@ -1,16 +1,21 @@
 import type { Conversation } from "@twilio/conversations";
 import { doc, updateDoc } from "firebase/firestore";
+import { formatShortSunday } from "@/features/schedule/dateFormat";
 import { db } from "@/lib/firebase";
 import type { SpeakerStatus } from "@/lib/types";
 
 /** Wording for the neutral status-change messages. Kept free of
  *  "the bishopric" framing so the line reads as a calm record update
  *  rather than a rebuke — the message is rendered as a centered
- *  system notice in the thread, not attributed to any participant. */
-const BODY_BY_STATUS: Partial<Record<SpeakerStatus, string>> = {
-  confirmed: "Assignment confirmed — thank you for speaking this Sunday.",
-  declined: "Assignment updated to declined. Thank you for letting us know.",
-};
+ *  system notice in the thread, not attributed to any participant.
+ *  The meeting date is substituted in place of the ambiguous "this
+ *  Sunday" so the line is unambiguous for a speaker scrolling back
+ *  through an older thread. */
+function bodyFor(status: "confirmed" | "declined", meetingDateIso: string): string {
+  const when = formatShortSunday(meetingDateIso);
+  if (status === "confirmed") return `Assignment confirmed — thank you for speaking on ${when}.`;
+  return `Assignment updated to declined. Thank you for letting us know.`;
+}
 
 /** Marker on the Twilio Message's attributes subtree. The thread
  *  renderer keys off this and drops the message out of the normal
@@ -31,10 +36,15 @@ export interface StatusChangeAttributes {
 export async function noteBishopStatusChange(args: {
   wardId: string;
   invitationId: string;
+  /** ISO `YYYY-MM-DD` of the meeting the speaker is assigned to —
+   *  substituted into the system-notice body so the message reads
+   *  "speaking on Sun May 20" instead of the ambiguous "this
+   *  Sunday". */
+  meetingDate: string;
   status: SpeakerStatus;
   conversation: Conversation | null;
 }): Promise<void> {
-  const { wardId, invitationId, status, conversation } = args;
+  const { wardId, invitationId, meetingDate, status, conversation } = args;
   await updateDoc(doc(db, "wards", wardId, "speakerInvitations", invitationId), {
     currentSpeakerStatus: status,
   }).catch((err) => {
@@ -43,9 +53,9 @@ export async function noteBishopStatusChange(args: {
     // chat message still posts.
     console.warn("[steward] currentSpeakerStatus mirror failed", err);
   });
-  const body = BODY_BY_STATUS[status];
-  if (!body || !conversation) return;
   if (status !== "confirmed" && status !== "declined") return;
+  if (!conversation) return;
+  const body = bodyFor(status, meetingDate);
   const attributes: StatusChangeAttributes = { kind: "status-change", status };
   try {
     await conversation.sendMessage(body, attributes);

--- a/src/features/invitations/statusStripBg.ts
+++ b/src/features/invitations/statusStripBg.ts
@@ -1,0 +1,20 @@
+import type { SpeakerStatus } from "@/lib/types";
+
+/** Tailwind gradient classes for the status-switcher strip background.
+ *  Used by both InvitationStatusBanner (when a chat invitation exists)
+ *  and NoInvitationPlaceholder (when one doesn't), so the top of the
+ *  chat dialog carries the same tinted shell regardless of which
+ *  surface renders. Keeps colour shifts consistent as a speaker moves
+ *  through the status lifecycle. */
+export function statusStripBg(status: SpeakerStatus): string {
+  switch (status) {
+    case "confirmed":
+      return "bg-gradient-to-br from-success-soft to-success-soft/55";
+    case "declined":
+      return "bg-gradient-to-br from-danger-soft to-danger-soft/55";
+    case "invited":
+      return "bg-gradient-to-br from-brass-soft/70 to-brass-soft/30";
+    case "planned":
+      return "bg-gradient-to-br from-parchment-2 to-parchment";
+  }
+}

--- a/src/features/invitations/threadItems.ts
+++ b/src/features/invitations/threadItems.ts
@@ -11,7 +11,7 @@ export interface MessageGroup {
 export type ThreadItem =
   | { kind: "day"; key: string; label: string }
   | { kind: "unread"; key: string }
-  | { kind: "system"; key: string; body: string }
+  | { kind: "system"; key: string; body: string; status: "confirmed" | "declined" }
   | { kind: "group"; key: string; group: MessageGroup };
 
 export interface BuildOpts {
@@ -49,9 +49,12 @@ export function buildThreadItems(opts: BuildOpts): ThreadItem[] {
     // no author bubble, no grouping. Posted by the bishop's client
     // under their uid but displayed as a neutral system event.
     if (m.attributes && m.attributes.kind === "status-change") {
-      pushGroup();
-      items.push({ kind: "system", key: m.sid, body: m.body });
-      continue;
+      const status = m.attributes.status;
+      if (status === "confirmed" || status === "declined") {
+        pushGroup();
+        items.push({ kind: "system", key: m.sid, body: m.body, status });
+        continue;
+      }
     }
     const mine = m.author === currentIdentity;
     if (

--- a/src/features/invitations/threadItems.ts
+++ b/src/features/invitations/threadItems.ts
@@ -11,6 +11,7 @@ export interface MessageGroup {
 export type ThreadItem =
   | { kind: "day"; key: string; label: string }
   | { kind: "unread"; key: string }
+  | { kind: "system"; key: string; body: string }
   | { kind: "group"; key: string; group: MessageGroup };
 
 export interface BuildOpts {
@@ -43,6 +44,14 @@ export function buildThreadItems(opts: BuildOpts): ThreadItem[] {
       pushGroup();
       items.push({ kind: "day", key: `day-${day}`, label: dayLabel(m.dateCreated, now) });
       lastDay = day;
+    }
+    // Status-change messages render as a centered system notice —
+    // no author bubble, no grouping. Posted by the bishop's client
+    // under their uid but displayed as a neutral system event.
+    if (m.attributes && m.attributes.kind === "status-change") {
+      pushGroup();
+      items.push({ kind: "system", key: m.sid, body: m.body });
+      continue;
     }
     const mine = m.author === currentIdentity;
     if (

--- a/src/features/invitations/useConversation.ts
+++ b/src/features/invitations/useConversation.ts
@@ -9,6 +9,10 @@ export interface ChatMessage {
   author: string;
   body: string;
   dateCreated: Date | null;
+  /** Set only when the message has been edited after creation. The
+   *  bubble renders a small "Edited" tag when this is strictly later
+   *  than `dateCreated`. */
+  dateUpdated: Date | null;
   /** Parsed attributes — `{ responseType: 'yes' | 'no', reason? }`
    *  for the structured quick-action messages, `{ kind: 'invitation' }`
    *  for the initial letter, else null. */
@@ -54,6 +58,19 @@ export function useConversation(conversationSid: string | null): ConversationHoo
     const onMessageAdded = (m: Message) => {
       setState((s) => ({ ...s, messages: [...s.messages, toChatMessage(m)] }));
     };
+    const onMessageUpdated = (args: { message: Message }) => {
+      const next = toChatMessage(args.message);
+      setState((s) => ({
+        ...s,
+        messages: s.messages.map((existing) => (existing.sid === next.sid ? next : existing)),
+      }));
+    };
+    const onMessageRemoved = (m: Message) => {
+      setState((s) => ({
+        ...s,
+        messages: s.messages.filter((existing) => existing.sid !== m.sid),
+      }));
+    };
     const onParticipantUpdate = (p: Participant) => {
       setState((s) => {
         if (!p.identity) return s;
@@ -89,6 +106,8 @@ export function useConversation(conversationSid: string | null): ConversationHoo
           error: null,
         });
         convo.on("messageAdded", onMessageAdded);
+        convo.on("messageUpdated", onMessageUpdated);
+        convo.on("messageRemoved", onMessageRemoved);
         convo.on("participantJoined", onParticipantUpdate);
         convo.on("participantUpdated", onParticipantUpdatedEvent);
       } catch (err) {
@@ -110,6 +129,8 @@ export function useConversation(conversationSid: string | null): ConversationHoo
       cancelled = true;
       if (convo) {
         convo.off("messageAdded", onMessageAdded);
+        convo.off("messageUpdated", onMessageUpdated);
+        convo.off("messageRemoved", onMessageRemoved);
         convo.off("participantJoined", onParticipantUpdate);
         convo.off("participantUpdated", onParticipantUpdatedEvent);
       }

--- a/src/features/invitations/useSpeakerHeartbeat.ts
+++ b/src/features/invitations/useSpeakerHeartbeat.ts
@@ -1,14 +1,25 @@
 import { useEffect } from "react";
-import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { doc, serverTimestamp, Timestamp, updateDoc } from "firebase/firestore";
 import { inviteDb } from "@/lib/firebase";
 
 const HEARTBEAT_INTERVAL_MS = 60_000;
+/** When the speaker hides / closes the tab we stamp
+ *  `speakerLastSeenAt` this far into the past so the bishop-side
+ *  banner's "viewing now" bucket (< 2 min) immediately falls over
+ *  into "N min ago". Without this, the badge would linger for up to
+ *  ~2 minutes after the speaker actually left. */
+const STALE_OFFSET_MS = 3 * 60_000;
 
 /** Speaker-side presence heartbeat. Writes `speakerLastSeenAt` on the
  *  invitation doc every 60s while the tab is visible, and on every
  *  visibilitychange → visible transition. The bishop-reply webhook
  *  reads this to skip the SMS-with-resume-link when the speaker is
  *  looking at the chat live.
+ *
+ *  On `pagehide` or `visibilitychange → hidden` we proactively
+ *  backdate the heartbeat by 3 minutes — that way the bishop's
+ *  "viewing now" badge clears within a refresh cycle, not at the end
+ *  of the natural 2-min expiry window.
  *
  *  Errors are swallowed: if the heartbeat write fails the speaker
  *  falls back to being treated as offline, which is the safe default
@@ -28,17 +39,24 @@ export function useSpeakerHeartbeat({
     const ping = () => {
       void updateDoc(ref, { speakerLastSeenAt: serverTimestamp() }).catch(() => {});
     };
+    const markOffline = () => {
+      const staleAt = Timestamp.fromMillis(Date.now() - STALE_OFFSET_MS);
+      void updateDoc(ref, { speakerLastSeenAt: staleAt }).catch(() => {});
+    };
     ping();
     const interval = window.setInterval(() => {
       if (document.visibilityState === "visible") ping();
     }, HEARTBEAT_INTERVAL_MS);
     const onVisibility = () => {
-      if (document.visibilityState === "visible") ping();
+      if (document.visibilityState === "hidden") markOffline();
+      else if (document.visibilityState === "visible") ping();
     };
     document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("pagehide", markOffline);
     return () => {
       window.clearInterval(interval);
       document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("pagehide", markOffline);
     };
   }, [wardId, invitationId, enabled]);
 }

--- a/src/features/meetings/WeekEditor.tsx
+++ b/src/features/meetings/WeekEditor.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { OverflowMenu } from "@/components/ui/OverflowMenu";
+import { TwilioAutoConnect } from "@/features/invitations/TwilioAutoConnect";
+import { TwilioChatProvider } from "@/features/invitations/twilioClientProvider";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
@@ -74,84 +76,87 @@ export function WeekEditor({ date }: Props) {
   ];
 
   return (
-    <main className="pb-30">
-      <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_380px]">
-        <div>
-          <ProgramHead date={date} type={type} rightSlot={<OverflowMenu items={menuItems} />} />
+    <TwilioChatProvider>
+      <TwilioAutoConnect wardId={wardId} />
+      <main className="pb-30">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_380px]">
+          <div>
+            <ProgramHead date={date} type={type} rightSlot={<OverflowMenu items={menuItems} />} />
 
-          <CancellationBanner wardId={wardId} date={date} cancellation={cancellation} />
-          <CancelDialog
-            open={confirmingCancel}
-            onClose={() => setConfirmingCancel(false)}
-            onConfirm={async (reason) => {
-              if (!authUid) return;
-              await cancelMeeting(wardId, date, reason, authUid, nonMeeting);
-            }}
-          />
+            <CancellationBanner wardId={wardId} date={date} cancellation={cancellation} />
+            <CancelDialog
+              open={confirmingCancel}
+              onClose={() => setConfirmingCancel(false)}
+              onConfirm={async (reason) => {
+                if (!authUid) return;
+                await cancelMeeting(wardId, date, reason, authUid, nonMeeting);
+              }}
+            />
 
-          {isNonMeeting ? (
-            <div className="rounded-xl border border-border bg-parchment-2 p-5 text-sm text-walnut-2">
-              No sacrament meeting is held on {TYPE_LABELS[type].toLowerCase()} Sundays.
-            </div>
-          ) : (
-            <>
-              <ProgramApproval
-                date={date}
-                report={report}
-                status={currentStatus}
-                approvals={meeting.data?.approvals ?? []}
-                requiredApprovals={meeting.data?.requiredApprovals}
-                onRequestApproval={approval.requestApproval}
-                onApprove={approval.approve}
-                canApprove={approval.canApprove}
-                alreadyApproved={approval.alreadyApproved}
-                error={approval.error}
-                busy={approval.busy}
-                memberReady={approval.memberReady}
-              />
-              {isLocked && (
-                <LockBanner status={currentStatus} onUnlock={approval.openResetDialog} />
-              )}
-              <div className="flex justify-center mb-4 lg:hidden">
-                <StatusLegend />
+            {isNonMeeting ? (
+              <div className="rounded-xl border border-border bg-parchment-2 p-5 text-sm text-walnut-2">
+                No sacrament meeting is held on {TYPE_LABELS[type].toLowerCase()} Sundays.
               </div>
-              <div
-                className={isLocked ? "pointer-events-none opacity-60 select-none" : ""}
-                aria-disabled={isLocked}
-              >
-                <ProgramSections
-                  wardId={wardId}
+            ) : (
+              <>
+                <ProgramApproval
                   date={date}
-                  meeting={meeting.data}
-                  type={type}
-                  speakers={speakers.data}
-                  nonMeetingSundays={nonMeeting}
+                  report={report}
+                  status={currentStatus}
+                  approvals={meeting.data?.approvals ?? []}
+                  requiredApprovals={meeting.data?.requiredApprovals}
+                  onRequestApproval={approval.requestApproval}
+                  onApprove={approval.approve}
+                  canApprove={approval.canApprove}
+                  alreadyApproved={approval.alreadyApproved}
+                  error={approval.error}
+                  busy={approval.busy}
+                  memberReady={approval.memberReady}
                 />
-              </div>
-              <ResetToDraftDialog
-                open={approval.resetDialogOpen}
-                status={currentStatus}
-                liveApprovals={liveApprovals}
-                onClose={approval.closeResetDialog}
-                onConfirm={approval.resetToDraft}
-              />
-            </>
-          )}
+                {isLocked && (
+                  <LockBanner status={currentStatus} onUnlock={approval.openResetDialog} />
+                )}
+                <div className="flex justify-center mb-4 lg:hidden">
+                  <StatusLegend />
+                </div>
+                <div
+                  className={isLocked ? "pointer-events-none opacity-60 select-none" : ""}
+                  aria-disabled={isLocked}
+                >
+                  <ProgramSections
+                    wardId={wardId}
+                    date={date}
+                    meeting={meeting.data}
+                    type={type}
+                    speakers={speakers.data}
+                    nonMeetingSundays={nonMeeting}
+                  />
+                </div>
+                <ResetToDraftDialog
+                  open={approval.resetDialogOpen}
+                  status={currentStatus}
+                  liveApprovals={liveApprovals}
+                  onClose={approval.closeResetDialog}
+                  onConfirm={approval.resetToDraft}
+                />
+              </>
+            )}
+          </div>
+
+          {!isNonMeeting && <ProgramSide wardId={wardId} date={date} rail={rail} />}
         </div>
 
-        {!isNonMeeting && <ProgramSide wardId={wardId} date={date} rail={rail} />}
-      </div>
-
-      {!isNonMeeting && (
-        <ProgramSaveBar
-          status={currentStatus}
-          ready={report.ready}
-          remaining={report.missing.length + report.unconfirmed.length}
-          busy={approval.busy}
-          onRequestApproval={approval.requestApproval}
-        />
-      )}
-      <HistoryModal date={date} open={historyOpen} onClose={() => setHistoryOpen(false)} />
-    </main>
+        {!isNonMeeting && (
+          <ProgramSaveBar
+            status={currentStatus}
+            ready={report.ready}
+            remaining={report.missing.length + report.unconfirmed.length}
+            busy={approval.busy}
+            onRequestApproval={approval.requestApproval}
+          />
+        )}
+        <HistoryModal date={date} open={historyOpen} onClose={() => setHistoryOpen(false)} />
+      </main>
+    </TwilioChatProvider>
   );
 }

--- a/src/features/meetings/sections/SpeakerListRow.tsx
+++ b/src/features/meetings/sections/SpeakerListRow.tsx
@@ -1,3 +1,4 @@
+import { SpeakerChatLauncher } from "@/features/invitations/SpeakerChatLauncher";
 import type { WithId } from "@/hooks/_sub";
 import type { Speaker } from "@/lib/types";
 import { cn } from "@/lib/cn";
@@ -45,9 +46,22 @@ interface SpeakerRowProps extends DragHandlers {
   speaker: WithId<Speaker>;
   index: number;
   isLast: boolean;
+  /** Threaded so each row can host a `SpeakerChatLauncher` — clicking
+   *  the chat icon opens the bishopric/speaker conversation for that
+   *  individual speaker, mirroring the affordance on the schedule
+   *  view. */
+  wardId: string;
+  date: string;
 }
 
-export function SpeakerListRow({ speaker: s, index, isLast, ...drag }: SpeakerRowProps) {
+export function SpeakerListRow({
+  speaker: s,
+  index,
+  isLast,
+  wardId,
+  date,
+  ...drag
+}: SpeakerRowProps) {
   return (
     <li
       {...useDragProps(drag)}
@@ -72,6 +86,7 @@ export function SpeakerListRow({ speaker: s, index, isLast, ...drag }: SpeakerRo
       </div>
       <div className="flex items-center gap-2.5">
         <StatusPill status={s.data.status} />
+        <SpeakerChatLauncher wardId={wardId} date={date} speaker={s.data} speakerId={s.id} />
         <Grip />
       </div>
     </li>

--- a/src/features/meetings/sections/SpeakersSection.tsx
+++ b/src/features/meetings/sections/SpeakersSection.tsx
@@ -1,10 +1,7 @@
-import { useMemo, useRef, useState } from "react";
+import { useMemo, useState } from "react";
 import type { WithId } from "@/hooks/_sub";
 import type { MidItem as MidItemType, NonMeetingSunday, Speaker } from "@/lib/types";
 import { reorderSpeakers } from "@/features/speakers/speakerActions";
-import { AssignDialog } from "@/features/schedule/AssignDialog";
-import { SpeakerEditList, type SpeakerEditListHandle } from "@/features/schedule/SpeakerEditList";
-import { formatShortDate } from "@/features/schedule/dateFormat";
 import { ProgramSection } from "../program/ProgramSection";
 import { updateMeetingField } from "../updateMeeting";
 import { MidPlaceholderRow, SpeakerListRow } from "./SpeakerListRow";
@@ -24,9 +21,6 @@ export function SpeakersSection({ wardId, date, speakers, mid, nonMeetingSundays
   const items = useMemo(() => buildItems(ordered, mid, midLabel), [ordered, mid, midLabel]);
   const [dragIdx, setDragIdx] = useState<number | null>(null);
   const [overIdx, setOverIdx] = useState<number | null>(null);
-  const [manageOpen, setManageOpen] = useState(false);
-  const [saving, setSaving] = useState(false);
-  const editListRef = useRef<SpeakerEditListHandle>(null);
 
   function persist(nextItems: Item[]) {
     const speakerIds = nextItems.filter((x) => x.kind === "speaker").map((x) => x.id);
@@ -53,51 +47,12 @@ export function SpeakersSection({ wardId, date, speakers, mid, nonMeetingSundays
     setOverIdx(null);
   }
 
-  async function handleManageSave() {
-    if (!editListRef.current) return;
-    setSaving(true);
-    try {
-      await editListRef.current.save();
-      setManageOpen(false);
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  const manageButton = (
-    <button
-      type="button"
-      onClick={() => setManageOpen(true)}
-      className="ml-auto font-sans text-[12.5px] font-semibold text-bordeaux hover:text-bordeaux-deep hover:underline hover:underline-offset-2 transition-colors"
-    >
-      Manage speakers →
-    </button>
-  );
-
-  const dialog = (
-    <AssignDialog
-      open={manageOpen}
-      title={formatShortDate(date)}
-      saving={saving}
-      onClose={() => setManageOpen(false)}
-      onSave={() => void handleManageSave()}
-    >
-      <SpeakerEditList
-        ref={editListRef}
-        date={date}
-        wardId={wardId}
-        nonMeetingSundays={nonMeetingSundays}
-      />
-    </AssignDialog>
-  );
-
   if (items.length === 0) {
     return (
-      <ProgramSection id="sec-speakers" label="Speakers" rightSlot={manageButton}>
+      <ProgramSection id="sec-speakers" label="Speakers">
         <p className="font-serif italic text-[13.5px] text-walnut-3 py-1">
-          No speakers yet. Use <em>Manage speakers</em> to add them.
+          No speakers yet. Add them from the schedule view.
         </p>
-        {dialog}
       </ProgramSection>
     );
   }
@@ -109,9 +64,8 @@ export function SpeakersSection({ wardId, date, speakers, mid, nonMeetingSundays
       label="Speakers"
       count={ordered.length}
       rightSlot={
-        <span className="ml-auto inline-flex gap-3 items-center">
-          <span className="font-serif italic text-[12.5px] text-walnut-3">Drag to reorder</span>
-          {manageButton}
+        <span className="ml-auto font-serif italic text-[12.5px] text-walnut-3">
+          Drag to reorder
         </span>
       }
     >
@@ -138,12 +92,13 @@ export function SpeakersSection({ wardId, date, speakers, mid, nonMeetingSundays
               speaker={item.speaker}
               index={speakerCounter++}
               isLast={isLast}
+              wardId={wardId}
+              date={date}
               {...drag}
             />
           );
         })}
       </ul>
-      {dialog}
     </ProgramSection>
   );
 }

--- a/src/features/schedule/AssignDialog.tsx
+++ b/src/features/schedule/AssignDialog.tsx
@@ -4,6 +4,10 @@ import { cn } from "@/lib/cn";
 interface Props {
   open: boolean;
   title: string;
+  /** Optional caption that appears beside the date in the header
+   *  — used for the "X of N speakers haven't been invited yet"
+   *  status line. Wraps under the title on narrow screens. */
+  subtitle?: React.ReactNode;
   onClose: () => void;
   /** Pinned bottom band rendered as-is. When omitted, the dialog has
    *  no footer — step bodies that own their own terminal actions can
@@ -12,7 +16,7 @@ interface Props {
   children?: React.ReactNode;
 }
 
-export function AssignDialog({ open, title, onClose, footerSlot, children }: Props) {
+export function AssignDialog({ open, title, subtitle, onClose, footerSlot, children }: Props) {
   const dialogRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -58,8 +62,13 @@ export function AssignDialog({ open, title, onClose, footerSlot, children }: Pro
             <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
               Assign speakers
             </div>
-            <div className="font-display text-2xl font-semibold text-walnut tracking-[-0.01em] leading-tight mt-0.5">
-              {title}
+            <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 mt-0.5">
+              <span className="font-display text-2xl font-semibold text-walnut tracking-[-0.01em] leading-tight">
+                {title}
+              </span>
+              {subtitle && (
+                <span className="font-serif italic text-[13px] text-walnut-3">{subtitle}</span>
+              )}
             </div>
           </div>
           <button

--- a/src/features/schedule/AssignDialogFooters.tsx
+++ b/src/features/schedule/AssignDialogFooters.tsx
@@ -24,7 +24,7 @@ export function EditFooter({
         disabled={saving}
         className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
       >
-        {saving ? "Saving…" : "Start preparing invitations"}
+        {saving ? "Saving…" : "Continue →"}
       </button>
     </>
   );

--- a/src/features/schedule/AssignDialogFooters.tsx
+++ b/src/features/schedule/AssignDialogFooters.tsx
@@ -24,7 +24,7 @@ export function EditFooter({
         disabled={saving}
         className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
       >
-        {saving ? "Saving…" : "Save"}
+        {saving ? "Saving…" : "Start preparing invitations"}
       </button>
     </>
   );

--- a/src/features/schedule/SpeakerCardHeader.tsx
+++ b/src/features/schedule/SpeakerCardHeader.tsx
@@ -1,30 +1,57 @@
+import type { SpeakerStatus } from "@/lib/types";
+import { cn } from "@/lib/cn";
 import { RemoveIcon } from "./SpeakerInviteIcons";
 
 interface Props {
   index: number;
+  status: SpeakerStatus;
   /** Null hides the remove button — used by the step-2 locked card,
    *  where editing (including removal) is deferred to step 1. */
   onRemove: (() => void) | null;
 }
 
-/** The top row of a SpeakerEditCard: "Speaker · 01" label and the
+/** The top row of a SpeakerEditCard: "Speaker · 01" eyebrow, the
+ *  current status pill (always visible so a bishop scanning the
+ *  card grid can see who's still pending an invitation), and the
  *  remove button. */
-export function SpeakerCardHeader({ index, onRemove }: Props) {
+export function SpeakerCardHeader({ index, status, onRemove }: Props) {
   return (
     <div className="flex items-center gap-2 mb-2.5">
       <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep font-medium">
         Speaker · {String(index + 1).padStart(2, "0")}
       </span>
+      <StatusPill status={status} className="ml-auto" />
       {onRemove && (
         <button
           type="button"
           onClick={onRemove}
           aria-label="Remove speaker"
-          className="ml-auto text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 rounded p-1 transition-colors"
+          className="text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 rounded p-1 transition-colors"
         >
           <RemoveIcon />
         </button>
       )}
     </div>
+  );
+}
+
+const STATE_CLS: Record<SpeakerStatus, string> = {
+  planned: "bg-parchment-2 text-walnut-2 border-border",
+  invited: "bg-brass-soft/40 text-brass-deep border-brass-soft",
+  confirmed: "bg-success-soft text-success border-success-soft",
+  declined: "bg-danger-soft text-bordeaux border-danger-soft",
+};
+
+function StatusPill({ status, className }: { status: SpeakerStatus; className?: string }) {
+  return (
+    <span
+      className={cn(
+        "font-mono text-[9px] uppercase tracking-[0.12em] px-2 py-0.5 rounded-full border whitespace-nowrap",
+        STATE_CLS[status],
+        className,
+      )}
+    >
+      {status}
+    </span>
   );
 }

--- a/src/features/schedule/SpeakerEditCard.tsx
+++ b/src/features/schedule/SpeakerEditCard.tsx
@@ -12,10 +12,17 @@ interface Props {
   onChange: (partial: Partial<Draft>) => void;
   onRemove: () => void;
   /** Step-2 read-only mode: disables all inputs, hides the remove
-   *  button, and shows the Prepare-invitation action band. The same
-   *  card shell renders in both modes so the modal's dimensions stay
-   *  stable across steps. */
-  locked?: { date: string };
+   *  button, and shows the Prepare-invitation / open-conversation
+   *  action band. Same card shell renders in both modes so the
+   *  modal's dimensions stay stable across steps. `invitationId` +
+   *  `onOpenChat` drive the non-planned "open conversation" button;
+   *  the parent is responsible for closing the Assign modal before
+   *  the chat dialog opens. */
+  locked?: {
+    date: string;
+    invitationId?: string | null;
+    onOpenChat?: (invitationId: string) => void;
+  };
 }
 
 const INPUT_CLS =
@@ -38,6 +45,8 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
         draft={draft}
         date={locked?.date ?? ""}
         step={locked ? "invite" : "edit"}
+        invitationId={locked?.invitationId ?? null}
+        {...(locked?.onOpenChat ? { onOpenChat: locked.onOpenChat } : {})}
       />
 
       <div className="flex flex-col gap-2.5">

--- a/src/features/schedule/SpeakerEditCard.tsx
+++ b/src/features/schedule/SpeakerEditCard.tsx
@@ -39,7 +39,11 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
   const readOnly = Boolean(locked);
   return (
     <div className="bg-chalk border border-border rounded-lg p-3 flex flex-col">
-      <SpeakerCardHeader index={index} onRemove={readOnly ? null : onRemove} />
+      <SpeakerCardHeader
+        index={index}
+        status={draft.status}
+        onRemove={readOnly ? null : onRemove}
+      />
 
       <SpeakerLockedBand
         draft={draft}

--- a/src/features/schedule/SpeakerEditCard.tsx
+++ b/src/features/schedule/SpeakerEditCard.tsx
@@ -1,10 +1,10 @@
-import { SPEAKER_ROLES } from "@/lib/types";
 import { cn } from "@/lib/cn";
 import { isValidEmail } from "@/lib/email";
 import { isE164, toE164 } from "@/features/templates/smsInvitation";
 import { SpeakerCardHeader } from "./SpeakerCardHeader";
 import type { Draft } from "./speakerDraft";
 import { SpeakerLockedBand } from "./SpeakerLockedBand";
+import { SpeakerRolePicker } from "./SpeakerRolePicker";
 
 interface Props {
   draft: Draft;
@@ -21,6 +21,11 @@ interface Props {
 const INPUT_CLS =
   "font-sans text-[13.5px] px-2.5 py-2 bg-chalk border border-border-strong rounded-md text-walnut w-full transition-colors placeholder:text-walnut-3 focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 disabled:bg-parchment-2 disabled:text-walnut-2 disabled:cursor-not-allowed";
 
+// Matches INPUT_CLS dimensions so swapping between the disabled input
+// and the "Nothing set" label in step 2 doesn't shift the card.
+const NOTHING_SET_CLS =
+  "font-sans italic text-[13.5px] px-2.5 py-2 bg-parchment-2 border border-border-strong rounded-md text-walnut-3 w-full";
+
 const LABEL_CLS = "font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep font-medium";
 
 export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Props) {
@@ -29,7 +34,11 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
     <div className="bg-chalk border border-border rounded-lg p-3 flex flex-col">
       <SpeakerCardHeader index={index} onRemove={readOnly ? null : onRemove} />
 
-      {locked && <SpeakerLockedBand draft={draft} date={locked.date} />}
+      <SpeakerLockedBand
+        draft={draft}
+        date={locked?.date ?? ""}
+        step={locked ? "invite" : "edit"}
+      />
 
       <div className="flex flex-col gap-2.5">
         <label className="flex flex-col gap-1">
@@ -52,20 +61,24 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
               — optional
             </span>
           </span>
-          <input
-            type="email"
-            value={draft.email}
-            onChange={(e) => onChange({ email: e.target.value })}
-            disabled={readOnly}
-            placeholder="name@example.com"
-            aria-invalid={draft.email.trim().length > 0 && !isValidEmail(draft.email)}
-            className={cn(
-              INPUT_CLS,
-              draft.email.trim().length > 0 &&
-                !isValidEmail(draft.email) &&
-                "border-bordeaux focus:border-bordeaux focus:ring-bordeaux/25",
-            )}
-          />
+          {readOnly && !draft.email.trim() ? (
+            <div className={NOTHING_SET_CLS}>Nothing set</div>
+          ) : (
+            <input
+              type="email"
+              value={draft.email}
+              onChange={(e) => onChange({ email: e.target.value })}
+              disabled={readOnly}
+              placeholder="name@example.com"
+              aria-invalid={draft.email.trim().length > 0 && !isValidEmail(draft.email)}
+              className={cn(
+                INPUT_CLS,
+                draft.email.trim().length > 0 &&
+                  !isValidEmail(draft.email) &&
+                  "border-bordeaux focus:border-bordeaux focus:ring-bordeaux/25",
+              )}
+            />
+          )}
           {!readOnly && draft.email.trim().length > 0 && !isValidEmail(draft.email) && (
             <span className="font-sans text-[11.5px] text-bordeaux mt-0.5">
               Enter a valid email address (e.g. name@example.com).
@@ -80,24 +93,28 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
               — optional, enables Send SMS
             </span>
           </span>
-          <input
-            type="tel"
-            value={draft.phone}
-            onChange={(e) => onChange({ phone: e.target.value })}
-            onBlur={() => {
-              const normalized = toE164(draft.phone);
-              if (normalized !== draft.phone) onChange({ phone: normalized });
-            }}
-            disabled={readOnly}
-            placeholder="+1 416 555 1234"
-            aria-invalid={draft.phone.trim().length > 0 && !isE164(draft.phone)}
-            className={cn(
-              INPUT_CLS,
-              draft.phone.trim().length > 0 &&
-                !isE164(draft.phone) &&
-                "border-bordeaux focus:border-bordeaux focus:ring-bordeaux/25",
-            )}
-          />
+          {readOnly && !draft.phone.trim() ? (
+            <div className={NOTHING_SET_CLS}>Nothing set</div>
+          ) : (
+            <input
+              type="tel"
+              value={draft.phone}
+              onChange={(e) => onChange({ phone: e.target.value })}
+              onBlur={() => {
+                const normalized = toE164(draft.phone);
+                if (normalized !== draft.phone) onChange({ phone: normalized });
+              }}
+              disabled={readOnly}
+              placeholder="+1 416 555 1234"
+              aria-invalid={draft.phone.trim().length > 0 && !isE164(draft.phone)}
+              className={cn(
+                INPUT_CLS,
+                draft.phone.trim().length > 0 &&
+                  !isE164(draft.phone) &&
+                  "border-bordeaux focus:border-bordeaux focus:ring-bordeaux/25",
+              )}
+            />
+          )}
           {!readOnly && draft.phone.trim().length > 0 && !isE164(draft.phone) && (
             <span className="font-sans text-[11.5px] text-bordeaux mt-0.5">
               Use international format: +1 then 10 digits, e.g. +14165551234.
@@ -112,34 +129,23 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
               — optional
             </span>
           </span>
-          <input
-            value={draft.topic}
-            onChange={(e) => onChange({ topic: e.target.value })}
-            disabled={readOnly}
-            placeholder="e.g. On the still, small voice"
-            className={INPUT_CLS}
-          />
+          {readOnly && !draft.topic.trim() ? (
+            <div className={NOTHING_SET_CLS}>Nothing set</div>
+          ) : (
+            <input
+              value={draft.topic}
+              onChange={(e) => onChange({ topic: e.target.value })}
+              disabled={readOnly}
+              placeholder="e.g. On the still, small voice"
+              className={INPUT_CLS}
+            />
+          )}
         </label>
-        <div className="flex flex-col gap-1.5">
-          <span className={LABEL_CLS}>Role</span>
-          <div className="flex flex-wrap gap-1.5">
-            {SPEAKER_ROLES.map((r) => (
-              <button
-                key={r}
-                onClick={() => onChange({ role: r })}
-                disabled={readOnly}
-                className={cn(
-                  "font-mono text-[10px] uppercase tracking-[0.12em] px-2.5 py-1.5 rounded-full border transition-colors disabled:cursor-not-allowed",
-                  draft.role === r
-                    ? "bg-walnut text-parchment border-walnut disabled:opacity-80"
-                    : "bg-chalk text-walnut-2 border-border-strong hover:bg-parchment-2 disabled:opacity-60 disabled:hover:bg-chalk",
-                )}
-              >
-                {r}
-              </button>
-            ))}
-          </div>
-        </div>
+        <SpeakerRolePicker
+          role={draft.role}
+          readOnly={readOnly}
+          onChange={(role) => onChange({ role })}
+        />
       </div>
     </div>
   );

--- a/src/features/schedule/SpeakerEditCard.tsx
+++ b/src/features/schedule/SpeakerEditCard.tsx
@@ -5,7 +5,6 @@ import { isE164, toE164 } from "@/features/templates/smsInvitation";
 import { SpeakerCardHeader } from "./SpeakerCardHeader";
 import type { Draft } from "./speakerDraft";
 import { SpeakerLockedBand } from "./SpeakerLockedBand";
-import { SpeakerStatusPills } from "./SpeakerStatusPills";
 
 interface Props {
   draft: Draft;
@@ -13,10 +12,9 @@ interface Props {
   onChange: (partial: Partial<Draft>) => void;
   onRemove: () => void;
   /** Step-2 read-only mode: disables all inputs, hides the remove
-   *  button, and swaps the status pills for a Prepare-invitation
-   *  action (planned) or an "already handled" note (invited /
-   *  confirmed). The same card shell renders in both modes so the
-   *  modal's dimensions stay stable across steps. */
+   *  button, and shows the Prepare-invitation action band. The same
+   *  card shell renders in both modes so the modal's dimensions stay
+   *  stable across steps. */
   locked?: { date: string };
 }
 
@@ -31,11 +29,7 @@ export function SpeakerEditCard({ draft, index, onChange, onRemove, locked }: Pr
     <div className="bg-chalk border border-border rounded-lg p-3 flex flex-col">
       <SpeakerCardHeader index={index} onRemove={readOnly ? null : onRemove} />
 
-      {locked ? (
-        <SpeakerLockedBand draft={draft} date={locked.date} />
-      ) : (
-        <SpeakerStatusPills status={draft.status} onChange={(status) => onChange({ status })} />
-      )}
+      {locked && <SpeakerLockedBand draft={draft} date={locked.date} />}
 
       <div className="flex flex-col gap-2.5">
         <label className="flex flex-col gap-1">

--- a/src/features/schedule/SpeakerEditList.tsx
+++ b/src/features/schedule/SpeakerEditList.tsx
@@ -86,12 +86,21 @@ export const SpeakerEditList = forwardRef<SpeakerEditListHandle, Props>(function
           await deleteSpeaker(wardId, date, id);
         }
         let plannedCount = 0;
+        // Build the post-save draft list as we go so that going back
+        // to step 1 (which keeps SpeakerEditList mounted) sees freshly
+        // created speakers as already-persisted. Without this, the
+        // draft retains `id: null` and a second Save fires another
+        // createSpeaker — duplicating the row.
+        const nextDrafts: Draft[] = [];
         for (const d of drafts) {
           const name = d.name.trim();
-          if (!name) continue;
+          if (!name) {
+            nextDrafts.push(d);
+            continue;
+          }
           if (d.status === "planned") plannedCount += 1;
           if (d.id === null) {
-            await createSpeaker({
+            const newId = await createSpeaker({
               wardId,
               date,
               nonMeetingSundays,
@@ -101,9 +110,15 @@ export const SpeakerEditList = forwardRef<SpeakerEditListHandle, Props>(function
               topic: d.topic.trim() || undefined,
               role: d.role,
             });
+            const persisted: Draft = { ...d, id: newId };
+            originalsRef.current.set(d.tempId, { ...persisted });
+            nextDrafts.push(persisted);
           } else {
             const original = originalsRef.current.get(d.tempId) ?? null;
-            if (!isDirty(d, original)) continue;
+            if (!isDirty(d, original)) {
+              nextDrafts.push(d);
+              continue;
+            }
             await updateSpeaker(wardId, date, d.id, {
               name,
               email: d.email.trim(),
@@ -112,9 +127,12 @@ export const SpeakerEditList = forwardRef<SpeakerEditListHandle, Props>(function
               role: d.role,
               status: d.status,
             });
+            originalsRef.current.set(d.tempId, { ...d });
+            nextDrafts.push(d);
           }
         }
         setDeletedIds([]);
+        setDrafts(nextDrafts);
         return plannedCount;
       },
     }),

--- a/src/features/schedule/SpeakerInvitationLauncher.test.tsx
+++ b/src/features/schedule/SpeakerInvitationLauncher.test.tsx
@@ -1,9 +1,20 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import userEvent from "@testing-library/user-event";
 import type { WithId } from "@/hooks/_sub";
 import type { Speaker } from "@/lib/types";
 import { SpeakerInvitationLauncher } from "./SpeakerInvitationLauncher";
+
+// Stub the live Firestore subscription. Each LauncherRow child calls
+// this once on mount; we just hand back a no-invitation-yet state so
+// the "Prepare invitation" path remains active for planned speakers
+// and the "Already X — open conversation" button stays disabled
+// (ok for most tests — invitationId is null so the button can't
+// actually route anywhere).
+vi.mock("@/features/invitations/useLatestInvitation", () => ({
+  useLatestInvitation: () => ({ loading: false, invitation: null }),
+}));
 
 function makeSpeaker(partial: Partial<Speaker> & { name: string }): Speaker {
   return {
@@ -20,56 +31,48 @@ function row(id: string, speaker: Speaker): WithId<Speaker> {
   return { id, data: speaker };
 }
 
+function renderLauncher(speakers: readonly WithId<Speaker>[]) {
+  return render(
+    <MemoryRouter>
+      <SpeakerInvitationLauncher date="2026-04-26" speakers={speakers} onClose={() => {}} />
+    </MemoryRouter>,
+  );
+}
+
 afterEach(() => {
   cleanup();
 });
 
 describe("SpeakerInvitationLauncher", () => {
   it("renders planned speakers with a Prepare invitation button", () => {
-    render(
-      <SpeakerInvitationLauncher
-        date="2026-04-26"
-        speakers={[row("s1", makeSpeaker({ name: "Sister Reeves", email: "r@x.com" }))]}
-      />,
-    );
+    renderLauncher([row("s1", makeSpeaker({ name: "Sister Reeves", email: "r@x.com" }))]);
     expect(screen.getByDisplayValue("Sister Reeves")).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Open prepare invitation for Sister Reeves/i }),
     ).toBeInTheDocument();
   });
 
-  it("renders invited speakers with an 'already invited' note and no button", () => {
-    render(
-      <SpeakerInvitationLauncher
-        date="2026-04-26"
-        speakers={[row("s1", makeSpeaker({ name: "Brother Lee", status: "invited" }))]}
-      />,
-    );
+  it("renders invited speakers with an 'open conversation' button", () => {
+    renderLauncher([row("s1", makeSpeaker({ name: "Brother Lee", status: "invited" }))]);
     expect(screen.getByDisplayValue("Brother Lee")).toBeInTheDocument();
-    expect(screen.getByText(/Already invited — open edit mode to change/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Already invited — open conversation/i }),
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Open prepare invitation/i }),
     ).not.toBeInTheDocument();
   });
 
-  it("confirmed speakers render with an 'already confirmed' note", () => {
-    render(
-      <SpeakerInvitationLauncher
-        date="2026-04-26"
-        speakers={[row("s1", makeSpeaker({ name: "Sister Park", status: "confirmed" }))]}
-      />,
-    );
-    expect(screen.getByText(/Already confirmed — open edit mode to change/i)).toBeInTheDocument();
+  it("confirmed speakers render with an 'open conversation' button", () => {
+    renderLauncher([row("s1", makeSpeaker({ name: "Sister Park", status: "confirmed" }))]);
+    expect(
+      screen.getByRole("button", { name: /Already confirmed — open conversation/i }),
+    ).toBeInTheDocument();
   });
 
   it("Prepare invitation button calls window.open with the expected URL", async () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
-    render(
-      <SpeakerInvitationLauncher
-        date="2026-04-26"
-        speakers={[row("speaker-abc", makeSpeaker({ name: "Sister Reeves" }))]}
-      />,
-    );
+    renderLauncher([row("speaker-abc", makeSpeaker({ name: "Sister Reeves" }))]);
 
     await userEvent.click(
       screen.getByRole("button", { name: /Open prepare invitation for Sister Reeves/i }),
@@ -83,20 +86,15 @@ describe("SpeakerInvitationLauncher", () => {
   });
 
   it("renders an empty-state hint when there are no speakers at all", () => {
-    render(<SpeakerInvitationLauncher date="2026-04-26" speakers={[]} />);
+    renderLauncher([]);
     expect(screen.getByText(/No speakers yet/i)).toBeInTheDocument();
   });
 
   it("hides declined speakers from the grid", () => {
-    render(
-      <SpeakerInvitationLauncher
-        date="2026-04-26"
-        speakers={[
-          row("s1", makeSpeaker({ name: "Planned Person" })),
-          row("s2", makeSpeaker({ name: "Declined Person", status: "declined" })),
-        ]}
-      />,
-    );
+    renderLauncher([
+      row("s1", makeSpeaker({ name: "Planned Person" })),
+      row("s2", makeSpeaker({ name: "Declined Person", status: "declined" })),
+    ]);
     expect(screen.getByDisplayValue("Planned Person")).toBeInTheDocument();
     expect(screen.queryByDisplayValue("Declined Person")).not.toBeInTheDocument();
   });

--- a/src/features/schedule/SpeakerInvitationLauncher.tsx
+++ b/src/features/schedule/SpeakerInvitationLauncher.tsx
@@ -1,4 +1,7 @@
+import { useSearchParams } from "react-router";
+import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
 import type { WithId } from "@/hooks/_sub";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
 import type { Speaker } from "@/lib/types";
 import { SpeakerEditCard } from "./SpeakerEditCard";
 import { fromSpeaker } from "./speakerDraft";
@@ -10,17 +13,21 @@ interface Props {
    *  loading-state flicker on the Edit → Invite transition — the
    *  parent already has fresh post-save data ready. */
   speakers: readonly WithId<Speaker>[];
+  /** Called by the "open conversation" button on non-planned cards.
+   *  Closes the Assign modal so the per-speaker chat dialog renders
+   *  on top of the clean schedule view. */
+  onClose: () => void;
 }
 
 const noop = () => {};
 
 /** Step 2 of the Assign Speakers modal. Reuses <SpeakerEditCard> in
  *  its read-only/locked mode so the modal dimensions stay identical
- *  to step 1 — only the status pills and remove button swap out for a
- *  "Prepare invitation" action (planned) or an "already handled"
- *  note (invited / confirmed). Declined speakers are hidden — they
- *  have a different re-invite flow. */
-export function SpeakerInvitationLauncher({ date, speakers }: Props) {
+ *  to step 1 — only the remove button drops out, and the band above
+ *  the detail fields swaps between "Prepare invitation" (planned) and
+ *  "Already X — open conversation" (non-planned). Declined speakers
+ *  are hidden — they have a different re-invite flow. */
+export function SpeakerInvitationLauncher({ date, speakers, onClose }: Props) {
   const rows = speakers.filter((s) => s.data.status !== "declined");
 
   if (rows.length === 0) {
@@ -31,17 +38,6 @@ export function SpeakerInvitationLauncher({ date, speakers }: Props) {
     );
   }
 
-  const drafts = rows.map((s) =>
-    fromSpeaker(s.id, {
-      name: s.data.name,
-      email: s.data.email,
-      phone: s.data.phone,
-      topic: s.data.topic,
-      status: s.data.status,
-      role: s.data.role,
-    }),
-  );
-
   return (
     <div className="flex flex-col gap-3">
       <p className="font-serif text-[13.5px] text-walnut-2">
@@ -49,17 +45,59 @@ export function SpeakerInvitationLauncher({ date, speakers }: Props) {
         conversation thread per speaker.
       </p>
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-2.5 lg:gap-3.5">
-        {drafts.map((d, i) => (
-          <SpeakerEditCard
-            key={d.tempId}
-            draft={d}
-            index={i}
-            onChange={noop}
-            onRemove={noop}
-            locked={{ date }}
-          />
+        {rows.map((s, i) => (
+          <LauncherRow key={s.id} speaker={s} date={date} index={i} onClose={onClose} />
         ))}
       </div>
     </div>
+  );
+}
+
+interface LauncherRowProps {
+  speaker: WithId<Speaker>;
+  date: string;
+  index: number;
+  onClose: () => void;
+}
+
+/** One speaker card in Step 2. Subscribes to the speaker's latest
+ *  invitation so the non-planned "open conversation" button knows
+ *  which chat to route to — SpeakerRow on the schedule auto-opens
+ *  its dialog when `?chat=<invitationId>` matches. */
+function LauncherRow({ speaker, date, index, onClose }: LauncherRowProps): React.ReactElement {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const latest = useLatestInvitation(wardId, date, speaker.id);
+  const invitationId = latest.invitation?.invitationId ?? null;
+  const [, setSearchParams] = useSearchParams();
+
+  const draft = fromSpeaker(speaker.id, {
+    name: speaker.data.name,
+    email: speaker.data.email,
+    phone: speaker.data.phone,
+    topic: speaker.data.topic,
+    status: speaker.data.status,
+    role: speaker.data.role,
+  });
+
+  function onOpenChat(id: string) {
+    onClose();
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("chat", id);
+        return next;
+      },
+      { replace: true },
+    );
+  }
+
+  return (
+    <SpeakerEditCard
+      draft={draft}
+      index={index}
+      onChange={noop}
+      onRemove={noop}
+      locked={{ date, invitationId, onOpenChat }}
+    />
   );
 }

--- a/src/features/schedule/SpeakerInvitationLauncher.tsx
+++ b/src/features/schedule/SpeakerInvitationLauncher.tsx
@@ -79,12 +79,13 @@ function LauncherRow({ speaker, date, index, onClose }: LauncherRowProps): React
     role: speaker.data.role,
   });
 
-  function onOpenChat(id: string) {
+  function onOpenChat(id: string | null) {
     onClose();
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);
-        next.set("chat", id);
+        if (id) next.set("chat", id);
+        else next.set("chatSpeaker", speaker.id);
         return next;
       },
       { replace: true },

--- a/src/features/schedule/SpeakerInvitationLauncher.tsx
+++ b/src/features/schedule/SpeakerInvitationLauncher.tsx
@@ -13,10 +13,6 @@ interface Props {
    *  loading-state flicker on the Edit → Invite transition — the
    *  parent already has fresh post-save data ready. */
   speakers: readonly WithId<Speaker>[];
-  /** Called by the "open conversation" button on non-planned cards.
-   *  Closes the Assign modal so the per-speaker chat dialog renders
-   *  on top of the clean schedule view. */
-  onClose: () => void;
 }
 
 const noop = () => {};
@@ -27,7 +23,7 @@ const noop = () => {};
  *  the detail fields swaps between "Prepare invitation" (planned) and
  *  "Already X — open conversation" (non-planned). Declined speakers
  *  are hidden — they have a different re-invite flow. */
-export function SpeakerInvitationLauncher({ date, speakers, onClose }: Props) {
+export function SpeakerInvitationLauncher({ date, speakers }: Props) {
   const rows = speakers.filter((s) => s.data.status !== "declined");
 
   if (rows.length === 0) {
@@ -46,7 +42,7 @@ export function SpeakerInvitationLauncher({ date, speakers, onClose }: Props) {
       </p>
       <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4 gap-2.5 lg:gap-3.5">
         {rows.map((s, i) => (
-          <LauncherRow key={s.id} speaker={s} date={date} index={i} onClose={onClose} />
+          <LauncherRow key={s.id} speaker={s} date={date} index={i} />
         ))}
       </div>
     </div>
@@ -57,14 +53,16 @@ interface LauncherRowProps {
   speaker: WithId<Speaker>;
   date: string;
   index: number;
-  onClose: () => void;
 }
 
 /** One speaker card in Step 2. Subscribes to the speaker's latest
  *  invitation so the non-planned "open conversation" button knows
  *  which chat to route to — SpeakerRow on the schedule auto-opens
- *  its dialog when `?chat=<invitationId>` matches. */
-function LauncherRow({ speaker, date, index, onClose }: LauncherRowProps): React.ReactElement {
+ *  its dialog when `?chat=<invitationId>` or `?chatSpeaker=<id>`
+ *  matches. Deliberately keeps the Assign modal open underneath so
+ *  the bishop can flip between conversation threads without losing
+ *  the speaker-overview context. */
+function LauncherRow({ speaker, date, index }: LauncherRowProps): React.ReactElement {
   const wardId = useCurrentWardStore((s) => s.wardId);
   const latest = useLatestInvitation(wardId, date, speaker.id);
   const invitationId = latest.invitation?.invitationId ?? null;
@@ -80,7 +78,6 @@ function LauncherRow({ speaker, date, index, onClose }: LauncherRowProps): React
   });
 
   function onOpenChat(id: string | null) {
-    onClose();
     setSearchParams(
       (prev) => {
         const next = new URLSearchParams(prev);

--- a/src/features/schedule/SpeakerLockedBand.tsx
+++ b/src/features/schedule/SpeakerLockedBand.tsx
@@ -4,20 +4,33 @@ interface Props {
   draft: Draft;
   date: string;
   /** "invite" (default) — Step 2 behaviour: planned speakers get the
-   *  "Prepare invitation →" button; non-planned get the "Already X
-   *  — open edit mode to change" message. "edit" — Step 1 behaviour:
-   *  everyone gets an invisible placeholder matching the Step 2 band
-   *  dimensions; the bishop is already in edit mode, so neither the
-   *  Prepare button nor the "open edit mode to change" nudge fits
-   *  there. The matched footprint keeps the card total-height stable
-   *  across step transitions. */
+   *  "Prepare invitation →" button; non-planned speakers get an
+   *  "Already X — open conversation" action that closes the Assign
+   *  modal + opens the per-speaker chat dialog. "edit" — Step 1
+   *  behaviour: everyone gets an invisible placeholder matching the
+   *  Step 2 band dimensions so the card height stays stable across
+   *  step transitions. */
   step?: "edit" | "invite";
+  /** Latest invitation id for this speaker (if any). Drives the
+   *  "open conversation" button's URL handoff — SpeakerRow auto-opens
+   *  its chat dialog whenever `?chat=<invitationId>` matches. */
+  invitationId?: string | null;
+  /** Called by the Step 2 "open conversation" button right before it
+   *  navigates — the parent closes the Assign modal so the chat
+   *  dialog renders on top of the clean schedule view. */
+  onOpenChat?: (invitationId: string) => void;
 }
 
 /** Band that sits above the speaker-detail fields in both steps of
  *  the Assign Speakers modal. See Props for the step-specific
  *  branching. */
-export function SpeakerLockedBand({ draft, date, step = "invite" }: Props): React.ReactElement {
+export function SpeakerLockedBand({
+  draft,
+  date,
+  step = "invite",
+  invitationId,
+  onOpenChat,
+}: Props): React.ReactElement {
   const status = draft.status;
   const persisted = draft.id !== null;
 
@@ -25,6 +38,11 @@ export function SpeakerLockedBand({ draft, date, step = "invite" }: Props): Reac
     if (!persisted || !draft.id) return;
     const url = `/week/${encodeURIComponent(date)}/speaker/${encodeURIComponent(draft.id)}/prepare`;
     window.open(url, "_blank", "noopener,noreferrer");
+  }
+
+  function openChat() {
+    if (!invitationId || !onOpenChat) return;
+    onOpenChat(invitationId);
   }
 
   if (step === "edit") {
@@ -59,14 +77,22 @@ export function SpeakerLockedBand({ draft, date, step = "invite" }: Props): Reac
 
   const label =
     status === "confirmed"
-      ? "Already confirmed — open edit mode to change."
+      ? "Already confirmed — open conversation"
       : status === "declined"
-        ? "Already declined — open edit mode to change."
-        : "Already invited — open edit mode to change.";
+        ? "Already declined — open conversation"
+        : "Already invited — open conversation";
 
+  const canOpen = Boolean(invitationId && onOpenChat);
   return (
-    <div className="w-full mb-2.5 border border-border-strong bg-parchment-2 text-walnut-2 rounded-md font-serif italic text-[11.5px] py-2 px-2.5 text-center">
-      {label}
-    </div>
+    <button
+      type="button"
+      onClick={openChat}
+      disabled={!canOpen}
+      aria-label={label}
+      title={canOpen ? undefined : "No invitation on file — open the chat from the schedule row."}
+      className="w-full mb-2.5 border border-walnut bg-walnut text-parchment rounded-md font-mono text-[10px] uppercase tracking-[0.14em] font-medium py-2 hover:bg-walnut-2 shadow-[0_1px_0_rgba(35,24,21,0.18)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+    >
+      {label} →
+    </button>
   );
 }

--- a/src/features/schedule/SpeakerLockedBand.tsx
+++ b/src/features/schedule/SpeakerLockedBand.tsx
@@ -11,14 +11,16 @@ interface Props {
    *  Step 2 band dimensions so the card height stays stable across
    *  step transitions. */
   step?: "edit" | "invite";
-  /** Latest invitation id for this speaker (if any). Drives the
-   *  "open conversation" button's URL handoff — SpeakerRow auto-opens
-   *  its chat dialog whenever `?chat=<invitationId>` matches. */
+  /** Latest invitation id for this speaker, when one exists. The
+   *  button still works without one — SpeakerRow's dialog handles
+   *  the no-invitation case with a placeholder. */
   invitationId?: string | null;
   /** Called by the Step 2 "open conversation" button right before it
    *  navigates — the parent closes the Assign modal so the chat
-   *  dialog renders on top of the clean schedule view. */
-  onOpenChat?: (invitationId: string) => void;
+   *  dialog renders on top of the clean schedule view. Receives the
+   *  invitationId when one is on file so the URL hint can pick the
+   *  exact invitation; null means route via speakerId instead. */
+  onOpenChat?: (invitationId: string | null) => void;
 }
 
 /** Band that sits above the speaker-detail fields in both steps of
@@ -41,8 +43,8 @@ export function SpeakerLockedBand({
   }
 
   function openChat() {
-    if (!invitationId || !onOpenChat) return;
-    onOpenChat(invitationId);
+    if (!onOpenChat) return;
+    onOpenChat(invitationId ?? null);
   }
 
   if (step === "edit") {
@@ -82,14 +84,12 @@ export function SpeakerLockedBand({
         ? "Already declined — open conversation"
         : "Already invited — open conversation";
 
-  const canOpen = Boolean(invitationId && onOpenChat);
   return (
     <button
       type="button"
       onClick={openChat}
-      disabled={!canOpen}
+      disabled={!onOpenChat}
       aria-label={label}
-      title={canOpen ? undefined : "No invitation on file — open the chat from the schedule row."}
       className="w-full mb-2.5 border border-walnut bg-walnut text-parchment rounded-md font-mono text-[10px] uppercase tracking-[0.14em] font-medium py-2 hover:bg-walnut-2 shadow-[0_1px_0_rgba(35,24,21,0.18)] disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
     >
       {label} →

--- a/src/features/schedule/SpeakerLockedBand.tsx
+++ b/src/features/schedule/SpeakerLockedBand.tsx
@@ -4,13 +4,13 @@ interface Props {
   draft: Draft;
   date: string;
   /** "invite" (default) — Step 2 behaviour: planned speakers get the
-   *  "Prepare invitation →" button; non-planned get the "Already X"
-   *  message. "edit" — Step 1 behaviour: planned speakers get a
-   *  same-dimensions invisible spacer (no redundant affordance while
-   *  the bishop is already editing), non-planned speakers still get
-   *  the "Already X" message. Matching dimensions between the two
-   *  modes keeps the card total-height stable across step
-   *  transitions. */
+   *  "Prepare invitation →" button; non-planned get the "Already X
+   *  — open edit mode to change" message. "edit" — Step 1 behaviour:
+   *  everyone gets an invisible placeholder matching the Step 2 band
+   *  dimensions; the bishop is already in edit mode, so neither the
+   *  Prepare button nor the "open edit mode to change" nudge fits
+   *  there. The matched footprint keeps the card total-height stable
+   *  across step transitions. */
   step?: "edit" | "invite";
 }
 
@@ -27,20 +27,23 @@ export function SpeakerLockedBand({ draft, date, step = "invite" }: Props): Reac
     window.open(url, "_blank", "noopener,noreferrer");
   }
 
+  if (step === "edit") {
+    // Visually hidden placeholder for Step 1 regardless of status —
+    // the bishop is already editing, so neither the "Prepare
+    // invitation" button nor the "open edit mode to change" nudge
+    // belong here. Matching the Step 2 band's vertical footprint
+    // keeps the card height stable across step transitions.
+    return (
+      <div
+        aria-hidden
+        className="w-full mb-2.5 border border-transparent font-mono text-[10px] tracking-[0.14em] font-medium py-2 invisible"
+      >
+        Prepare invitation →
+      </div>
+    );
+  }
+
   if (status === "planned") {
-    if (step === "edit") {
-      // Visually hidden placeholder — reserves the same vertical
-      // footprint as the Step 2 button so the card height stays
-      // stable when the bishop flips between steps.
-      return (
-        <div
-          aria-hidden
-          className="w-full mb-2.5 border border-transparent font-mono text-[10px] tracking-[0.14em] font-medium py-2 invisible"
-        >
-          Prepare invitation →
-        </div>
-      );
-    }
     return (
       <button
         type="button"

--- a/src/features/schedule/SpeakerLockedBand.tsx
+++ b/src/features/schedule/SpeakerLockedBand.tsx
@@ -3,15 +3,21 @@ import type { Draft } from "./speakerDraft";
 interface Props {
   draft: Draft;
   date: string;
+  /** "invite" (default) — Step 2 behaviour: planned speakers get the
+   *  "Prepare invitation →" button; non-planned get the "Already X"
+   *  message. "edit" — Step 1 behaviour: planned speakers get a
+   *  same-dimensions invisible spacer (no redundant affordance while
+   *  the bishop is already editing), non-planned speakers still get
+   *  the "Already X" message. Matching dimensions between the two
+   *  modes keeps the card total-height stable across step
+   *  transitions. */
+  step?: "edit" | "invite";
 }
 
-/** Replaces the SpeakerStatusPills row on a locked (step-2) card.
- *  Planned speakers get a primary "Prepare invitation →" action
- *  that opens the full Prepare page in a new tab. Everything else
- *  shows a muted "Already X — open edit mode to change" note;
- *  reviewing / applying responses lives on the Sunday card's
- *  per-speaker chat icon now, not here. */
-export function SpeakerLockedBand({ draft, date }: Props): React.ReactElement {
+/** Band that sits above the speaker-detail fields in both steps of
+ *  the Assign Speakers modal. See Props for the step-specific
+ *  branching. */
+export function SpeakerLockedBand({ draft, date, step = "invite" }: Props): React.ReactElement {
   const status = draft.status;
   const persisted = draft.id !== null;
 
@@ -22,6 +28,19 @@ export function SpeakerLockedBand({ draft, date }: Props): React.ReactElement {
   }
 
   if (status === "planned") {
+    if (step === "edit") {
+      // Visually hidden placeholder — reserves the same vertical
+      // footprint as the Step 2 button so the card height stays
+      // stable when the bishop flips between steps.
+      return (
+        <div
+          aria-hidden
+          className="w-full mb-2.5 border border-transparent font-mono text-[10px] tracking-[0.14em] font-medium py-2 invisible"
+        >
+          Prepare invitation →
+        </div>
+      );
+    }
     return (
       <button
         type="button"

--- a/src/features/schedule/SpeakerRolePicker.tsx
+++ b/src/features/schedule/SpeakerRolePicker.tsx
@@ -1,0 +1,40 @@
+import { SPEAKER_ROLES, type SpeakerRole } from "@/lib/types";
+import { cn } from "@/lib/cn";
+
+interface Props {
+  role: SpeakerRole;
+  readOnly: boolean;
+  onChange: (role: SpeakerRole) => void;
+}
+
+const LABEL_CLS = "font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep font-medium";
+
+/** Small pill row for picking a speaker role (Bishopric / Member /
+ *  Youth / Primary). Extracted out of SpeakerEditCard to keep that
+ *  file under the 150-LOC cap. Disabled in step-2 read-only mode;
+ *  selected pill keeps its active styling at reduced opacity so the
+ *  role stays legible. */
+export function SpeakerRolePicker({ role, readOnly, onChange }: Props) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className={LABEL_CLS}>Role</span>
+      <div className="flex flex-wrap gap-1.5">
+        {SPEAKER_ROLES.map((r) => (
+          <button
+            key={r}
+            onClick={() => onChange(r)}
+            disabled={readOnly}
+            className={cn(
+              "font-mono text-[10px] uppercase tracking-[0.12em] px-2.5 py-1.5 rounded-full border transition-colors disabled:cursor-not-allowed",
+              role === r
+                ? "bg-walnut text-parchment border-walnut disabled:opacity-80"
+                : "bg-chalk text-walnut-2 border-border-strong hover:bg-parchment-2 disabled:opacity-60 disabled:hover:bg-chalk",
+            )}
+          >
+            {r}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -18,10 +18,11 @@ interface Props {
 }
 
 const STATE_CLS: Record<SpeakerStatus, string> = {
-  planned: "bg-parchment-2 text-walnut-2 border-border",
-  invited: "bg-brass-soft/40 text-brass-deep border-brass-soft",
-  confirmed: "bg-success-soft text-success border-success-soft",
-  declined: "bg-danger-soft text-bordeaux border-danger-soft",
+  planned: "bg-gradient-to-br from-parchment-2 to-parchment text-walnut-2 border-border",
+  invited: "bg-gradient-to-br from-brass-soft to-brass-soft/50 text-brass-deep border-brass-soft",
+  confirmed:
+    "bg-gradient-to-br from-success-soft to-success-soft/60 text-success border-success-soft",
+  declined: "bg-gradient-to-br from-danger-soft to-danger-soft/60 text-bordeaux border-danger-soft",
 };
 
 export function SpeakerRow({ number, speaker, speakerId, date }: Props) {

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -35,20 +35,27 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
   const unreadCount = useConversationUnread(invitation?.conversationSid);
   const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
 
-  // Auto-open the dialog when a push notification deep-links us here
-  // via `?chat=<invitationId>`. Each row checks independently — only
-  // the matching one opens + clears the query. Invitation loads async,
-  // so we can't check until it arrives.
+  // Auto-open the dialog when something hands us a URL hint:
+  //   `?chat=<invitationId>`      — push-notification deep link
+  //   `?chatSpeaker=<speakerId>`  — Assign modal's "open conversation"
+  //                                  button (may have no invitation yet)
+  // Each row checks independently — only the matching one opens +
+  // clears the query. Invitation-keyed match waits for the invitation
+  // subscription to resolve; speakerId-keyed match is available
+  // immediately.
   const [searchParams, setSearchParams] = useSearchParams();
   useEffect(() => {
-    if (!invitation) return;
-    const target = searchParams.get("chat");
-    if (!target || target !== invitation.invitationId) return;
+    const chatKey = searchParams.get("chat");
+    const speakerKey = searchParams.get("chatSpeaker");
+    const invitationMatches = invitation && chatKey === invitation.invitationId;
+    const speakerMatches = speakerKey === speakerId;
+    if (!invitationMatches && !speakerMatches) return;
     setOpen(true);
     const next = new URLSearchParams(searchParams);
-    next.delete("chat");
+    if (invitationMatches) next.delete("chat");
+    if (speakerMatches) next.delete("chatSpeaker");
     setSearchParams(next, { replace: true });
-  }, [invitation, searchParams, setSearchParams]);
+  }, [invitation, speakerId, searchParams, setSearchParams]);
 
   return (
     <li className="flex items-center gap-3 py-3 border-b border-border last:border-b-0">

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -1,8 +1,4 @@
-import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router";
-import { BishopInvitationDialog } from "@/features/invitations/BishopInvitationDialog";
-import { useConversationUnread } from "@/features/invitations/useConversationUnread";
-import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
+import { SpeakerChatLauncher } from "@/features/invitations/SpeakerChatLauncher";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import type { Speaker, SpeakerStatus } from "@/lib/types";
 import { cn } from "@/lib/cn";
@@ -27,36 +23,6 @@ const STATE_CLS: Record<SpeakerStatus, string> = {
 export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
   const status = speaker.status ?? "planned";
   const wardId = useCurrentWardStore((s) => s.wardId) ?? "";
-  const [open, setOpen] = useState(false);
-  const latest = useLatestInvitation(wardId || null, date, speakerId);
-  const invitation = latest.invitation;
-  const response = invitation?.response;
-  const needsApply = Boolean(response && !response.acknowledgedAt);
-  const unreadCount = useConversationUnread(invitation?.conversationSid);
-  const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
-
-  // Auto-open the dialog when something hands us a URL hint:
-  //   `?chat=<invitationId>`      — push-notification deep link
-  //   `?chatSpeaker=<speakerId>`  — Assign modal's "open conversation"
-  //                                  button (may have no invitation yet)
-  // Each row checks independently — only the matching one opens +
-  // clears the query. Invitation-keyed match waits for the invitation
-  // subscription to resolve; speakerId-keyed match is available
-  // immediately.
-  const [searchParams, setSearchParams] = useSearchParams();
-  useEffect(() => {
-    const chatKey = searchParams.get("chat");
-    const speakerKey = searchParams.get("chatSpeaker");
-    const invitationMatches = invitation && chatKey === invitation.invitationId;
-    const speakerMatches = speakerKey === speakerId;
-    if (!invitationMatches && !speakerMatches) return;
-    setOpen(true);
-    const next = new URLSearchParams(searchParams);
-    if (invitationMatches) next.delete("chat");
-    if (speakerMatches) next.delete("chatSpeaker");
-    setSearchParams(next, { replace: true });
-  }, [invitation, speakerId, searchParams, setSearchParams]);
-
   return (
     <li className="flex items-center gap-3 py-3 border-b border-border last:border-b-0">
       <div className="font-mono text-[10.5px] tracking-[0.08em] text-brass-deep w-6">
@@ -76,64 +42,7 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
       >
         {status}
       </div>
-      <ChatIconButton
-        badge={needsApply || hasUnread}
-        onClick={() => setOpen(true)}
-        speakerName={speaker.name}
-      />
-      <BishopInvitationDialog
-        open={open}
-        onClose={() => setOpen(false)}
-        wardId={wardId}
-        invitationId={invitation?.invitationId ?? null}
-        invitation={invitation ?? null}
-        speaker={speaker}
-        date={date}
-        speakerId={speakerId}
-      />
+      <SpeakerChatLauncher wardId={wardId} date={date} speaker={speaker} speakerId={speakerId} />
     </li>
-  );
-}
-
-interface ChatIconButtonProps {
-  badge: boolean;
-  onClick: () => void;
-  speakerName: string;
-}
-
-function ChatIconButton({ badge, onClick, speakerName }: ChatIconButtonProps) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label={`Open conversation with ${speakerName}`}
-      title="Open conversation"
-      className="relative inline-flex items-center justify-center w-8 h-8 rounded-md border border-border-strong bg-chalk text-walnut hover:bg-parchment-2 hover:border-bordeaux transition-colors"
-    >
-      <ChatIcon />
-      {badge && (
-        <span
-          aria-hidden="true"
-          className="absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full bg-bordeaux border border-chalk"
-        />
-      )}
-    </button>
-  );
-}
-
-function ChatIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-    </svg>
   );
 }

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -18,11 +18,10 @@ interface Props {
 }
 
 const STATE_CLS: Record<SpeakerStatus, string> = {
-  planned: "bg-gradient-to-br from-parchment-2 to-parchment text-walnut-2 border-border",
-  invited: "bg-gradient-to-br from-brass-soft to-brass-soft/50 text-brass-deep border-brass-soft",
-  confirmed:
-    "bg-gradient-to-br from-success-soft to-success-soft/60 text-success border-success-soft",
-  declined: "bg-gradient-to-br from-danger-soft to-danger-soft/60 text-bordeaux border-danger-soft",
+  planned: "bg-parchment-2 text-walnut-2 border-border",
+  invited: "bg-brass-soft/40 text-brass-deep border-brass-soft",
+  confirmed: "bg-success-soft text-success border-success-soft",
+  declined: "bg-danger-soft text-bordeaux border-danger-soft",
 };
 
 export function SpeakerRow({ number, speaker, speakerId, date }: Props) {

--- a/src/features/schedule/SpeakerRow.tsx
+++ b/src/features/schedule/SpeakerRow.tsx
@@ -3,11 +3,9 @@ import { useSearchParams } from "react-router";
 import { BishopInvitationDialog } from "@/features/invitations/BishopInvitationDialog";
 import { useConversationUnread } from "@/features/invitations/useConversationUnread";
 import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
-import { useWardMembers } from "@/hooks/useWardMembers";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import type { Speaker, SpeakerStatus } from "@/lib/types";
 import { cn } from "@/lib/cn";
-import { statusProvenanceLabel } from "./statusProvenance";
 
 interface Props {
   number: number;
@@ -32,13 +30,10 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
   const [open, setOpen] = useState(false);
   const latest = useLatestInvitation(wardId || null, date, speakerId);
   const invitation = latest.invitation;
-  const hasInvitation = Boolean(invitation);
   const response = invitation?.response;
   const needsApply = Boolean(response && !response.acknowledgedAt);
   const unreadCount = useConversationUnread(invitation?.conversationSid);
   const hasUnread = typeof unreadCount === "number" && unreadCount > 0;
-  const members = useWardMembers();
-  const provenance = statusProvenanceLabel(speaker, members);
 
   // Auto-open the dialog when a push notification deep-links us here
   // via `?chat=<invitationId>`. Each row checks independently — only
@@ -65,11 +60,6 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
         {speaker.topic && (
           <div className="font-serif italic text-sm text-walnut-2 truncate">{speaker.topic}</div>
         )}
-        {provenance && (
-          <div className="font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 mt-0.5">
-            {provenance}
-          </div>
-        )}
       </div>
       <div
         className={cn(
@@ -80,52 +70,38 @@ export function SpeakerRow({ number, speaker, speakerId, date }: Props) {
         {status}
       </div>
       <ChatIconButton
-        enabled={hasInvitation}
         badge={needsApply || hasUnread}
         onClick={() => setOpen(true)}
         speakerName={speaker.name}
       />
-      {invitation && (
-        <BishopInvitationDialog
-          open={open}
-          onClose={() => setOpen(false)}
-          wardId={wardId}
-          invitationId={invitation.invitationId}
-          invitation={invitation}
-          speaker={speaker}
-          date={date}
-          speakerId={speakerId}
-        />
-      )}
+      <BishopInvitationDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        wardId={wardId}
+        invitationId={invitation?.invitationId ?? null}
+        invitation={invitation ?? null}
+        speaker={speaker}
+        date={date}
+        speakerId={speakerId}
+      />
     </li>
   );
 }
 
 interface ChatIconButtonProps {
-  enabled: boolean;
   badge: boolean;
   onClick: () => void;
   speakerName: string;
 }
 
-function ChatIconButton({ enabled, badge, onClick, speakerName }: ChatIconButtonProps) {
+function ChatIconButton({ badge, onClick, speakerName }: ChatIconButtonProps) {
   return (
     <button
       type="button"
       onClick={onClick}
-      disabled={!enabled}
-      aria-label={
-        enabled
-          ? `Open conversation with ${speakerName}`
-          : `No invitation sent yet to ${speakerName}`
-      }
-      title={enabled ? "Open conversation" : "No invitation sent yet"}
-      className={cn(
-        "relative inline-flex items-center justify-center w-8 h-8 rounded-md border transition-colors",
-        enabled
-          ? "border-border-strong bg-chalk text-walnut hover:bg-parchment-2 hover:border-bordeaux"
-          : "border-border bg-parchment-2 text-walnut-3 cursor-not-allowed",
-      )}
+      aria-label={`Open conversation with ${speakerName}`}
+      title="Open conversation"
+      className="relative inline-flex items-center justify-center w-8 h-8 rounded-md border border-border-strong bg-chalk text-walnut hover:bg-parchment-2 hover:border-bordeaux transition-colors"
     >
       <ChatIcon />
       {badge && (

--- a/src/features/schedule/SpeakerStatusPills.test.tsx
+++ b/src/features/schedule/SpeakerStatusPills.test.tsx
@@ -17,7 +17,7 @@ describe("SpeakerStatusPills", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it("applies the change directly when switching back to Planned", async () => {
+  it("Invited → Planned is frictionless (no commitment to erase)", async () => {
     const onChange = vi.fn();
     render(<SpeakerStatusPills status="invited" onChange={onChange} />);
 
@@ -25,6 +25,32 @@ describe("SpeakerStatusPills", () => {
 
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(onChange).toHaveBeenCalledWith("planned");
+  });
+
+  it("Confirmed → Planned surfaces the rollback dialog and requires confirm", async () => {
+    const onChange = vi.fn();
+    render(<SpeakerStatusPills status="confirmed" onChange={onChange} />);
+
+    await userEvent.click(screen.getByRole("radio", { name: /Planned/i }));
+
+    expect(screen.getByText(/Clear confirmed status\?/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rolling back to Planned clears that commitment/i)).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole("button", { name: /Clear confirmation/i }));
+    expect(onChange).toHaveBeenCalledWith("planned");
+  });
+
+  it("Declined → Invited surfaces the Undo-decline rollback dialog", async () => {
+    const onChange = vi.fn();
+    render(<SpeakerStatusPills status="declined" onChange={onChange} />);
+
+    await userEvent.click(screen.getByRole("radio", { name: /Invited/i }));
+
+    expect(screen.getByText(/Undo decline\?/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /Undo decline/i }));
+    expect(onChange).toHaveBeenCalledWith("invited");
   });
 
   it("opens a confirmation dialog when switching to Invited", async () => {

--- a/src/features/schedule/SpeakerStatusPills.tsx
+++ b/src/features/schedule/SpeakerStatusPills.tsx
@@ -13,10 +13,10 @@ const STATE_LABELS: Record<SpeakerStatus, string> = {
 };
 
 const STATE_ACTIVE: Record<SpeakerStatus, string> = {
-  planned: "bg-parchment-2 text-walnut",
-  invited: "bg-brass-soft text-walnut",
-  confirmed: "bg-success-soft text-success",
-  declined: "bg-danger-soft text-bordeaux",
+  planned: "bg-gradient-to-br from-parchment-2 to-parchment text-walnut",
+  invited: "bg-gradient-to-br from-brass-soft to-brass-soft/60 text-walnut",
+  confirmed: "bg-gradient-to-br from-success-soft to-success-soft/60 text-success",
+  declined: "bg-gradient-to-br from-danger-soft to-danger-soft/60 text-bordeaux",
 };
 
 type NonPlannedStatus = Exclude<SpeakerStatus, "planned">;

--- a/src/features/schedule/SpeakerStatusPills.tsx
+++ b/src/features/schedule/SpeakerStatusPills.tsx
@@ -4,6 +4,7 @@ import type { SubState } from "@/hooks/_sub";
 import { SPEAKER_STATUSES, type Member, type SpeakerStatus, type WithId } from "@/lib/types";
 import { cn } from "@/lib/cn";
 import type { StatusSource } from "@/lib/types/meeting";
+import { computeConfirmCopy } from "./speakerStatusConfirmCopy";
 
 const STATE_LABELS: Record<SpeakerStatus, string> = {
   planned: "Planned",
@@ -19,39 +20,6 @@ const STATE_ACTIVE: Record<SpeakerStatus, string> = {
   declined: "bg-danger-soft text-bordeaux",
 };
 
-type NonPlannedStatus = Exclude<SpeakerStatus, "planned">;
-
-/** Each non-planned state is a one-way-ish commitment: once the
- *  speaker is marked as invited/confirmed/declined, the Prepare
- *  Invitation flow is gated off. The confirm dialog spells out both
- *  the semantic (what this status means) and the consequence (need
- *  to switch back to Planned to send from the app).
- *
- *  When the current status was set by the speaker (via their yes/no
- *  reply) or by another bishopric member, the dialog prepends a
- *  context line so the reviewer understands whose decision they'd be
- *  overriding. */
-const BASE_CONFIRM_COPY: Record<
-  NonPlannedStatus,
-  { title: string; body: string; confirmLabel: string }
-> = {
-  invited: {
-    title: "Mark as Invited?",
-    body: "Use this when you've already reached out through another channel — email, SMS, or a hallway conversation. You won't be able to send an in-app invitation for this speaker unless you switch them back to Planned.",
-    confirmLabel: "Mark as Invited",
-  },
-  confirmed: {
-    title: "Mark as Confirmed?",
-    body: "Use this once the speaker has accepted the invitation. You won't be able to send further invitations unless you switch them back to Planned.",
-    confirmLabel: "Mark as Confirmed",
-  },
-  declined: {
-    title: "Mark as Declined?",
-    body: "We'll keep the speaker on file until you add a replacement. You won't be able to send further invitations unless you switch them back to Planned.",
-    confirmLabel: "Mark as Declined",
-  },
-};
-
 interface Props {
   status: SpeakerStatus;
   onChange: (status: SpeakerStatus) => void;
@@ -64,9 +32,11 @@ interface Props {
   currentUserUid?: string | undefined;
 }
 
-/** Segmented-control row of speaker statuses. Clicking any non-planned
- *  pill pops a confirm dialog explaining what the status means and
- *  the consequence (no in-app invitation while in that state). */
+/** Segmented-control row of speaker statuses. Every transition pops a
+ *  confirm dialog with provenance-aware copy — forward moves (→
+ *  invited / confirmed / declined) explain the consequence; rollbacks
+ *  out of a terminal state (confirmed/declined → planned/invited) add
+ *  friction so a misclick doesn't silently erase a real commitment. */
 export function SpeakerStatusPills({
   status,
   onChange,
@@ -75,11 +45,16 @@ export function SpeakerStatusPills({
   members,
   currentUserUid,
 }: Props) {
-  const [pending, setPending] = useState<NonPlannedStatus | null>(null);
+  const [pending, setPending] = useState<SpeakerStatus | null>(null);
 
   function requestChange(next: SpeakerStatus) {
     if (next === status) return;
-    if (next === "planned") {
+    // Invited → Planned stays frictionless (no real commitment to
+    // erase). Terminal → any non-terminal goes through the heavier
+    // rollback dialog; forward moves go through the base forward
+    // dialog. Both paths handled by computeConfirmCopy.
+    const isTerminal = status === "confirmed" || status === "declined";
+    if (!isTerminal && next === "planned") {
       onChange(next);
       return;
     }
@@ -87,7 +62,14 @@ export function SpeakerStatusPills({
   }
 
   const copy = pending
-    ? decorateConfirmCopy(pending, currentStatusSource, currentStatusSetBy, members, currentUserUid)
+    ? computeConfirmCopy({
+        current: status,
+        next: pending,
+        currentStatusSource,
+        currentStatusSetBy,
+        members,
+        currentUserUid,
+      })
     : null;
 
   return (
@@ -119,7 +101,7 @@ export function SpeakerStatusPills({
           title={copy.title}
           body={copy.body}
           confirmLabel={copy.confirmLabel}
-          danger={pending === "declined"}
+          danger={copy.danger}
           onCancel={() => setPending(null)}
           onConfirm={() => {
             onChange(pending);
@@ -129,35 +111,4 @@ export function SpeakerStatusPills({
       )}
     </>
   );
-}
-
-function decorateConfirmCopy(
-  next: NonPlannedStatus,
-  source: StatusSource | undefined,
-  setBy: string | undefined,
-  members: SubState<WithId<Member>[]> | undefined,
-  currentUserUid: string | undefined,
-): { title: string; body: string; confirmLabel: string } {
-  const base = BASE_CONFIRM_COPY[next];
-  const prefix = overridePrefix(source, setBy, members, currentUserUid);
-  if (!prefix) return base;
-  return { ...base, body: `${prefix} ${base.body}` };
-}
-
-function overridePrefix(
-  source: StatusSource | undefined,
-  setBy: string | undefined,
-  members: SubState<WithId<Member>[]> | undefined,
-  currentUserUid: string | undefined,
-): string | null {
-  if (!source) return null;
-  if (source === "speaker-response") {
-    return "The speaker set this status by replying to the invitation. Overriding it won't change their reply — it only updates the schedule record.";
-  }
-  // Manual changes: call out the setter if it was someone other than
-  // the current signed-in user; stay quiet when self-overriding.
-  if (!setBy || setBy === currentUserUid) return null;
-  const who = members?.data.find((m) => m.id === setBy)?.data.displayName;
-  if (!who) return null;
-  return `${who} set the current status. Override with care — there's no automatic notification to them.`;
 }

--- a/src/features/schedule/SpeakerStatusPills.tsx
+++ b/src/features/schedule/SpeakerStatusPills.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
-import { SPEAKER_STATUSES, type SpeakerStatus } from "@/lib/types";
+import type { SubState } from "@/hooks/_sub";
+import { SPEAKER_STATUSES, type Member, type SpeakerStatus, type WithId } from "@/lib/types";
 import { cn } from "@/lib/cn";
+import type { StatusSource } from "@/lib/types/meeting";
 
 const STATE_LABELS: Record<SpeakerStatus, string> = {
   planned: "Planned",
@@ -23,8 +25,13 @@ type NonPlannedStatus = Exclude<SpeakerStatus, "planned">;
  *  speaker is marked as invited/confirmed/declined, the Prepare
  *  Invitation flow is gated off. The confirm dialog spells out both
  *  the semantic (what this status means) and the consequence (need
- *  to switch back to Planned to send from the app). */
-const CONFIRM_COPY: Record<
+ *  to switch back to Planned to send from the app).
+ *
+ *  When the current status was set by the speaker (via their yes/no
+ *  reply) or by another bishopric member, the dialog prepends a
+ *  context line so the reviewer understands whose decision they'd be
+ *  overriding. */
+const BASE_CONFIRM_COPY: Record<
   NonPlannedStatus,
   { title: string; body: string; confirmLabel: string }
 > = {
@@ -48,12 +55,26 @@ const CONFIRM_COPY: Record<
 interface Props {
   status: SpeakerStatus;
   onChange: (status: SpeakerStatus) => void;
+  /** Provenance context used to tailor the confirm-dialog body. When
+   *  omitted the dialog falls back to the vanilla copy (useful for
+   *  callsites where provenance isn't readily available). */
+  currentStatusSource?: StatusSource;
+  currentStatusSetBy?: string;
+  members?: SubState<WithId<Member>[]>;
+  currentUserUid?: string | undefined;
 }
 
 /** Segmented-control row of speaker statuses. Clicking any non-planned
  *  pill pops a confirm dialog explaining what the status means and
  *  the consequence (no in-app invitation while in that state). */
-export function SpeakerStatusPills({ status, onChange }: Props) {
+export function SpeakerStatusPills({
+  status,
+  onChange,
+  currentStatusSource,
+  currentStatusSetBy,
+  members,
+  currentUserUid,
+}: Props) {
   const [pending, setPending] = useState<NonPlannedStatus | null>(null);
 
   function requestChange(next: SpeakerStatus) {
@@ -64,6 +85,10 @@ export function SpeakerStatusPills({ status, onChange }: Props) {
     }
     setPending(next);
   }
+
+  const copy = pending
+    ? decorateConfirmCopy(pending, currentStatusSource, currentStatusSetBy, members, currentUserUid)
+    : null;
 
   return (
     <>
@@ -88,12 +113,12 @@ export function SpeakerStatusPills({ status, onChange }: Props) {
           </button>
         ))}
       </div>
-      {pending && (
+      {pending && copy && (
         <ConfirmDialog
           open
-          title={CONFIRM_COPY[pending].title}
-          body={CONFIRM_COPY[pending].body}
-          confirmLabel={CONFIRM_COPY[pending].confirmLabel}
+          title={copy.title}
+          body={copy.body}
+          confirmLabel={copy.confirmLabel}
           danger={pending === "declined"}
           onCancel={() => setPending(null)}
           onConfirm={() => {
@@ -104,4 +129,35 @@ export function SpeakerStatusPills({ status, onChange }: Props) {
       )}
     </>
   );
+}
+
+function decorateConfirmCopy(
+  next: NonPlannedStatus,
+  source: StatusSource | undefined,
+  setBy: string | undefined,
+  members: SubState<WithId<Member>[]> | undefined,
+  currentUserUid: string | undefined,
+): { title: string; body: string; confirmLabel: string } {
+  const base = BASE_CONFIRM_COPY[next];
+  const prefix = overridePrefix(source, setBy, members, currentUserUid);
+  if (!prefix) return base;
+  return { ...base, body: `${prefix} ${base.body}` };
+}
+
+function overridePrefix(
+  source: StatusSource | undefined,
+  setBy: string | undefined,
+  members: SubState<WithId<Member>[]> | undefined,
+  currentUserUid: string | undefined,
+): string | null {
+  if (!source) return null;
+  if (source === "speaker-response") {
+    return "The speaker set this status by replying to the invitation. Overriding it won't change their reply — it only updates the schedule record.";
+  }
+  // Manual changes: call out the setter if it was someone other than
+  // the current signed-in user; stay quiet when self-overriding.
+  if (!setBy || setBy === currentUserUid) return null;
+  const who = members?.data.find((m) => m.id === setBy)?.data.displayName;
+  if (!who) return null;
+  return `${who} set the current status. Override with care — there's no automatic notification to them.`;
 }

--- a/src/features/schedule/SpeakerStatusPills.tsx
+++ b/src/features/schedule/SpeakerStatusPills.tsx
@@ -13,10 +13,10 @@ const STATE_LABELS: Record<SpeakerStatus, string> = {
 };
 
 const STATE_ACTIVE: Record<SpeakerStatus, string> = {
-  planned: "bg-gradient-to-br from-parchment-2 to-parchment text-walnut",
-  invited: "bg-gradient-to-br from-brass-soft to-brass-soft/60 text-walnut",
-  confirmed: "bg-gradient-to-br from-success-soft to-success-soft/60 text-success",
-  declined: "bg-gradient-to-br from-danger-soft to-danger-soft/60 text-bordeaux",
+  planned: "bg-parchment-2 text-walnut",
+  invited: "bg-brass-soft text-walnut",
+  confirmed: "bg-success-soft text-success",
+  declined: "bg-danger-soft text-bordeaux",
 };
 
 type NonPlannedStatus = Exclude<SpeakerStatus, "planned">;

--- a/src/features/schedule/SundayCard.tsx
+++ b/src/features/schedule/SundayCard.tsx
@@ -156,7 +156,11 @@ export function SundayCard({
           />
         </div>
         <div className={step === "invite" ? "" : "hidden"} aria-hidden={step !== "invite"}>
-          <SpeakerInvitationLauncher date={date} speakers={speakers} />
+          <SpeakerInvitationLauncher
+            date={date}
+            speakers={speakers}
+            onClose={() => setAssignDialogOpen(false)}
+          />
         </div>
       </AssignDialog>
     </article>

--- a/src/features/schedule/SundayCard.tsx
+++ b/src/features/schedule/SundayCard.tsx
@@ -156,11 +156,7 @@ export function SundayCard({
           />
         </div>
         <div className={step === "invite" ? "" : "hidden"} aria-hidden={step !== "invite"}>
-          <SpeakerInvitationLauncher
-            date={date}
-            speakers={speakers}
-            onClose={() => setAssignDialogOpen(false)}
-          />
+          <SpeakerInvitationLauncher date={date} speakers={speakers} />
         </div>
       </AssignDialog>
     </article>

--- a/src/features/schedule/SundayCard.tsx
+++ b/src/features/schedule/SundayCard.tsx
@@ -142,16 +142,22 @@ export function SundayCard({
           )
         }
       >
-        {step === "edit" ? (
+        {/* Both step subtrees stay mounted so the back-to-edit
+         *  transition doesn't re-seed SpeakerEditList's drafts from
+         *  scratch — hitting Back used to blank the card grid for
+         *  a frame while `useSpeakers()` re-hydrated. `hidden` keeps
+         *  the DOM present but removes layout + interactivity. */}
+        <div className={step === "edit" ? "" : "hidden"} aria-hidden={step !== "edit"}>
           <SpeakerEditList
             ref={editListRef}
             date={date}
             wardId={wardId}
             nonMeetingSundays={nonMeetingSundays}
           />
-        ) : (
+        </div>
+        <div className={step === "invite" ? "" : "hidden"} aria-hidden={step !== "invite"}>
           <SpeakerInvitationLauncher date={date} speakers={speakers} />
-        )}
+        </div>
       </AssignDialog>
     </article>
   );

--- a/src/features/schedule/SundayCard.tsx
+++ b/src/features/schedule/SundayCard.tsx
@@ -7,6 +7,7 @@ import { kindLabel, type KindVariant } from "./kindLabel";
 import { SpeakerEditList, type SpeakerEditListHandle } from "./SpeakerEditList";
 import { SpeakerInvitationLauncher } from "./SpeakerInvitationLauncher";
 import { AssignDialog } from "./AssignDialog";
+import { pendingInviteLabel } from "./pendingInviteLabel";
 import { EditFooter, InviteFooter } from "./AssignDialogFooters";
 import { SundayCardBody } from "./SundayCardBody";
 import { SundayCardCancelled } from "./SundayCardCancelled";
@@ -88,6 +89,7 @@ export function SundayCard({
 
   const title =
     step === "invite" ? `Send invitations — ${formatShortDate(date)}` : formatShortDate(date);
+  const subtitle = pendingInviteLabel(speakers);
 
   return (
     <article className={cn("rounded-lg border border-border shadow-elev-1", CARD_BG[kind.variant])}>
@@ -126,6 +128,7 @@ export function SundayCard({
       <AssignDialog
         open={assignDialogOpen}
         title={title}
+        {...(subtitle ? { subtitle } : {})}
         onClose={() => setAssignDialogOpen(false)}
         footerSlot={
           step === "edit" ? (

--- a/src/features/schedule/dateFormat.ts
+++ b/src/features/schedule/dateFormat.ts
@@ -7,6 +7,20 @@ export function formatShortDate(iso: string): string {
   });
 }
 
+/** Short weekday + date — e.g. "Sun May 20". Used in speaker-facing
+ *  chat copy ("Can you speak on Sun May 20?", confirmation system
+ *  notices) where the ambiguous "this Sunday" could land 0–6 days
+ *  out. Falls back to the raw ISO string if parsing fails. */
+export function formatShortSunday(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 export function formatCountdown(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number);
   if (!y || !m || !d) return iso;

--- a/src/features/schedule/pendingInviteLabel.test.ts
+++ b/src/features/schedule/pendingInviteLabel.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import type { WithId } from "@/hooks/_sub";
+import type { Speaker, SpeakerStatus } from "@/lib/types";
+import { pendingInviteLabel } from "./pendingInviteLabel";
+
+function speaker(status: SpeakerStatus | undefined, id = "x"): WithId<Speaker> {
+  return { id, data: { name: "Sample", ...(status ? { status } : {}) } as Speaker };
+}
+
+describe("pendingInviteLabel", () => {
+  it("returns null when there are no speakers", () => {
+    expect(pendingInviteLabel([])).toBeNull();
+  });
+
+  it("treats a missing status as planned (not invited yet)", () => {
+    expect(pendingInviteLabel([speaker(undefined)])).toBe("1 speaker has not been invited yet");
+  });
+
+  it("singular planned-only", () => {
+    expect(pendingInviteLabel([speaker("planned")])).toBe("1 speaker has not been invited yet");
+  });
+
+  it("plural planned-only", () => {
+    expect(pendingInviteLabel([speaker("planned", "a"), speaker("planned", "b")])).toBe(
+      "2 speakers have not been invited yet",
+    );
+  });
+
+  it("uses singular agreement on '1 of N'", () => {
+    expect(pendingInviteLabel([speaker("planned", "a"), speaker("invited", "b")])).toBe(
+      "1 of 2 speakers has not been invited yet",
+    );
+  });
+
+  it("uses plural agreement on '>1 of N'", () => {
+    expect(
+      pendingInviteLabel([
+        speaker("planned", "a"),
+        speaker("planned", "b"),
+        speaker("invited", "c"),
+      ]),
+    ).toBe("2 of 3 speakers have not been invited yet");
+  });
+
+  it("all-invited (singular)", () => {
+    expect(pendingInviteLabel([speaker("invited")])).toBe("Speaker invited");
+  });
+
+  it("all-actioned (mix of invited/confirmed/declined) is treated as fully invited", () => {
+    expect(
+      pendingInviteLabel([
+        speaker("invited", "a"),
+        speaker("confirmed", "b"),
+        speaker("declined", "c"),
+      ]),
+    ).toBe("All 3 speakers invited");
+  });
+});

--- a/src/features/schedule/pendingInviteLabel.ts
+++ b/src/features/schedule/pendingInviteLabel.ts
@@ -1,0 +1,28 @@
+import type { WithId } from "@/hooks/_sub";
+import type { Speaker } from "@/lib/types";
+
+/** Produces the "X of N speakers haven't been invited yet"-style
+ *  caption that sits beside the date on the Assign Speakers modal.
+ *  Returns null when there's nothing useful to say (no speakers on
+ *  the slot yet) — the header just shows the date in that case.
+ *
+ *  "Pending" = `status === "planned"` (or missing status, which we
+ *  treat as planned). Anything past that — invited / confirmed /
+ *  declined — counts as already actioned for this caption. */
+export function pendingInviteLabel(speakers: readonly WithId<Speaker>[]): string | null {
+  const total = speakers.length;
+  if (total === 0) return null;
+  const pending = speakers.filter((s) => (s.data.status ?? "planned") === "planned").length;
+
+  if (pending === 0) {
+    return total === 1 ? "Speaker invited" : `All ${total} speakers invited`;
+  }
+  if (pending === total) {
+    return total === 1
+      ? "1 speaker has not been invited yet"
+      : `${total} speakers have not been invited yet`;
+  }
+  return pending === 1
+    ? `1 of ${total} speakers has not been invited yet`
+    : `${pending} of ${total} speakers have not been invited yet`;
+}

--- a/src/features/schedule/speakerStatusConfirmCopy.ts
+++ b/src/features/schedule/speakerStatusConfirmCopy.ts
@@ -1,0 +1,130 @@
+import type { SubState } from "@/hooks/_sub";
+import type { Member, SpeakerStatus, WithId } from "@/lib/types";
+import type { StatusSource } from "@/lib/types/meeting";
+
+type NonPlannedStatus = Exclude<SpeakerStatus, "planned">;
+type TerminalStatus = "confirmed" | "declined";
+
+/** Base copy for forward transitions (→ invited/confirmed/declined).
+ *  Rollbacks and provenance context are decorated on top. */
+const BASE_CONFIRM_COPY: Record<
+  NonPlannedStatus,
+  { title: string; body: string; confirmLabel: string }
+> = {
+  invited: {
+    title: "Mark as Invited?",
+    body: "Use this when you've already reached out through another channel — email, SMS, or a hallway conversation. You won't be able to send an in-app invitation for this speaker unless you switch them back to Planned.",
+    confirmLabel: "Mark as Invited",
+  },
+  confirmed: {
+    title: "Mark as Confirmed?",
+    body: "Use this once the speaker has accepted the invitation. You won't be able to send further invitations unless you switch them back to Planned.",
+    confirmLabel: "Mark as Confirmed",
+  },
+  declined: {
+    title: "Mark as Declined?",
+    body: "We'll keep the speaker on file until you add a replacement. You won't be able to send further invitations unless you switch them back to Planned.",
+    confirmLabel: "Mark as Declined",
+  },
+};
+
+export interface CopyArgs {
+  current: SpeakerStatus;
+  next: SpeakerStatus;
+  currentStatusSource: StatusSource | undefined;
+  currentStatusSetBy: string | undefined;
+  members: SubState<WithId<Member>[]> | undefined;
+  currentUserUid: string | undefined;
+}
+
+export interface ConfirmCopy {
+  title: string;
+  body: string;
+  confirmLabel: string;
+  danger: boolean;
+}
+
+/** Compose the confirm-dialog copy for a requested status transition.
+ *  Three shapes:
+ *    - Rollback out of a terminal (confirmed/declined →
+ *      planned/invited): heavy-friction copy that names who made the
+ *      original commitment and what downstream surfaces lose.
+ *    - Forward transition (to invited/confirmed/declined): the
+ *      familiar per-target BASE copy, optionally prefixed with a
+ *      provenance nudge when someone else set the current status. */
+export function computeConfirmCopy(args: CopyArgs): ConfirmCopy {
+  const { current, next, currentStatusSource, currentStatusSetBy, members, currentUserUid } = args;
+  if (isTerminal(current) && !isTerminal(next)) {
+    return rollbackCopy({
+      from: current,
+      to: next,
+      source: currentStatusSource,
+      setBy: currentStatusSetBy,
+      members,
+      currentUserUid,
+    });
+  }
+  const base = BASE_CONFIRM_COPY[next as NonPlannedStatus];
+  const prefix = overridePrefix(currentStatusSource, currentStatusSetBy, members, currentUserUid);
+  return {
+    ...base,
+    body: prefix ? `${prefix} ${base.body}` : base.body,
+    danger: next === "declined",
+  };
+}
+
+function rollbackCopy(args: {
+  from: TerminalStatus;
+  to: "planned" | "invited";
+  source: StatusSource | undefined;
+  setBy: string | undefined;
+  members: SubState<WithId<Member>[]> | undefined;
+  currentUserUid: string | undefined;
+}): ConfirmCopy {
+  const { from, to, source, setBy, members, currentUserUid } = args;
+  const whoSet =
+    source === "speaker-response" ? "The speaker" : authorshipHint(setBy, members, currentUserUid);
+  const verb = from === "confirmed" ? "confirmation" : "decline";
+  const destLabel = to === "planned" ? "Planned" : "Invited";
+  const toLine =
+    to === "planned"
+      ? "The card reverts to Planned and you can send a fresh invitation or remove them without further friction."
+      : "The card reverts to Invited — the commitment log still carries the history but this speaker is no longer locked in.";
+  const subject = whoSet ?? "This";
+  return {
+    title: from === "confirmed" ? "Clear confirmed status?" : "Undo decline?",
+    body: `${subject} set the ${verb}. Rolling back to ${destLabel} clears that commitment from the card. The history stays in the audit log, but downstream surfaces (chat banner, schedule pill) will stop reflecting it. ${toLine}`,
+    confirmLabel: from === "confirmed" ? "Clear confirmation" : "Undo decline",
+    danger: true,
+  };
+}
+
+function authorshipHint(
+  setBy: string | undefined,
+  members: SubState<WithId<Member>[]> | undefined,
+  currentUserUid: string | undefined,
+): string | null {
+  if (!setBy) return null;
+  if (setBy === currentUserUid) return "You";
+  return members?.data.find((m) => m.id === setBy)?.data.displayName ?? null;
+}
+
+function isTerminal(s: SpeakerStatus): s is TerminalStatus {
+  return s === "confirmed" || s === "declined";
+}
+
+function overridePrefix(
+  source: StatusSource | undefined,
+  setBy: string | undefined,
+  members: SubState<WithId<Member>[]> | undefined,
+  currentUserUid: string | undefined,
+): string | null {
+  if (!source) return null;
+  if (source === "speaker-response") {
+    return "The speaker set this status by replying to the invitation. Overriding it won't change their reply — it only updates the schedule record.";
+  }
+  if (!setBy || setBy === currentUserUid) return null;
+  const who = members?.data.find((m) => m.id === setBy)?.data.displayName;
+  if (!who) return null;
+  return `${who} set the current status. Override with care — there's no automatic notification to them.`;
+}

--- a/src/features/schedule/statusProvenance.ts
+++ b/src/features/schedule/statusProvenance.ts
@@ -25,23 +25,38 @@ function formatShortDate(value: unknown): string | null {
 
 /** Compact label describing who set the speaker's current status and
  *  how, for surfaces that want to show provenance next to the status
- *  badge. Returns null when the status is planned/invited (provenance
- *  is meaningful only for the terminal states) or when the speaker
- *  doc is missing the provenance fields (legacy rows pre-rollout). */
+ *  badge. Returns null only when the speaker doc is missing the
+ *  provenance fields (legacy rows pre-rollout) — every live status
+ *  (planned / invited / confirmed / declined) gets a label so the
+ *  banner's height stays stable across transitions. */
 export function statusProvenanceLabel(
   speaker: Speaker,
   members: SubState<WithId<Member>[]>,
 ): string | null {
-  if (speaker.status !== "confirmed" && speaker.status !== "declined") return null;
   if (!speaker.statusSource) return null;
   const who = resolveName(speaker.statusSetBy, members);
   const when = formatShortDate(speaker.statusSetAt);
-  const source = speaker.statusSource === "speaker-response" ? "from reply" : "set manually";
+  const verb = statusVerb(speaker.status ?? "planned", speaker.statusSource);
   const byPart = who ? ` by ${who}` : "";
   const whenPart = when ? ` · ${when}` : "";
   const prefix =
-    speaker.statusSource === "speaker-response"
-      ? `${source} · applied${byPart}`
-      : `${source}${byPart}`;
+    speaker.statusSource === "speaker-response" ? `${verb} · applied${byPart}` : `${verb}${byPart}`;
   return `${prefix}${whenPart}`;
+}
+
+function statusVerb(
+  status: NonNullable<Speaker["status"]>,
+  source: NonNullable<Speaker["statusSource"]>,
+): string {
+  if (source === "speaker-response") return "from reply";
+  switch (status) {
+    case "planned":
+      return "planned";
+    case "invited":
+      return "invited";
+    case "confirmed":
+      return "set manually";
+    case "declined":
+      return "set manually";
+  }
 }

--- a/src/features/speakers/speakerActions.ts
+++ b/src/features/speakers/speakerActions.ts
@@ -38,7 +38,7 @@ export interface CreateSpeakerInput {
   role?: SpeakerRole | undefined;
 }
 
-export async function createSpeaker(input: CreateSpeakerInput): Promise<void> {
+export async function createSpeaker(input: CreateSpeakerInput): Promise<string> {
   return withSaveError(async () => {
     // Creating a speaker before the meeting doc exists would orphan the
     // subcollection entry. Ensure the parent meeting is there first.
@@ -73,6 +73,7 @@ export async function createSpeaker(input: CreateSpeakerInput): Promise<void> {
     }
     await batch.commit();
     await writeMeetingPatch(input.wardId, input.date, {});
+    return ref.id;
   });
 }
 

--- a/src/features/templates/PrepareInvitationActionBar.test.tsx
+++ b/src/features/templates/PrepareInvitationActionBar.test.tsx
@@ -15,6 +15,8 @@ const baseProps = {
   canSmsReason: null,
   hasOverride: false,
   speakerName: "Sister Reeves",
+  speakerEmail: "",
+  speakerPhone: "",
   onRevert: noop,
   onMarkInvited: noop,
   onPrint: noop,
@@ -23,43 +25,50 @@ const baseProps = {
 };
 
 describe("PrepareInvitationActionBar — SMS", () => {
-  it("disables Send SMS when no phone on file", () => {
-    render(<PrepareInvitationActionBar {...baseProps} canSms={false} />);
-    const smsBtn = screen.getByRole("button", { name: "Send SMS" });
-    expect(smsBtn).toBeDisabled();
-  });
-
-  it("enables Send SMS when a plausible phone is on file", () => {
-    render(<PrepareInvitationActionBar {...baseProps} canSms={true} />);
+  it("Send SMS is always enabled now — clicking opens the input dialog", () => {
+    render(<PrepareInvitationActionBar {...baseProps} canSms={false} speakerPhone="" />);
     const smsBtn = screen.getByRole("button", { name: "Send SMS" });
     expect(smsBtn).not.toBeDisabled();
   });
 
-  it("shows confirm modal before firing onSendSms", async () => {
+  it("clicking Send SMS opens the channel dialog prefilled with the phone on file", async () => {
     const onSendSms = vi.fn();
-    render(<PrepareInvitationActionBar {...baseProps} canSms={true} onSendSms={onSendSms} />);
+    render(
+      <PrepareInvitationActionBar
+        {...baseProps}
+        canSms
+        speakerPhone="+14165551234"
+        onSendSms={onSendSms}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Send SMS" }));
-    // Confirm modal opens with speaker-specific copy
     expect(screen.getByText(/Text invitation to Sister Reeves/i)).toBeInTheDocument();
-    // onSendSms doesn't fire until the primary confirm button is clicked
+    const input = screen.getByDisplayValue("+14165551234");
+    expect(input).toBeInTheDocument();
     expect(onSendSms).not.toHaveBeenCalled();
 
-    // The SMS confirm dialog's primary button is also labeled "Send SMS".
-    // There are now two such buttons (the toolbar icon + the dialog primary);
-    // pick the last, which is the one rendered inside the dialog.
+    // Dialog's primary "Send SMS" is the second button with that label
+    // (the toolbar icon is the first).
     const sendSmsButtons = screen.getAllByRole("button", { name: /Send SMS/i });
     await userEvent.click(sendSmsButtons.at(-1)!);
     expect(onSendSms).toHaveBeenCalledTimes(1);
+    expect(onSendSms).toHaveBeenCalledWith("+14165551234");
   });
 
-  it("cancel closes the confirm without firing onSendSms", async () => {
+  it("cancel closes the dialog without firing onSendSms", async () => {
     const onSendSms = vi.fn();
-    render(<PrepareInvitationActionBar {...baseProps} canSms={true} onSendSms={onSendSms} />);
+    render(
+      <PrepareInvitationActionBar
+        {...baseProps}
+        canSms
+        speakerPhone="+14165551234"
+        onSendSms={onSendSms}
+      />,
+    );
 
     await userEvent.click(screen.getByRole("button", { name: "Send SMS" }));
     const cancelBtns = screen.getAllByRole("button", { name: /^Cancel$/i });
-    // Modal's Cancel button is inside the dialog (the last one rendered)
     await userEvent.click(cancelBtns[cancelBtns.length - 1]!);
     expect(onSendSms).not.toHaveBeenCalled();
   });

--- a/src/features/templates/PrepareInvitationActionBar.tsx
+++ b/src/features/templates/PrepareInvitationActionBar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { CheckIcon, PrintIcon, SendIcon } from "@/features/schedule/SpeakerInviteIcons";
+import { PrepareInvitationDialogs } from "./PrepareInvitationDialogs";
 import { PrepareInvitationGroupBtn as GroupBtn } from "./PrepareInvitationGroupBtn";
 import { RevertIcon, SmsIcon } from "./PrepareInvitationIcons";
 
@@ -12,23 +12,32 @@ interface Props {
   canSmsReason: string | null;
   hasOverride: boolean;
   speakerName: string;
+  /** Current email / phone on file for the speaker. Used to prefill
+   *  the Send-channel dialog; empty strings are handled (the dialog
+   *  treats them as a first-time-add flow). */
+  speakerEmail: string;
+  speakerPhone: string;
   onRevert: () => void;
   onMarkInvited: () => void;
   onPrint: () => void;
-  onSend: () => void;
-  onSendSms: () => void;
+  /** Called with the final email the bishop confirmed in the dialog.
+   *  The parent is responsible for persisting it to the speaker doc
+   *  when it differs from what was on file. */
+  onSend: (email: string) => void;
+  onSendSms: (phone: string) => void;
 }
 
-type PendingConfirm = "revert" | "markInvited" | "printAndMarkInvited" | "send" | "sms" | null;
+type PendingConfirm = "revert" | "markInvited" | "printAndMarkInvited" | null;
+type PendingSend = "email" | "sms" | null;
 
 /** Top-of-page action toolbar for the Prepare Invitation page.
  *  Icon-only buttons in a connected group — labels travel via `title`
- *  (desktop tooltip) and `aria-label` (screen readers). Destructive /
- *  silent-state-change / side-effecting actions (Revert, Mark invited
- *  only, Send email, Send SMS) gate on a confirm modal so an accidental
- *  tap doesn't flip status, wipe an override, or fire a live mailto /
- *  Messages handoff. Cancel lives on the page chrome, not in this
- *  toolbar. */
+ *  (desktop tooltip) and `aria-label` (screen readers). Send Email
+ *  and Send SMS are always enabled; they open a SendChannelDialog
+ *  that lets the bishop confirm or edit the destination (saving any
+ *  change to the speaker record) before firing. Other destructive /
+ *  side-effecting actions gate on a ConfirmDialog. Cancel lives on
+ *  the page chrome, not in this toolbar. */
 export function PrepareInvitationActionBar({
   busy,
   canSend,
@@ -37,6 +46,8 @@ export function PrepareInvitationActionBar({
   canSmsReason,
   hasOverride,
   speakerName,
+  speakerEmail,
+  speakerPhone,
   onRevert,
   onMarkInvited,
   onPrint,
@@ -44,11 +55,7 @@ export function PrepareInvitationActionBar({
   onSendSms,
 }: Props) {
   const [pending, setPending] = useState<PendingConfirm>(null);
-
-  function confirm<T>(run: () => T) {
-    setPending(null);
-    run();
-  }
+  const [pendingSend, setPendingSend] = useState<PendingSend>(null);
 
   const hint = canSendReason ?? canSmsReason;
   // When neither channel is available, printing is the only "I've
@@ -90,16 +97,16 @@ export function PrepareInvitationActionBar({
         <GroupBtn
           position="mid"
           label="Send SMS"
-          onClick={() => setPending("sms")}
-          disabled={busy || !canSms}
+          onClick={() => setPendingSend("sms")}
+          disabled={busy}
         >
           <SmsIcon />
         </GroupBtn>
         <GroupBtn
           position="last"
           label="Send email"
-          onClick={() => setPending("send")}
-          disabled={busy || !canSend}
+          onClick={() => setPendingSend("email")}
+          disabled={busy}
           primary
         >
           <SendIcon />
@@ -109,55 +116,21 @@ export function PrepareInvitationActionBar({
         <span className="font-serif italic text-[11px] sm:text-[11.5px] text-walnut-3">{hint}</span>
       )}
 
-      <ConfirmDialog
-        open={pending === "revert"}
-        title={hasOverride ? "Clear per-speaker override?" : "Revert to ward default?"}
-        body={
-          hasOverride
-            ? `This deletes ${speakerName}'s saved letter override and restores the ward default. Any unsaved edits in the editor are also discarded.`
-            : "This resets the editor to the ward default template. Any unsaved edits in the editor are discarded."
-        }
-        confirmLabel={hasOverride ? "Clear override" : "Revert"}
-        danger={hasOverride}
-        onConfirm={() => confirm(onRevert)}
-        onCancel={() => setPending(null)}
-      />
-      <ConfirmDialog
-        open={pending === "markInvited"}
-        title="Mark as invited without sending?"
-        body={`${speakerName}'s status will be set to "invited" — no email is sent. Use this if you've already reached them another way (phone, in person, separate email).`}
-        confirmLabel="Mark invited"
-        onConfirm={() => confirm(onMarkInvited)}
-        onCancel={() => setPending(null)}
-      />
-      <ConfirmDialog
-        open={pending === "printAndMarkInvited"}
-        title="Print letter and mark as invited?"
-        body={`${speakerName} has no phone or email on file, so printing the letter is how you'll hand off this invitation. We'll open the print dialog now and set their status to "invited" so the schedule reflects that you've delivered it.`}
-        confirmLabel="Print & mark invited"
-        onConfirm={() =>
-          confirm(() => {
-            onPrint();
-            onMarkInvited();
-          })
-        }
-        onCancel={() => setPending(null)}
-      />
-      <ConfirmDialog
-        open={pending === "send"}
-        title={`Send invitation to ${speakerName}?`}
-        body={`This creates a new invitation link and emails it to ${speakerName}. Their status flips to "invited" once the email is queued. You'll see per-channel delivery status if anything fails.`}
-        confirmLabel="Send email"
-        onConfirm={() => confirm(onSend)}
-        onCancel={() => setPending(null)}
-      />
-      <ConfirmDialog
-        open={pending === "sms"}
-        title={`Text invitation to ${speakerName}?`}
-        body={`This creates a new invitation link and sends it as an SMS to ${speakerName} from the ward's Twilio number. Their status flips to "invited" once the SMS is queued. You'll see per-channel delivery status if anything fails.`}
-        confirmLabel="Send SMS"
-        onConfirm={() => confirm(onSendSms)}
-        onCancel={() => setPending(null)}
+      <PrepareInvitationDialogs
+        pending={pending}
+        pendingSend={pendingSend}
+        busy={busy}
+        hasOverride={hasOverride}
+        speakerName={speakerName}
+        speakerEmail={speakerEmail}
+        speakerPhone={speakerPhone}
+        onCancelPending={() => setPending(null)}
+        onCancelPendingSend={() => setPendingSend(null)}
+        onRevert={onRevert}
+        onMarkInvited={onMarkInvited}
+        onPrint={onPrint}
+        onSend={onSend}
+        onSendSms={onSendSms}
       />
     </div>
   );

--- a/src/features/templates/PrepareInvitationActionBar.tsx
+++ b/src/features/templates/PrepareInvitationActionBar.tsx
@@ -19,7 +19,7 @@ interface Props {
   onSendSms: () => void;
 }
 
-type PendingConfirm = "revert" | "markInvited" | "send" | "sms" | null;
+type PendingConfirm = "revert" | "markInvited" | "printAndMarkInvited" | "send" | "sms" | null;
 
 /** Top-of-page action toolbar for the Prepare Invitation page.
  *  Icon-only buttons in a connected group — labels travel via `title`
@@ -51,6 +51,13 @@ export function PrepareInvitationActionBar({
   }
 
   const hint = canSendReason ?? canSmsReason;
+  // When neither channel is available, printing is the only "I've
+  // sent" signal — surface a confirm that also flips status to
+  // invited so the record stays in sync with reality. Speakers with
+  // contact keep the plain print-only behavior (they can still use
+  // Send or Mark invited buttons explicitly).
+  const printTriggersMarkInvited = !canSend && !canSms;
+  const printHandler = printTriggersMarkInvited ? () => setPending("printAndMarkInvited") : onPrint;
 
   return (
     <div className="flex flex-col items-center gap-1">
@@ -72,7 +79,12 @@ export function PrepareInvitationActionBar({
         >
           <CheckIcon />
         </GroupBtn>
-        <GroupBtn position="mid" label="Print letter" onClick={onPrint} disabled={busy}>
+        <GroupBtn
+          position="mid"
+          label={printTriggersMarkInvited ? "Print letter and mark invited" : "Print letter"}
+          onClick={printHandler}
+          disabled={busy}
+        >
           <PrintIcon />
         </GroupBtn>
         <GroupBtn
@@ -116,6 +128,19 @@ export function PrepareInvitationActionBar({
         body={`${speakerName}'s status will be set to "invited" — no email is sent. Use this if you've already reached them another way (phone, in person, separate email).`}
         confirmLabel="Mark invited"
         onConfirm={() => confirm(onMarkInvited)}
+        onCancel={() => setPending(null)}
+      />
+      <ConfirmDialog
+        open={pending === "printAndMarkInvited"}
+        title="Print letter and mark as invited?"
+        body={`${speakerName} has no phone or email on file, so printing the letter is how you'll hand off this invitation. We'll open the print dialog now and set their status to "invited" so the schedule reflects that you've delivered it.`}
+        confirmLabel="Print & mark invited"
+        onConfirm={() =>
+          confirm(() => {
+            onPrint();
+            onMarkInvited();
+          })
+        }
         onCancel={() => setPending(null)}
       />
       <ConfirmDialog

--- a/src/features/templates/PrepareInvitationDialogs.tsx
+++ b/src/features/templates/PrepareInvitationDialogs.tsx
@@ -1,0 +1,110 @@
+import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
+import { SendChannelDialog } from "./SendChannelDialog";
+
+type PendingConfirm = "revert" | "markInvited" | "printAndMarkInvited" | null;
+type PendingSend = "email" | "sms" | null;
+
+interface Props {
+  pending: PendingConfirm;
+  pendingSend: PendingSend;
+  busy: boolean;
+  hasOverride: boolean;
+  speakerName: string;
+  speakerEmail: string;
+  speakerPhone: string;
+  onCancelPending: () => void;
+  onCancelPendingSend: () => void;
+  onRevert: () => void;
+  onMarkInvited: () => void;
+  onPrint: () => void;
+  onSend: (email: string) => void;
+  onSendSms: (phone: string) => void;
+}
+
+/** Extracts the five confirm / send-channel dialogs that the Prepare
+ *  Invitation action bar renders. Keeps the action bar focused on
+ *  button layout + state and under the 150-LOC file cap. */
+export function PrepareInvitationDialogs({
+  pending,
+  pendingSend,
+  busy,
+  hasOverride,
+  speakerName,
+  speakerEmail,
+  speakerPhone,
+  onCancelPending,
+  onCancelPendingSend,
+  onRevert,
+  onMarkInvited,
+  onPrint,
+  onSend,
+  onSendSms,
+}: Props) {
+  return (
+    <>
+      <ConfirmDialog
+        open={pending === "revert"}
+        title={hasOverride ? "Clear per-speaker override?" : "Revert to ward default?"}
+        body={
+          hasOverride
+            ? `This deletes ${speakerName}'s saved letter override and restores the ward default. Any unsaved edits in the editor are also discarded.`
+            : "This resets the editor to the ward default template. Any unsaved edits in the editor are discarded."
+        }
+        confirmLabel={hasOverride ? "Clear override" : "Revert"}
+        danger={hasOverride}
+        onConfirm={() => {
+          onCancelPending();
+          onRevert();
+        }}
+        onCancel={onCancelPending}
+      />
+      <ConfirmDialog
+        open={pending === "markInvited"}
+        title="Mark as invited without sending?"
+        body={`${speakerName}'s status will be set to "invited" — no email is sent. Use this if you've already reached them another way (phone, in person, separate email).`}
+        confirmLabel="Mark invited"
+        onConfirm={() => {
+          onCancelPending();
+          onMarkInvited();
+        }}
+        onCancel={onCancelPending}
+      />
+      <ConfirmDialog
+        open={pending === "printAndMarkInvited"}
+        title="Print letter and mark as invited?"
+        body={`${speakerName} has no phone or email on file, so printing the letter is how you'll hand off this invitation. We'll open the print dialog now and set their status to "invited" so the schedule reflects that you've delivered it.`}
+        confirmLabel="Print & mark invited"
+        onConfirm={() => {
+          onCancelPending();
+          onPrint();
+          onMarkInvited();
+        }}
+        onCancel={onCancelPending}
+      />
+      <SendChannelDialog
+        open={pendingSend === "email"}
+        channel="email"
+        speakerName={speakerName}
+        currentValue={speakerEmail}
+        busy={busy}
+        onCancel={onCancelPendingSend}
+        onConfirm={(email) => {
+          onCancelPendingSend();
+          onSend(email);
+        }}
+      />
+      <SendChannelDialog
+        open={pendingSend === "sms"}
+        channel="sms"
+        speakerName={speakerName}
+        currentValue={speakerPhone}
+        busy={busy}
+        onCancel={onCancelPendingSend}
+        onConfirm={(phone) => {
+          onCancelPendingSend();
+          onSendSms(phone);
+        }}
+      />
+    </>
+  );
+}

--- a/src/features/templates/SendChannelDialog.tsx
+++ b/src/features/templates/SendChannelDialog.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useState } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+import { isE164, toE164 } from "@/features/templates/smsInvitation";
+import { cn } from "@/lib/cn";
+import { isValidEmail } from "@/lib/email";
+
+export type ChannelKind = "email" | "sms";
+
+interface Props {
+  open: boolean;
+  channel: ChannelKind;
+  speakerName: string;
+  /** Current on-file value. The dialog prefills the input with it so
+   *  the bishop can confirm-as-is or tweak in place. Empty string is
+   *  fine — the dialog's "add" flow handles the new-value case. */
+  currentValue: string;
+  busy: boolean;
+  onCancel: () => void;
+  /** Called with the final value after client-side validation. The
+   *  parent is responsible for persisting it to the speaker doc (if
+   *  changed) and firing the actual send. */
+  onConfirm: (value: string) => void;
+}
+
+/** Combined input + send modal used by the Prepare Invitation action
+ *  bar. Replaces the earlier static-body ConfirmDialog for the email
+ *  and SMS actions so the bishop always reviews (and can edit) the
+ *  destination before anything fires — same UX whether the record has
+ *  a value on file or not. */
+export function SendChannelDialog({
+  open,
+  channel,
+  speakerName,
+  currentValue,
+  busy,
+  onCancel,
+  onConfirm,
+}: Props) {
+  useLockBodyScroll(open);
+  const [value, setValue] = useState(currentValue);
+  const [touched, setTouched] = useState(false);
+
+  // Re-seed the input when the dialog opens (or the underlying record
+  // changes). Without this, re-opening the dialog after a rename would
+  // show the stale last-typed value.
+  useEffect(() => {
+    if (!open) return;
+    setValue(currentValue);
+    setTouched(false);
+  }, [open, currentValue]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      onCancel();
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, onCancel]);
+
+  if (!open) return null;
+
+  const normalized = channel === "sms" ? toE164(value) : value.trim();
+  const valid = channel === "email" ? isValidEmail(normalized) : isE164(normalized);
+  const showInvalid = touched && normalized.length > 0 && !valid;
+  const disabled = busy || !valid;
+
+  const copy = channel === "email" ? EMAIL_COPY : SMS_COPY;
+
+  function submit() {
+    if (!valid) {
+      setTouched(true);
+      return;
+    }
+    onConfirm(normalized);
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="send-channel-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+        <h2
+          id="send-channel-title"
+          className="font-display text-[19px] font-semibold text-walnut mb-1.5"
+        >
+          {copy.title.replace("{name}", speakerName)}
+        </h2>
+        <p className="font-serif text-[13.5px] text-walnut-2 leading-relaxed mb-4">{copy.body}</p>
+        <label className="flex flex-col gap-1 mb-4">
+          <span className="font-mono text-[9.5px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+            {copy.label}
+          </span>
+          <input
+            type={channel === "email" ? "email" : "tel"}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={() => setTouched(true)}
+            placeholder={copy.placeholder}
+            autoFocus
+            disabled={busy}
+            aria-invalid={showInvalid}
+            className={cn(
+              "font-sans text-[13.5px] px-2.5 py-2 bg-chalk border border-border-strong rounded-md text-walnut w-full transition-colors focus:outline-none focus:border-bordeaux focus:ring-2 focus:ring-bordeaux/15 disabled:bg-parchment-2",
+              showInvalid && "border-bordeaux focus:border-bordeaux focus:ring-bordeaux/25",
+            )}
+          />
+          {showInvalid && (
+            <span className="font-sans text-[11.5px] text-bordeaux mt-0.5">{copy.invalid}</span>
+          )}
+        </label>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={disabled}
+            className="rounded-md border border-bordeaux bg-bordeaux px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-bordeaux-deep disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {busy ? "Sending…" : copy.confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const EMAIL_COPY = {
+  title: "Send email to {name}?",
+  body: "Confirm or update the email address. Any change is saved to the speaker record so all surfaces stay in sync.",
+  label: "Speaker email",
+  placeholder: "name@example.com",
+  invalid: "Enter a valid email address (e.g. name@example.com).",
+  confirmLabel: "Send email",
+};
+
+const SMS_COPY = {
+  title: "Text invitation to {name}?",
+  body: "Confirm or update the phone number. Any change is saved to the speaker record so all surfaces stay in sync.",
+  label: "Speaker phone",
+  placeholder: "+1 416 555 1234",
+  invalid: "Use international format: +1 then 10 digits, e.g. +14165551234.",
+  confirmLabel: "Send SMS",
+};

--- a/src/features/templates/usePrepareInvitationActions.ts
+++ b/src/features/templates/usePrepareInvitationActions.ts
@@ -68,15 +68,34 @@ export function usePrepareInvitationActions(args: Args) {
     }
   }
 
-  async function sendVia(channels: ("email" | "sms")[]): Promise<void> {
+  async function sendVia(
+    channels: ("email" | "sms")[],
+    contactOverride?: { email?: string; phone?: string },
+  ): Promise<void> {
+    // Persist a changed contact value before the send so the speaker
+    // doc stays the single source of truth. The callable receives the
+    // resolved (override ?? current) value directly to avoid racing
+    // against the Firestore subscription re-snapshotting our props.
+    const resolvedEmail = (contactOverride?.email ?? args.speakerEmail).trim();
+    const resolvedPhone = (contactOverride?.phone ?? args.speakerPhone).trim();
+    const contactPatch: { email?: string; phone?: string } = {};
+    if (contactOverride?.email && resolvedEmail !== args.speakerEmail.trim()) {
+      contactPatch.email = resolvedEmail;
+    }
+    if (contactOverride?.phone && resolvedPhone !== args.speakerPhone.trim()) {
+      contactPatch.phone = resolvedPhone;
+    }
+    if (contactPatch.email || contactPatch.phone) {
+      await updateSpeaker(args.wardId, args.date, args.speakerId, contactPatch);
+    }
     const res = await sendSpeakerInvitation({
       wardId: args.wardId,
       meetingDate: args.date,
       speakerId: args.speakerId,
       speakerName: args.speakerName,
       ...(args.speakerTopic.trim() ? { speakerTopic: args.speakerTopic.trim() } : {}),
-      speakerEmail: args.speakerEmail,
-      speakerPhone: args.speakerPhone,
+      speakerEmail: resolvedEmail,
+      speakerPhone: resolvedPhone,
       inviterName: args.inviterName,
       bishopReplyToEmail: bishopEmail,
       bodyMarkdown: form.letterBody,
@@ -97,7 +116,9 @@ export function usePrepareInvitationActions(args: Args) {
       void runAction(() =>
         updateSpeaker(args.wardId, args.date, args.speakerId, { status: "invited" }),
       ),
-    send: () => void runAction(() => sendVia(["email"])),
-    sendSms: () => void runAction(() => sendVia(["sms"])),
+    send: (email?: string) =>
+      void runAction(() => sendVia(["email"], email ? { email } : undefined)),
+    sendSms: (phone?: string) =>
+      void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
   };
 }

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,81 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface Options {
+  /** Milliseconds the user must hold before `onLongPress` fires.
+   *  Matches iOS Messages' 500ms default. */
+  duration?: number;
+  /** Fires once when the press has lasted `duration` ms without a
+   *  release or pointer-leave. The pointer event is consumed (no
+   *  click follows) so callers can safely open a menu. */
+  onLongPress: () => void;
+  /** When false, every event is a no-op — lets the caller cheaply
+   *  disable the gesture without unmounting the bound element. */
+  enabled?: boolean;
+}
+
+interface Result {
+  /** True from pointerdown until either the timer fires or the
+   *  press ends. UI uses this to show a hold-feedback indicator
+   *  (scale-down, ring, etc). */
+  pressing: boolean;
+  /** Spread onto the pressable element. Covers mouse + touch + pen
+   *  via the Pointer Events API. */
+  bind: {
+    onPointerDown: (e: React.PointerEvent) => void;
+    onPointerUp: () => void;
+    onPointerLeave: () => void;
+    onPointerCancel: () => void;
+    onContextMenu: (e: React.MouseEvent) => void;
+  };
+}
+
+/** Pointer-Events-based long-press detector. Returns a `pressing`
+ *  flag for live visual feedback and a `bind` object to spread onto
+ *  the target element. */
+export function useLongPress({ duration = 500, onLongPress, enabled = true }: Options): Result {
+  const [pressing, setPressing] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const firedRef = useRef(false);
+
+  const cancel = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    setPressing(false);
+  }, []);
+
+  useEffect(() => () => cancel(), [cancel]);
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (!enabled) return;
+      // Right- and middle-click shouldn't start a long-press.
+      if (e.pointerType === "mouse" && e.button !== 0) return;
+      firedRef.current = false;
+      setPressing(true);
+      timerRef.current = setTimeout(() => {
+        firedRef.current = true;
+        timerRef.current = null;
+        setPressing(false);
+        onLongPress();
+      }, duration);
+    },
+    [duration, enabled, onLongPress],
+  );
+
+  const onPointerUp = useCallback(() => cancel(), [cancel]);
+  const onPointerLeave = useCallback(() => cancel(), [cancel]);
+  const onPointerCancel = useCallback(() => cancel(), [cancel]);
+  const onContextMenu = useCallback((e: React.MouseEvent) => {
+    // Suppress the default browser context menu only when our own
+    // long-press just fired — leaves normal right-click behaviour
+    // intact for taps that didn't reach the threshold.
+    if (firedRef.current) e.preventDefault();
+  }, []);
+
+  return {
+    pressing,
+    bind: { onPointerDown, onPointerUp, onPointerLeave, onPointerCancel, onContextMenu },
+  };
+}

--- a/src/hooks/useMinuteTick.ts
+++ b/src/hooks/useMinuteTick.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+/** Returns the current epoch minute, ticking once a minute. Cheap
+ *  way to force consumers to re-render at minute granularity — used
+ *  for time-windowed UI like the 30-min edit/delete affordance,
+ *  where the gate must close even when nothing else changes. */
+export function useMinuteTick(): number {
+  const [minute, setMinute] = useState(() => Math.floor(Date.now() / 60_000));
+  useEffect(() => {
+    const id = setInterval(() => setMinute(Math.floor(Date.now() / 60_000)), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  return minute;
+}

--- a/src/lib/types/speakerInvitation.ts
+++ b/src/lib/types/speakerInvitation.ts
@@ -141,5 +141,14 @@ export const speakerInvitationSchema = z.object({
    *  the heartbeat is fresh the speaker is presumed to be looking at
    *  the chat live and we stay quiet. */
   speakerLastSeenAt: z.any().optional(),
+
+  /** Mirror of the underlying speaker doc's status, kept on the
+   *  invitation so the speaker-side page can render status-aware
+   *  copy without subscribing to the meeting-scoped speaker doc
+   *  (which the speaker's capability-token session can't read).
+   *  Written by the bishop's client when it applies a response or
+   *  changes status via the chat-banner pills. Absent on pre-rollout
+   *  invitations — the speaker page treats that as unchanged. */
+  currentSpeakerStatus: z.enum(["planned", "invited", "confirmed", "declined"]).optional(),
 });
 export type SpeakerInvitation = z.infer<typeof speakerInvitationSchema>;


### PR DESCRIPTION
Bundles eight UI polish asks from live testing into a single PR.

## What's in

| # | Ask | Where |
|---|---|---|
| 1 | Remove Speaker state radio group from Step 1 of the editor | [SpeakerEditCard.tsx](src/features/schedule/SpeakerEditCard.tsx) |
| 2 | Show "who planned / who invited" so the chat banner height stays stable across status transitions | [statusProvenance.ts](src/features/schedule/statusProvenance.ts) |
| 3 | Chat icon always clickable; empty-state placeholder when no invitation sent | [SpeakerRow.tsx](src/features/schedule/SpeakerRow.tsx) · [BishopInvitationDialog.tsx](src/features/invitations/BishopInvitationDialog.tsx) · new [NoInvitationPlaceholder.tsx](src/features/invitations/NoInvitationPlaceholder.tsx) |
| 4 | Drop the duplicate provenance line on the Sunday card (banner shows it) | [SpeakerRow.tsx](src/features/schedule/SpeakerRow.tsx) |
| 5 | Speaker-side "You accepted / declined" banner | new [SpeakerResponseBanner.tsx](src/features/invitations/SpeakerResponseBanner.tsx) · [SpeakerInvitationChat.tsx](src/features/invitations/SpeakerInvitationChat.tsx) · [invite-speaker.tsx](src/app/routes/invite-speaker.tsx) |
| 6 | Print + Save as PDF button → icon only | [invite-speaker-states.tsx](src/app/routes/invite-speaker-states.tsx) |
| 7 | Provenance-aware ConfirmDialog copy on status override | [SpeakerStatusPills.tsx](src/features/schedule/SpeakerStatusPills.tsx) · [InvitationStatusBanner.tsx](src/features/invitations/InvitationStatusBanner.tsx) · [BishopInvitationChat.tsx](src/features/invitations/BishopInvitationChat.tsx) |
| 8 | "Speaker is viewing the chat now" clears fast when the speaker actually closes the tab | [useSpeakerHeartbeat.ts](src/features/invitations/useSpeakerHeartbeat.ts) |

## Notable implementation calls

- **Ask 3**: `BishopInvitationDialog` now accepts nullable `invitation` + `invitationId`. When null, renders `NoInvitationPlaceholder` inside the dialog shell — same chrome, different body. Placeholder explains the limitation in plain English and surfaces `speaker.phone` / `speaker.email` as `tel:` / `mailto:` links if available; if no contact is on file, prompts to add some. The overflow three-dot menu is hidden when no invitation exists (nothing to resend).
- **Ask 7**: `SpeakerStatusPills` gains four optional props — `currentStatusSource`, `currentStatusSetBy`, `members`, `currentUserUid` — feeding a new pure `decorateConfirmCopy()` helper that prepends an override-context line to the base confirm body. Self-overrides are suppressed; "someone else" copy names them; "speaker set this" copy spells out that the override doesn't change the speaker's reply.
- **Ask 8**: `useSpeakerHeartbeat` now listens for `pagehide` + `visibilitychange → hidden` and writes `speakerLastSeenAt` with a 3-minute back-dated `Timestamp.fromMillis(...)`. Drops the bishop's "viewing now" badge immediately. No schema change.

## Structure / refactors for the 150-LOC cap
- Extracted `SpeakerChatHeader` + `SpeakerResponseBanner` out of `SpeakerInvitationChat`.
- `SpeakerStatusPills` keeps decoration helpers at the file bottom; file stays under cap.

## Test plan
- [x] `pnpm typecheck` · `pnpm lint` (0 errors) · `pnpm test` — 285/285
- [ ] Visual on the Vercel preview:
  - Speaker editor Step 1: no status radio, layout still looks right
  - Chat banner provenance line is always present (no layout shift)
  - Chat icon enabled for every speaker; placeholder shows the "contact directly" panel when no invitation sent
  - Print toolbar button is an icon-only square
  - Speaker invite page shows a green "You accepted" / red "You declined" banner after submission
  - Resize / restart a chat session to confirm the "viewing now" badge vanishes within a second of the speaker closing their tab
  - Status override dialog body changes wording when the current status was set by the speaker vs by another bishopric member vs by yourself
- [ ] Merge → cut v0.9.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)