### PR TITLE
chore(vercel): only build on main to stay under daily deploy cap

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
   "installCommand": "pnpm install --frozen-lockfile",
   "buildCommand": "pnpm run build",
   "outputDirectory": "dist",
+  "ignoreCommand": "test \"$VERCEL_GIT_COMMIT_REF\" != \"main\"",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
## Summary

Vercel's free tier caps automatic deploys at **100/day**. Pushes to `develop` and feature branches kept burning through this budget on preview deploys we don't use — which is what blocked the v0.10.1 production deploy today.

This adds an `ignoreCommand` to `vercel.json` that returns exit 0 (skip build) for every git ref except `main`, so:

| Branch / ref | Result |
| --- | --- |
| `main` | Builds and deploys to production |
| `develop` | Skipped |
| `chore/*`, `claude/*`, any feature branch | Skipped |

The `develop → main` release merge still triggers exactly one production build, which is the only deploy we ever actually need.

## Caveats

- **Skipped deployments still appear in the Vercel dashboard** (marked "Ignored"). Per Vercel's docs they don't run the build, so they shouldn't consume build minutes; whether they count toward the daily-deployment cap is undocumented. If we still hit the cap after this lands, the next step is to disable the GitHub integration in Vercel's project settings entirely and rely solely on the production build.
- **No more PR preview URLs.** You said you don't use them — flag this if that changes.

## Test plan

- [ ] Push to a non-main branch (e.g. this PR) → confirm Vercel marks the deployment "Ignored" and doesn't burn a build slot
- [ ] Next `develop → main` release merge → confirm production deploy fires as usual

---
_Generated by [Claude Code](https://claude.ai/code/session_015Eod8RqV4j3gvmm94Frw4x)_