### PR TITLE
feat(editors): playground-style floating selection toolbar (Phase 0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
+    "@lexical/link": "^0.43.0",
     "@lexical/list": "^0.43.0",
     "@lexical/markdown": "^0.43.0",
     "@lexical/react": "^0.43.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.72.1(react@19.2.5))
+      '@lexical/link':
+        specifier: ^0.43.0
+        version: 0.43.0
       '@lexical/list':
         specifier: ^0.43.0
         version: 0.43.0

--- a/src/features/program-templates/FloatingSelectionToolbar.tsx
+++ b/src/features/program-templates/FloatingSelectionToolbar.tsx
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { mergeRegister } from "@lexical/utils";
+import {
+  $getSelection,
+  $isRangeSelection,
+  COMMAND_PRIORITY_LOW,
+  SELECTION_CHANGE_COMMAND,
+} from "lexical";
+import { $isLinkNode } from "@lexical/link";
+import { type ActiveFormats, EMPTY_FORMATS, ToolbarButtons } from "./floatingToolbarButtons";
+
+const VERTICAL_GAP = 10;
+const VIEWPORT_PADDING = 8;
+const FALLBACK_HEIGHT = 36;
+const FALLBACK_WIDTH = 320;
+
+/** Floating selection toolbar that appears above a non-collapsed text
+ *  selection, à la the Lexical playground. Mounted as a Lexical
+ *  plugin so it can read selection state directly; rendered via a
+ *  portal at `document.body` so it isn't clipped by the editor's
+ *  scroll container. Mount alongside `LinkPlugin` so the link button
+ *  has a target for `TOGGLE_LINK_COMMAND`. */
+export function FloatingSelectionToolbar() {
+  const [editor] = useLexicalComposerContext();
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+  const [active, setActive] = useState<ActiveFormats>(EMPTY_FORMATS);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const update = useCallback(() => {
+    const sel = $getSelection();
+    if (!$isRangeSelection(sel) || sel.isCollapsed()) {
+      setPos(null);
+      return;
+    }
+    const native = window.getSelection();
+    if (!native || native.rangeCount === 0 || native.isCollapsed) {
+      setPos(null);
+      return;
+    }
+    const rect = native.getRangeAt(0).getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      setPos(null);
+      return;
+    }
+    const tw = ref.current?.offsetWidth ?? FALLBACK_WIDTH;
+    const th = ref.current?.offsetHeight ?? FALLBACK_HEIGHT;
+    const left = Math.max(
+      VIEWPORT_PADDING,
+      Math.min(window.innerWidth - tw - VIEWPORT_PADDING, rect.left + rect.width / 2 - tw / 2),
+    );
+    const top = rect.top - th - VERTICAL_GAP;
+    setPos({ top: top < VIEWPORT_PADDING ? rect.bottom + VERTICAL_GAP : top, left });
+    const node = sel.anchor.getNode();
+    const parent = node.getParent();
+    setActive({
+      bold: sel.hasFormat("bold"),
+      italic: sel.hasFormat("italic"),
+      underline: sel.hasFormat("underline"),
+      strikethrough: sel.hasFormat("strikethrough"),
+      subscript: sel.hasFormat("subscript"),
+      superscript: sel.hasFormat("superscript"),
+      code: sel.hasFormat("code"),
+      link: $isLinkNode(parent) || $isLinkNode(node),
+    });
+  }, []);
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerUpdateListener(({ editorState }) => editorState.read(update)),
+      editor.registerCommand(
+        SELECTION_CHANGE_COMMAND,
+        () => {
+          update();
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [editor, update]);
+
+  useEffect(() => {
+    if (!pos) return;
+    const onScroll = () => editor.getEditorState().read(update);
+    window.addEventListener("scroll", onScroll, true);
+    window.addEventListener("resize", onScroll);
+    return () => {
+      window.removeEventListener("scroll", onScroll, true);
+      window.removeEventListener("resize", onScroll);
+    };
+  }, [pos, editor, update]);
+
+  if (!pos) return null;
+  return createPortal(
+    <div
+      ref={ref}
+      role="toolbar"
+      aria-label="Text formatting"
+      style={{ top: pos.top, left: pos.left }}
+      className="fixed z-50 inline-flex items-center rounded-full border border-border-strong bg-chalk shadow-elev-3 px-1 py-1 gap-0.5"
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      <ToolbarButtons editor={editor} active={active} />
+    </div>,
+    document.body,
+  );
+}

--- a/src/features/program-templates/ProgramTemplateEditor.tsx
+++ b/src/features/program-templates/ProgramTemplateEditor.tsx
@@ -4,10 +4,13 @@ import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { LinkNode } from "@lexical/link";
 import { ListItemNode, ListNode } from "@lexical/list";
+import { FloatingSelectionToolbar } from "./FloatingSelectionToolbar";
 import { lexicalTheme } from "./lexicalTheme";
 import { ProgramToolbar } from "./ProgramToolbar";
 import { GROUP_LABEL, PROGRAM_VARIABLES } from "./programVariables";
@@ -25,7 +28,7 @@ interface Props {
   ariaLabel: string;
 }
 
-const NODES = [HeadingNode, QuoteNode, ListNode, ListItemNode, VariableChipNode];
+const NODES = [HeadingNode, QuoteNode, ListNode, ListItemNode, LinkNode, VariableChipNode];
 
 /** Headless Lexical editor pre-wired for program templates: rich-text
  *  + lists + history + variable chips. Wrap-and-go — the host page
@@ -67,6 +70,8 @@ export function ProgramTemplateEditor({ initialStateJson, onChange, ariaLabel }:
         </div>
         <HistoryPlugin />
         <ListPlugin />
+        <LinkPlugin />
+        <FloatingSelectionToolbar />
         <StateJsonOnChangePlugin onChange={onChange} />
       </LexicalComposer>
     </div>

--- a/src/features/program-templates/floatingToolbarButtons.tsx
+++ b/src/features/program-templates/floatingToolbarButtons.tsx
@@ -1,0 +1,152 @@
+import type { LexicalEditor, TextFormatType } from "lexical";
+import { FORMAT_TEXT_COMMAND } from "lexical";
+import { TOGGLE_LINK_COMMAND } from "@lexical/link";
+import { cn } from "@/lib/cn";
+
+export interface ActiveFormats {
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
+  subscript: boolean;
+  superscript: boolean;
+  code: boolean;
+  link: boolean;
+}
+
+export const EMPTY_FORMATS: ActiveFormats = {
+  bold: false,
+  italic: false,
+  underline: false,
+  strikethrough: false,
+  subscript: false,
+  superscript: false,
+  code: false,
+  link: false,
+};
+
+interface ToolbarButtonsProps {
+  editor: LexicalEditor;
+  active: ActiveFormats;
+}
+
+/** The button row inside the floating toolbar. Pulled out of the
+ *  positioning shell so the shell file stays under the 150-LOC cap. */
+export function ToolbarButtons({ editor, active }: ToolbarButtonsProps) {
+  const fmt = (type: TextFormatType) => editor.dispatchCommand(FORMAT_TEXT_COMMAND, type);
+  return (
+    <>
+      <FmtBtn
+        label="Bold"
+        active={active.bold}
+        className="font-semibold"
+        onClick={() => fmt("bold")}
+      >
+        B
+      </FmtBtn>
+      <FmtBtn
+        label="Italic"
+        active={active.italic}
+        className="italic"
+        onClick={() => fmt("italic")}
+      >
+        I
+      </FmtBtn>
+      <FmtBtn
+        label="Underline"
+        active={active.underline}
+        className="underline"
+        onClick={() => fmt("underline")}
+      >
+        U
+      </FmtBtn>
+      <FmtBtn
+        label="Strikethrough"
+        active={active.strikethrough}
+        className="line-through"
+        onClick={() => fmt("strikethrough")}
+      >
+        S
+      </FmtBtn>
+      <Sep />
+      <FmtBtn label="Subscript" active={active.subscript} onClick={() => fmt("subscript")}>
+        X<sub className="text-[8px]">2</sub>
+      </FmtBtn>
+      <FmtBtn label="Superscript" active={active.superscript} onClick={() => fmt("superscript")}>
+        X<sup className="text-[8px]">2</sup>
+      </FmtBtn>
+      <Sep />
+      <FmtBtn
+        label="Inline code"
+        active={active.code}
+        className="font-mono text-[11px]"
+        onClick={() => fmt("code")}
+      >
+        {"</>"}
+      </FmtBtn>
+      <FmtBtn label="Link" active={active.link} onClick={() => toggleLink(editor, active.link)}>
+        <LinkIcon />
+      </FmtBtn>
+    </>
+  );
+}
+
+function toggleLink(editor: LexicalEditor, hasLink: boolean) {
+  if (hasLink) {
+    editor.dispatchCommand(TOGGLE_LINK_COMMAND, null);
+    return;
+  }
+  const url = window.prompt("Link URL", "https://");
+  if (!url) return;
+  editor.dispatchCommand(TOGGLE_LINK_COMMAND, url);
+}
+
+interface FmtBtnProps {
+  label: string;
+  active?: boolean;
+  className?: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}
+
+function FmtBtn({ label, active, className, onClick, children }: FmtBtnProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      aria-pressed={active}
+      title={label}
+      onClick={onClick}
+      className={cn(
+        "h-7 min-w-7 px-1.5 rounded-full grid place-items-center text-[12.5px] text-walnut hover:bg-parchment-2 transition-colors",
+        active && "bg-walnut text-parchment hover:bg-walnut-2 hover:text-parchment",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Sep() {
+  return <span aria-hidden className="mx-0.5 w-px h-4 bg-border" />;
+}
+
+function LinkIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}

--- a/src/features/templates/MarkdownEditor.tsx
+++ b/src/features/templates/MarkdownEditor.tsx
@@ -4,9 +4,11 @@ import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
 import { ContentEditable } from "@lexical/react/LexicalContentEditable";
 import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
 import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
 import { ListPlugin } from "@lexical/react/LexicalListPlugin";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { LinkNode } from "@lexical/link";
 import { ListItemNode, ListNode } from "@lexical/list";
 import {
   $convertFromMarkdownString,
@@ -14,6 +16,7 @@ import {
   TRANSFORMERS,
   type Transformer,
 } from "@lexical/markdown";
+import { FloatingSelectionToolbar } from "@/features/program-templates/FloatingSelectionToolbar";
 import { lexicalTheme } from "@/features/program-templates/lexicalTheme";
 import { ProgramToolbar } from "@/features/program-templates/ProgramToolbar";
 import type { ProgramVariable } from "@/features/program-templates/programVariables";
@@ -33,7 +36,7 @@ interface Props {
   placeholder?: string;
 }
 
-const NODES = [HeadingNode, QuoteNode, ListNode, ListItemNode, VariableChipNode];
+const NODES = [HeadingNode, QuoteNode, ListNode, ListItemNode, LinkNode, VariableChipNode];
 const ALL_TRANSFORMERS: Transformer[] = [VARIABLE_CHIP_MARKDOWN_TRANSFORMER, ...TRANSFORMERS];
 
 /** Canonical markdown editor for the app — Lexical inside, plain
@@ -90,6 +93,8 @@ export function MarkdownEditor({
         </div>
         <HistoryPlugin />
         <ListPlugin />
+        <LinkPlugin />
+        <FloatingSelectionToolbar />
         <MarkdownOnChange onChange={onChange} />
       </LexicalComposer>
     </div>


### PR DESCRIPTION
## Summary
- Phase 0 of the WYSIWYG case study (plan: \`/Users/oriel/.claude/plans/i-think-we-must-mellow-harp.md\`).
- New \`FloatingSelectionToolbar\` plugin: pill-shaped, portal-mounted at \`document.body\`, listens to \`SELECTION_CHANGE_COMMAND\`. Buttons: B / I / U / S, sub / sup, inline code, link toggle. Active states reflect via \`sel.hasFormat(...)\` + \`\$isLinkNode(...)\`. Repositions on scroll/resize, flips below selection when there's no room above.
- Wires \`@lexical/link\` (LinkNode + LinkPlugin) into both \`MarkdownEditor\` and \`ProgramTemplateEditor\` so the link button has a target for \`TOGGLE_LINK_COMMAND\`.
- Helpers split into \`floatingToolbarButtons.tsx\` so each file stays under the 150-LOC cap.

Self-contained — works on today's editors as-is, ahead of the larger framework migration in Phase 1.

## Test plan
- [ ] Highlight text in \`/settings/templates/speaker-letter\` → toolbar appears, all buttons toggle, link prompt round-trips.
- [ ] Same on \`/settings/templates/programs\`.
- [ ] Same in the wizard's Review-letter step.
- [ ] Scroll the editor with a live selection → toolbar follows.
- [ ] Click outside → toolbar disappears.
- [ ] No regression in 311 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)