### PR TITLE
fix: force Google account chooser on sign-in

### DIFF
--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -25,6 +25,10 @@ export const useAuthStore = create<AuthState>(() => ({
   status: "loading",
   signIn: async () => {
     const provider = new GoogleAuthProvider();
+    // Force the Google account chooser so users can switch accounts after
+    // signing out. Without this, Google silently reuses the existing
+    // browser session and re-authenticates the previous account.
+    provider.setCustomParameters({ prompt: "select_account" });
     await signInWithPopup(auth, provider);
   },
   signInWithEmail: async (email, password) => {


### PR DESCRIPTION
Signing out of Firebase doesn't end the underlying Google session, so
signInWithPopup was silently re-authenticating the previous account.
Setting prompt=select_account forces the chooser every time, letting
users switch accounts after signing out.