### PR TITLE
feat(page-editor): WYSIWYG speaker-letter editor (Phase 1)

### DIFF
--- a/e2e/emulators/wysiwyg-letter-persist.spec.ts
+++ b/e2e/emulators/wysiwyg-letter-persist.spec.ts
@@ -1,0 +1,121 @@
+import { expect, test } from "@playwright/test";
+
+const PROJECT = process.env.FIREBASE_PROJECT ?? "demo-steward";
+const AUTH_HOST = "127.0.0.1:9099";
+const FIRESTORE_HOST = "127.0.0.1:8080";
+const FAKE_API_KEY = "fake-api-key";
+
+// Unique per-run identifiers so this test runs against a live shared
+// emulator without wiping the developer's existing state. Pulled into
+// the spec file (rather than the shared global-setup) precisely for
+// that property.
+const STAMP = `${Date.now()}`;
+const TEST_EMAIL = `e2e-letter-${STAMP}@e2e.local`;
+const TEST_PASSWORD = "test1234";
+const TEST_WARD_ID = `e2e-letter-${STAMP}`;
+const TYPE_MARKER = ` PERSIST-${STAMP}`;
+
+function fsValue(v: unknown): unknown {
+  if (typeof v === "string") return { stringValue: v };
+  if (typeof v === "boolean") return { booleanValue: v };
+  if (typeof v === "number") return { integerValue: v };
+  if (Array.isArray(v)) return { arrayValue: { values: v.map(fsValue) } };
+  if (v && typeof v === "object") {
+    const fields: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) fields[k] = fsValue(val);
+    return { mapValue: { fields } };
+  }
+  if (v == null) return { nullValue: null };
+  throw new Error(`unsupported value: ${typeof v}`);
+}
+
+async function writeDoc(path: string, data: Record<string, unknown>): Promise<void> {
+  const fields: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data)) fields[k] = fsValue(v);
+  const url = `http://${FIRESTORE_HOST}/v1/projects/${PROJECT}/databases/(default)/documents/${path}`;
+  // The `owner` bearer token bypasses Firestore security rules in the
+  // emulator — required so we can seed bootstrap docs (ward,
+  // member-self) that the deployed rules forbid creating from the
+  // client. Same trick the firebase-tools CLI uses internally.
+  const resp = await fetch(url, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", authorization: "Bearer owner" },
+    body: JSON.stringify({ fields }),
+  });
+  if (!resp.ok) throw new Error(`writeDoc ${path} failed: ${resp.status} ${await resp.text()}`);
+}
+
+async function signUpUniqueUser(): Promise<{ uid: string }> {
+  const resp = await fetch(
+    `http://${AUTH_HOST}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${FAKE_API_KEY}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        email: TEST_EMAIL,
+        password: TEST_PASSWORD,
+        returnSecureToken: true,
+      }),
+    },
+  );
+  if (!resp.ok) throw new Error(`signUp failed: ${resp.status} ${await resp.text()}`);
+  const data = (await resp.json()) as { localId: string };
+  return { uid: data.localId };
+}
+
+test.describe("speaker-letter WYSIWYG persistence", () => {
+  test.beforeAll(async () => {
+    const user = await signUpUniqueUser();
+    await writeDoc(`wards/${TEST_WARD_ID}`, {
+      name: "Persistence Test Ward",
+      settings: {
+        timezone: "UTC",
+        speakerLeadTimeDays: 14,
+        scheduleHorizonWeeks: 4,
+        nonMeetingSundays: [],
+        nudgeSchedule: {
+          wednesday: { enabled: true, hour: 19 },
+          friday: { enabled: true, hour: 19 },
+          saturday: { enabled: false, hour: 9 },
+        },
+        emailCcDefaults: {},
+      },
+    });
+    await writeDoc(`wards/${TEST_WARD_ID}/members/${user.uid}`, {
+      email: TEST_EMAIL,
+      displayName: "Persistence Test Bishop",
+      calling: "bishop",
+      role: "bishopric",
+      active: true,
+      ccOnEmails: true,
+      fcmTokens: [],
+    });
+  });
+
+  test("typed content survives a save + page reload", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByTestId("e2e-email").fill(TEST_EMAIL);
+    await page.getByTestId("e2e-password").fill(TEST_PASSWORD);
+    await page.getByTestId("e2e-signin").click();
+    await expect(page).toHaveURL(/\/schedule$/, { timeout: 10_000 });
+
+    await page.goto("/settings/templates/speaker-letter");
+    const editor = page.getByRole("textbox", { name: "Speaker invitation letter" });
+    await expect(editor).toBeVisible();
+
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.type(TYPE_MARKER);
+
+    const save = page.getByRole("button", { name: "Save changes" });
+    await expect(save).toBeEnabled({ timeout: 5_000 });
+    await save.click();
+    await expect(page.getByText(/^Saved · /)).toBeVisible({ timeout: 10_000 });
+
+    await page.reload();
+
+    const reloaded = page.getByRole("textbox", { name: "Speaker invitation letter" });
+    await expect(reloaded).toBeVisible();
+    await expect(reloaded).toContainText(TYPE_MARKER, { timeout: 10_000 });
+  });
+});

--- a/e2e/emulators/wysiwyg-letter-slash.spec.ts
+++ b/e2e/emulators/wysiwyg-letter-slash.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from "@playwright/test";
+
+const PROJECT = process.env.FIREBASE_PROJECT ?? "demo-steward";
+const AUTH_HOST = "127.0.0.1:9099";
+const FIRESTORE_HOST = "127.0.0.1:8080";
+const FAKE_API_KEY = "fake-api-key";
+
+const STAMP = `${Date.now()}`;
+const TEST_EMAIL = `e2e-slash-${STAMP}@e2e.local`;
+const TEST_PASSWORD = "test1234";
+const TEST_WARD_ID = `e2e-slash-${STAMP}`;
+
+function fsValue(v: unknown): unknown {
+  if (typeof v === "string") return { stringValue: v };
+  if (typeof v === "boolean") return { booleanValue: v };
+  if (typeof v === "number") return { integerValue: v };
+  if (Array.isArray(v)) return { arrayValue: { values: v.map(fsValue) } };
+  if (v && typeof v === "object") {
+    const fields: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) fields[k] = fsValue(val);
+    return { mapValue: { fields } };
+  }
+  if (v == null) return { nullValue: null };
+  throw new Error(`unsupported value: ${typeof v}`);
+}
+
+async function writeDoc(path: string, data: Record<string, unknown>): Promise<void> {
+  const fields: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(data)) fields[k] = fsValue(v);
+  const url = `http://${FIRESTORE_HOST}/v1/projects/${PROJECT}/databases/(default)/documents/${path}`;
+  const resp = await fetch(url, {
+    method: "PATCH",
+    headers: { "content-type": "application/json", authorization: "Bearer owner" },
+    body: JSON.stringify({ fields }),
+  });
+  if (!resp.ok) throw new Error(`writeDoc ${path} failed: ${resp.status} ${await resp.text()}`);
+}
+
+async function signUpUser(): Promise<{ uid: string }> {
+  const resp = await fetch(
+    `http://${AUTH_HOST}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${FAKE_API_KEY}`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: TEST_EMAIL, password: TEST_PASSWORD, returnSecureToken: true }),
+    },
+  );
+  if (!resp.ok) throw new Error(`signUp failed: ${resp.status} ${await resp.text()}`);
+  const data = (await resp.json()) as { localId: string };
+  return { uid: data.localId };
+}
+
+test.describe("speaker-letter slash command palette", () => {
+  test.beforeAll(async () => {
+    const user = await signUpUser();
+    await writeDoc(`wards/${TEST_WARD_ID}`, {
+      name: "Slash Test Ward",
+      settings: {
+        timezone: "UTC",
+        speakerLeadTimeDays: 14,
+        scheduleHorizonWeeks: 4,
+        nonMeetingSundays: [],
+        nudgeSchedule: {
+          wednesday: { enabled: true, hour: 19 },
+          friday: { enabled: true, hour: 19 },
+          saturday: { enabled: false, hour: 9 },
+        },
+        emailCcDefaults: {},
+      },
+    });
+    await writeDoc(`wards/${TEST_WARD_ID}/members/${user.uid}`, {
+      email: TEST_EMAIL,
+      displayName: "Slash Test Bishop",
+      calling: "bishop",
+      role: "bishopric",
+      active: true,
+      ccOnEmails: true,
+      fcmTokens: [],
+    });
+  });
+
+  test("typing / opens the palette and Enter inserts a divider", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByTestId("e2e-email").fill(TEST_EMAIL);
+    await page.getByTestId("e2e-password").fill(TEST_PASSWORD);
+    await page.getByTestId("e2e-signin").click();
+    await expect(page).toHaveURL(/\/schedule$/, { timeout: 10_000 });
+
+    await page.goto("/settings/templates/speaker-letter");
+    const editor = page.getByRole("textbox", { name: "Speaker invitation letter" });
+    await expect(editor).toBeVisible();
+
+    // Click into the editor, jump to end, then start a new paragraph
+    // and trigger the slash menu.
+    await editor.click();
+    await page.keyboard.press("End");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("/divider");
+
+    // The typeahead menu appears as a dialog-flavored portal — wait
+    // for at least one menu item titled "Divider" (in case the
+    // typeahead's a11y role differs across versions, fall back to
+    // the literal label).
+    await expect(page.getByText("Divider", { exact: true }).first()).toBeVisible({
+      timeout: 5_000,
+    });
+    await page.keyboard.press("Enter");
+
+    // After insertion the editor should contain an <hr>.
+    const hrCount = await editor.locator("hr").count();
+    expect(hrCount).toBeGreaterThan(0);
+  });
+});

--- a/e2e/helpers/seed.ts
+++ b/e2e/helpers/seed.ts
@@ -4,7 +4,13 @@
 // Assumes both emulators are running on their default ports (Auth :9099 and
 // Firestore :8080) under project id 'demo-steward'.
 
-const PROJECT = "demo-steward";
+// Project ID defaults to `demo-steward` to match the firebase
+// emulators:exec wrapper in `pnpm test:e2e:emulators`. When a developer
+// already has emulators running under a different project ID (e.g.
+// the dev server's `steward-dev-…` project), they can override via
+// `FIREBASE_PROJECT=…` so seeding targets the live emulator instead
+// of starting a fresh one.
+const PROJECT = process.env.FIREBASE_PROJECT ?? "demo-steward";
 const AUTH_HOST = "127.0.0.1:9099";
 const FIRESTORE_HOST = "127.0.0.1:8080";
 const FAKE_API_KEY = "fake-api-key";

--- a/playwright.iterate.config.ts
+++ b/playwright.iterate.config.ts
@@ -14,7 +14,7 @@ const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: "./e2e/emulators",
-  testMatch: /wysiwyg-letter-persist\.spec\.ts$/,
+  testMatch: /wysiwyg-.*\.spec\.ts$/,
   fullyParallel: false,
   forbidOnly: false,
   retries: 0,

--- a/playwright.iterate.config.ts
+++ b/playwright.iterate.config.ts
@@ -1,0 +1,28 @@
+// One-off Playwright config for iterating against an already-running
+// `pnpm dev` server + already-running Firebase emulators. The spec
+// under e2e/emulators/wysiwyg-letter-persist.spec.ts seeds its own
+// unique ward + user via the emulator REST APIs so we don't trample
+// the developer's existing Firestore state.
+//
+// Usage: `FIREBASE_PROJECT=<projectId> pnpm exec playwright test \
+//   --config playwright.iterate.config.ts wysiwyg-letter-persist`
+
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 5173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e/emulators",
+  testMatch: /wysiwyg-letter-persist\.spec\.ts$/,
+  fullyParallel: false,
+  forbidOnly: false,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/src/app/routes/templates-speaker-letter.tsx
+++ b/src/app/routes/templates-speaker-letter.tsx
@@ -1,31 +1,16 @@
-import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
-import {
-  DEFAULT_SPEAKER_LETTER_BODY,
-  DEFAULT_SPEAKER_LETTER_FOOTER,
-} from "@/features/templates/speakerLetterDefaults";
-import { useSpeakerLetterTemplate } from "@/features/templates/useSpeakerLetterTemplate";
-import { writeSpeakerLetterTemplate } from "@/features/templates/writeSpeakerLetterTemplate";
 import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
+import { useSpeakerLetterTemplateEditor } from "@/features/page-editor/useSpeakerLetterTemplateEditor";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useWardSettings } from "@/hooks/useWardSettings";
-import { useCurrentWardStore } from "@/stores/currentWardStore";
-import { friendlyWriteError } from "@/stores/saveStatusStore";
 
-const SAMPLE_VARS = {
-  speakerName: "Sebastian Tan",
-  topic: "Repentance",
+const SAMPLE = {
   date: "Sunday, April 26, 2026",
   today: "April 21, 2026",
-  inviterName: "Bishop Paul",
 };
-
-function nowLabel(): string {
-  return new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-}
 
 /** Speaker-letter template editor — Word-style WYSIWYG, single
  *  canvas. The editor IS the page: chrome (ornament, eyebrow, title,
@@ -35,72 +20,20 @@ function nowLabel(): string {
  *  persist/discard/status. */
 export function SpeakerLetterTemplatePage(): React.ReactElement {
   useFullViewportLayout();
-  const wardId = useCurrentWardStore((s) => s.wardId);
   const ward = useWardSettings();
   const me = useCurrentMember();
-  const { data: template, loading } = useSpeakerLetterTemplate();
-
-  const [stateJson, setStateJson] = useState<string | null>(null);
-  const [savedJson, setSavedJson] = useState<string | null>(null);
-  const [seeded, setSeeded] = useState(false);
-  const [editorKey, setEditorKey] = useState(0);
-  const [usingDefault, setUsingDefault] = useState(true);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedAt, setSavedAt] = useState<string | null>(null);
-
-  const initialMarkdown = useMemo(
-    () => ({
-      bodyMarkdown: template?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
-      footerMarkdown: template?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
-    }),
-    [template?.bodyMarkdown, template?.footerMarkdown],
-  );
-  const initialJson = template?.editorStateJson ?? null;
-
-  useEffect(() => {
-    if (loading || seeded) return;
-    setSavedJson(initialJson);
-    setStateJson(initialJson);
-    setUsingDefault(!template);
-    setSeeded(true);
-  }, [loading, seeded, template, initialJson]);
-
+  const editor = useSpeakerLetterTemplateEditor();
   const canEdit = Boolean(me?.data.active);
   const wardName = ward.data?.name ?? "";
-
-  const dirty = stateJson !== savedJson && stateJson !== null;
-
-  async function save() {
-    if (!wardId || !stateJson) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await writeSpeakerLetterTemplate(wardId, { editorStateJson: stateJson });
-      setSavedJson(stateJson);
-      setUsingDefault(false);
-      setSavedAt(nowLabel());
-    } catch (e) {
-      setError(friendlyWriteError(e));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function discard() {
-    setStateJson(savedJson);
-    setEditorKey((k) => k + 1);
-    setError(null);
-  }
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
       <PrintOnlyLetter
         wardName={wardName}
-        assignedDate={SAMPLE_VARS.date}
-        today={SAMPLE_VARS.today}
-        bodyMarkdown={initialMarkdown.bodyMarkdown}
-        footerMarkdown={initialMarkdown.footerMarkdown}
+        assignedDate={SAMPLE.date}
+        today={SAMPLE.today}
+        bodyMarkdown={editor.initialMarkdown.bodyMarkdown}
+        footerMarkdown={editor.initialMarkdown.footerMarkdown}
       />
       <header className="shrink-0 border-b border-border bg-chalk px-5 sm:px-8 py-4 flex items-center justify-between gap-4">
         <div className="flex flex-col gap-1 min-w-0">
@@ -115,7 +48,7 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
           </h1>
         </div>
         <div className="flex items-center gap-2">
-          {usingDefault && (
+          {editor.usingDefault && (
             <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-brass-soft bg-brass-soft/30 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep">
               <span aria-hidden>★</span>
               System default — save to lock in
@@ -132,16 +65,17 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
       </header>
 
       <div className="flex-1 lg:min-h-0 overflow-y-auto bg-parchment py-8 px-4 sm:px-8 pb-24">
-        {seeded && (
+        {editor.seeded && (
           <LetterPageEditor
-            key={editorKey}
+            key={editor.editorKey}
             wardName={wardName}
-            today={SAMPLE_VARS.today}
-            assignedDate={SAMPLE_VARS.date}
-            initialJson={initialJson}
-            initialMarkdown={initialMarkdown}
-            pageStyle={template?.pageStyle ?? undefined}
-            onChange={setStateJson}
+            today={SAMPLE.today}
+            assignedDate={SAMPLE.date}
+            initialJson={editor.initialJson}
+            initialMarkdown={editor.initialMarkdown}
+            pageStyle={editor.initialPageStyle ?? undefined}
+            onChange={editor.setStateJson}
+            onPageStyleChange={canEdit ? editor.setPageStyle : undefined}
             ariaLabel="Speaker invitation letter"
             editorDisabled={!canEdit}
           />
@@ -149,12 +83,12 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
       </div>
 
       <SaveBar
-        dirty={dirty && canEdit}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={discard}
-        onSave={() => void save()}
+        dirty={editor.dirty && canEdit}
+        saving={editor.saving}
+        savedAt={editor.savedAt}
+        error={editor.error}
+        onDiscard={editor.discard}
+        onSave={() => void editor.save()}
       />
     </main>
   );

--- a/src/app/routes/templates-speaker-letter.tsx
+++ b/src/app/routes/templates-speaker-letter.tsx
@@ -75,6 +75,7 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
             initialMarkdown={editor.initialMarkdown}
             pageStyle={editor.initialPageStyle ?? undefined}
             onChange={editor.setStateJson}
+            onInitial={editor.captureInitial}
             onPageStyleChange={canEdit ? editor.setPageStyle : undefined}
             ariaLabel="Speaker invitation letter"
             editorDisabled={!canEdit}

--- a/src/app/routes/templates-speaker-letter.tsx
+++ b/src/app/routes/templates-speaker-letter.tsx
@@ -3,20 +3,19 @@ import { Link } from "react-router";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
-import { interpolate } from "@/features/templates/interpolate";
 import {
   DEFAULT_SPEAKER_LETTER_BODY,
   DEFAULT_SPEAKER_LETTER_FOOTER,
 } from "@/features/templates/speakerLetterDefaults";
 import { useSpeakerLetterTemplate } from "@/features/templates/useSpeakerLetterTemplate";
 import { writeSpeakerLetterTemplate } from "@/features/templates/writeSpeakerLetterTemplate";
-import { SpeakerLetterPanel } from "@/features/speaker-letter-template/SpeakerLetterPanel";
+import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
 
-const PREVIEW_VARS = {
+const SAMPLE_VARS = {
   speakerName: "Sebastian Tan",
   topic: "Repentance",
   date: "Sunday, April 26, 2026",
@@ -28,11 +27,12 @@ function nowLabel(): string {
   return new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }
 
-/** Standalone speaker-letter template editor — Lexical-powered, in
- *  parity with the sacrament-meeting program template page. Loads the
- *  ward template; falls back to the system defaults so a brand-new
- *  ward sees a sensible printed letter. SaveBar handles persist /
- *  discard / status. */
+/** Speaker-letter template editor — Word-style WYSIWYG, single
+ *  canvas. The editor IS the page: chrome (ornament, eyebrow, title,
+ *  date) renders around the contenteditable, and the bishop authors
+ *  greeting + body + assigned-Sunday callout + signature + closing
+ *  scripture all in one continuous flow. SaveBar handles
+ *  persist/discard/status. */
 export function SpeakerLetterTemplatePage(): React.ReactElement {
   useFullViewportLayout();
   const wardId = useCurrentWardStore((s) => s.wardId);
@@ -40,51 +40,44 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
   const me = useCurrentMember();
   const { data: template, loading } = useSpeakerLetterTemplate();
 
-  const [body, setBody] = useState(DEFAULT_SPEAKER_LETTER_BODY);
-  const [footer, setFooter] = useState(DEFAULT_SPEAKER_LETTER_FOOTER);
-  const [savedBody, setSavedBody] = useState(DEFAULT_SPEAKER_LETTER_BODY);
-  const [savedFooter, setSavedFooter] = useState(DEFAULT_SPEAKER_LETTER_FOOTER);
-  const [usingDefault, setUsingDefault] = useState(true);
+  const [stateJson, setStateJson] = useState<string | null>(null);
+  const [savedJson, setSavedJson] = useState<string | null>(null);
   const [seeded, setSeeded] = useState(false);
-  const [resetKey, setResetKey] = useState(0);
+  const [editorKey, setEditorKey] = useState(0);
+  const [usingDefault, setUsingDefault] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
+  const initialMarkdown = useMemo(
+    () => ({
+      bodyMarkdown: template?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+      footerMarkdown: template?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+    }),
+    [template?.bodyMarkdown, template?.footerMarkdown],
+  );
+  const initialJson = template?.editorStateJson ?? null;
+
   useEffect(() => {
     if (loading || seeded) return;
-    if (template) {
-      setBody(template.bodyMarkdown);
-      setFooter(template.footerMarkdown);
-      setSavedBody(template.bodyMarkdown);
-      setSavedFooter(template.footerMarkdown);
-      setUsingDefault(false);
-    }
+    setSavedJson(initialJson);
+    setStateJson(initialJson);
+    setUsingDefault(!template);
     setSeeded(true);
-  }, [loading, seeded, template]);
+  }, [loading, seeded, template, initialJson]);
 
   const canEdit = Boolean(me?.data.active);
   const wardName = ward.data?.name ?? "";
 
-  const renderedBody = useMemo(
-    () => interpolate(body, { ...PREVIEW_VARS, wardName }),
-    [body, wardName],
-  );
-  const renderedFooter = useMemo(
-    () => interpolate(footer, { ...PREVIEW_VARS, wardName }),
-    [footer, wardName],
-  );
-
-  const dirty = body !== savedBody || footer !== savedFooter;
+  const dirty = stateJson !== savedJson && stateJson !== null;
 
   async function save() {
-    if (!wardId) return;
+    if (!wardId || !stateJson) return;
     setSaving(true);
     setError(null);
     try {
-      await writeSpeakerLetterTemplate(wardId, { bodyMarkdown: body, footerMarkdown: footer });
-      setSavedBody(body);
-      setSavedFooter(footer);
+      await writeSpeakerLetterTemplate(wardId, { editorStateJson: stateJson });
+      setSavedJson(stateJson);
       setUsingDefault(false);
       setSavedAt(nowLabel());
     } catch (e) {
@@ -95,9 +88,8 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
   }
 
   function discard() {
-    setBody(savedBody);
-    setFooter(savedFooter);
-    setResetKey((k) => k + 1);
+    setStateJson(savedJson);
+    setEditorKey((k) => k + 1);
     setError(null);
   }
 
@@ -105,10 +97,10 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
       <PrintOnlyLetter
         wardName={wardName}
-        assignedDate={PREVIEW_VARS.date}
-        today={PREVIEW_VARS.today}
-        bodyMarkdown={renderedBody}
-        footerMarkdown={renderedFooter}
+        assignedDate={SAMPLE_VARS.date}
+        today={SAMPLE_VARS.today}
+        bodyMarkdown={initialMarkdown.bodyMarkdown}
+        footerMarkdown={initialMarkdown.footerMarkdown}
       />
       <header className="shrink-0 border-b border-border bg-chalk px-5 sm:px-8 py-4 flex items-center justify-between gap-4">
         <div className="flex flex-col gap-1 min-w-0">
@@ -122,29 +114,39 @@ export function SpeakerLetterTemplatePage(): React.ReactElement {
             Speaker invitation letter
           </h1>
         </div>
-        <button
-          type="button"
-          onClick={() => window.close()}
-          className="shrink-0 rounded-md border border-border-strong bg-chalk px-3 py-1.5 font-sans text-[12.5px] font-semibold text-walnut-2 hover:bg-parchment-2"
-        >
-          Close
-        </button>
+        <div className="flex items-center gap-2">
+          {usingDefault && (
+            <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-brass-soft bg-brass-soft/30 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep">
+              <span aria-hidden>★</span>
+              System default — save to lock in
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => window.close()}
+            className="shrink-0 rounded-md border border-border-strong bg-chalk px-3 py-1.5 font-sans text-[12.5px] font-semibold text-walnut-2 hover:bg-parchment-2"
+          >
+            Close
+          </button>
+        </div>
       </header>
 
-      <SpeakerLetterPanel
-        wardName={wardName}
-        sampleDate={PREVIEW_VARS.date}
-        sampleToday={PREVIEW_VARS.today}
-        body={body}
-        footer={footer}
-        renderedBody={renderedBody}
-        renderedFooter={renderedFooter}
-        canEdit={canEdit}
-        usingDefault={usingDefault}
-        resetKey={resetKey}
-        onBodyChange={setBody}
-        onFooterChange={setFooter}
-      />
+      <div className="flex-1 lg:min-h-0 overflow-y-auto bg-parchment py-8 px-4 sm:px-8 pb-24">
+        {seeded && (
+          <LetterPageEditor
+            key={editorKey}
+            wardName={wardName}
+            today={SAMPLE_VARS.today}
+            assignedDate={SAMPLE_VARS.date}
+            initialJson={initialJson}
+            initialMarkdown={initialMarkdown}
+            pageStyle={template?.pageStyle ?? undefined}
+            onChange={setStateJson}
+            ariaLabel="Speaker invitation letter"
+            editorDisabled={!canEdit}
+          />
+        )}
+      </div>
 
       <SaveBar
         dirty={dirty && canEdit}

--- a/src/features/page-editor/LetterPageEditor.tsx
+++ b/src/features/page-editor/LetterPageEditor.tsx
@@ -3,6 +3,7 @@ import { LetterRenderContextProvider } from "./letterRenderContext";
 import { LETTER_EDITOR_NODES, buildInitialLetterState } from "./letterEditorConfig";
 import { PageCanvas } from "./PageCanvas";
 import { PageEditorComposer } from "./PageEditorComposer";
+import { PageStylePanel } from "./PageStylePanel";
 import { LetterChrome } from "./chrome/LetterChrome";
 
 interface Props {
@@ -25,6 +26,10 @@ interface Props {
   /** Fires on every user edit with the editor state serialised as
    *  Lexical JSON. */
   onChange: (stateJson: string) => void;
+  /** Fires when the bishop edits the page style. Omit to hide the
+   *  page-style panel (e.g. read-only contexts, the wizard's per-
+   *  speaker preview). */
+  onPageStyleChange?: (next: LetterPageStyle) => void;
   ariaLabel: string;
   /** When true, the editor is read-only (e.g. the user lacks edit
    *  permission). */
@@ -43,13 +48,23 @@ export function LetterPageEditor({
   initialMarkdown,
   pageStyle,
   onChange,
+  onPageStyleChange,
   ariaLabel,
   editorDisabled,
 }: Props) {
   const initialState = initialJson ?? buildInitialLetterState(initialMarkdown);
   return (
     <LetterRenderContextProvider assignedDate={assignedDate}>
-      <div className={editorDisabled ? "opacity-60 pointer-events-none" : undefined}>
+      <div
+        className={`relative max-w-[8.5in] mx-auto ${editorDisabled ? "opacity-60 pointer-events-none" : ""}`}
+      >
+        {onPageStyleChange && (
+          <PageStylePanel
+            value={pageStyle}
+            onChange={onPageStyleChange}
+            disabled={editorDisabled}
+          />
+        )}
         <PageEditorComposer
           namespace="LetterPageEditor"
           nodes={LETTER_EDITOR_NODES}
@@ -60,11 +75,7 @@ export function LetterPageEditor({
             <PageCanvas
               variant="letter"
               pageStyle={pageStyle}
-              chrome={
-                <LetterChrome wardName={wardName} today={today}>
-                  {null}
-                </LetterChrome>
-              }
+              chrome={<LetterChrome wardName={wardName} today={today} />}
             >
               <div className="font-serif text-[16.5px] leading-[1.65] text-walnut-2">
                 {contentEditable}

--- a/src/features/page-editor/LetterPageEditor.tsx
+++ b/src/features/page-editor/LetterPageEditor.tsx
@@ -1,0 +1,78 @@
+import type { LetterPageStyle } from "@/lib/types/template";
+import { LetterRenderContextProvider } from "./letterRenderContext";
+import { LETTER_EDITOR_NODES, buildInitialLetterState } from "./letterEditorConfig";
+import { PageCanvas } from "./PageCanvas";
+import { PageEditorComposer } from "./PageEditorComposer";
+import { LetterChrome } from "./chrome/LetterChrome";
+
+interface Props {
+  /** Ward name for the chrome eyebrow ("Sacrament Meeting · Ward Name"). */
+  wardName: string;
+  /** Today's date label, e.g. "April 21, 2026". */
+  today: string;
+  /** Sample assigned-Sunday date for the AssignedSundayCalloutNode in
+   *  authoring view. Per-speaker contexts (wizard, send) override this. */
+  assignedDate: string;
+  /** Existing Lexical state JSON, if the ward has saved one already. */
+  initialJson: string | null;
+  /** Legacy markdown fallback — used when the ward only has the old
+   *  fields stored. The seed function hydrates these via the markdown
+   *  transformers and splices in the assigned-Sunday callout +
+   *  signature block + footer scripture paragraph. */
+  initialMarkdown: { bodyMarkdown: string; footerMarkdown: string };
+  /** Optional page-frame styling (border + paper). */
+  pageStyle?: LetterPageStyle;
+  /** Fires on every user edit with the editor state serialised as
+   *  Lexical JSON. */
+  onChange: (stateJson: string) => void;
+  ariaLabel: string;
+  /** When true, the editor is read-only (e.g. the user lacks edit
+   *  permission). */
+  editorDisabled?: boolean;
+}
+
+/** Composes the WYSIWYG speaker-letter editor: page canvas with the
+ *  letter chrome (ornament, eyebrow, title, date) wrapping a single
+ *  Lexical contenteditable that owns greeting + body + assigned-Sunday
+ *  callout + signature + closing scripture as one continuous flow. */
+export function LetterPageEditor({
+  wardName,
+  today,
+  assignedDate,
+  initialJson,
+  initialMarkdown,
+  pageStyle,
+  onChange,
+  ariaLabel,
+  editorDisabled,
+}: Props) {
+  const initialState = initialJson ?? buildInitialLetterState(initialMarkdown);
+  return (
+    <LetterRenderContextProvider assignedDate={assignedDate}>
+      <div className={editorDisabled ? "opacity-60 pointer-events-none" : undefined}>
+        <PageEditorComposer
+          namespace="LetterPageEditor"
+          nodes={LETTER_EDITOR_NODES}
+          initialState={initialState}
+          onChange={onChange}
+          ariaLabel={ariaLabel}
+          page={(contentEditable) => (
+            <PageCanvas
+              variant="letter"
+              pageStyle={pageStyle}
+              chrome={
+                <LetterChrome wardName={wardName} today={today}>
+                  {null}
+                </LetterChrome>
+              }
+            >
+              <div className="font-serif text-[16.5px] leading-[1.65] text-walnut-2">
+                {contentEditable}
+              </div>
+            </PageCanvas>
+          )}
+        />
+      </div>
+    </LetterRenderContextProvider>
+  );
+}

--- a/src/features/page-editor/LetterPageEditor.tsx
+++ b/src/features/page-editor/LetterPageEditor.tsx
@@ -26,6 +26,10 @@ interface Props {
   /** Fires on every user edit with the editor state serialised as
    *  Lexical JSON. */
   onChange: (stateJson: string) => void;
+  /** Fires once after hydration with the initial editor state — the
+   *  host should seed both working + saved baselines so dirty starts
+   *  clean. Without this, pageStyle-only edits couldn't be saved. */
+  onInitial?: (stateJson: string) => void;
   /** Fires when the bishop edits the page style. Omit to hide the
    *  page-style panel (e.g. read-only contexts, the wizard's per-
    *  speaker preview). */
@@ -48,6 +52,7 @@ export function LetterPageEditor({
   initialMarkdown,
   pageStyle,
   onChange,
+  onInitial,
   onPageStyleChange,
   ariaLabel,
   editorDisabled,
@@ -70,6 +75,7 @@ export function LetterPageEditor({
           nodes={LETTER_EDITOR_NODES}
           initialState={initialState}
           onChange={onChange}
+          onInitial={onInitial}
           ariaLabel={ariaLabel}
           page={(contentEditable) => (
             <PageCanvas

--- a/src/features/page-editor/LetterPageEditor.tsx
+++ b/src/features/page-editor/LetterPageEditor.tsx
@@ -1,6 +1,10 @@
 import type { LetterPageStyle } from "@/lib/types/template";
 import { LetterRenderContextProvider } from "./letterRenderContext";
-import { LETTER_EDITOR_NODES, buildInitialLetterState } from "./letterEditorConfig";
+import {
+  LETTER_EDITOR_NODES,
+  LETTER_SLASH_COMMANDS,
+  buildInitialLetterState,
+} from "./letterEditorConfig";
 import { PageCanvas } from "./PageCanvas";
 import { PageEditorComposer } from "./PageEditorComposer";
 import { PageStylePanel } from "./PageStylePanel";
@@ -77,6 +81,7 @@ export function LetterPageEditor({
           onChange={onChange}
           onInitial={onInitial}
           ariaLabel={ariaLabel}
+          slashCommands={LETTER_SLASH_COMMANDS}
           page={(contentEditable) => (
             <PageCanvas
               variant="letter"

--- a/src/features/page-editor/PageCanvas.tsx
+++ b/src/features/page-editor/PageCanvas.tsx
@@ -1,0 +1,76 @@
+import { cn } from "@/lib/cn";
+import type { LetterPageStyle } from "@/lib/types/template";
+
+interface Props {
+  /** Variant drives the natural width + chrome surface. `letter` is
+   *  8.5 × 11 in print; `conducting` / `congregation` add pagination
+   *  in Phase 3. */
+  variant: "letter" | "conducting" | "congregation";
+  /** Page-level styling (border + paper) — falls back to the variant
+   *  default when omitted. Edited via `PageStylePanel` (Phase 1
+   *  follow-up). */
+  pageStyle?: LetterPageStyle;
+  /** Render-only chrome (ornament, eyebrow, title, date). Sits as a
+   *  CSS-positioned overlay around the editable region. */
+  chrome: React.ReactNode;
+  /** The Lexical contenteditable subtree. The canvas reserves vertical
+   *  space for the chrome and lets the contenteditable claim the rest
+   *  of the page; long content extends the page naturally. */
+  children: React.ReactNode;
+  /** When true, tighten paddings + shadows for an on-screen authoring
+   *  view. The print path keeps `false` so the canvas renders at true
+   *  letter-sheet proportions. */
+  compact?: boolean;
+}
+
+const PAPER_BG_CLASS: Record<NonNullable<LetterPageStyle["paper"]>, string> = {
+  chalk: "bg-chalk",
+  parchment: "bg-parchment",
+  "parchment-2": "bg-parchment-2",
+};
+
+const BORDER_COLOR_CLASS: Record<NonNullable<LetterPageStyle["borderColor"]>, string> = {
+  none: "border-transparent",
+  walnut: "border-walnut-3",
+  "brass-deep": "border-brass-deep",
+  bordeaux: "border-bordeaux",
+};
+
+/** The visible 8.5 × 11 paper that the page editor lives inside.
+ *  Chalk background, drop shadow, exact-DPI dimensions in CSS `in`
+ *  units, printer margins as inner padding. Chrome overlays the
+ *  content area; the editable region scrolls inside the page —
+ *  the page itself sits inside whatever scroll container the host
+ *  route provides. */
+export function PageCanvas({ variant, pageStyle, chrome, children, compact }: Props) {
+  const paperClass = pageStyle?.paper ? PAPER_BG_CLASS[pageStyle.paper] : "bg-chalk";
+  const borderClass = pageStyle?.borderColor
+    ? BORDER_COLOR_CLASS[pageStyle.borderColor]
+    : "border-transparent";
+  const borderWidth = pageStyle?.borderWidth ?? 0;
+  const isLetter = variant === "letter";
+  return (
+    <div
+      className={cn(
+        paperClass,
+        "text-walnut font-serif relative mx-auto",
+        compact
+          ? "w-full max-w-[680px] px-8 py-10 rounded-md shadow-elev-3"
+          : isLetter
+            ? "w-[8.5in] min-h-[11in] px-[0.75in] pt-[0.85in] pb-[0.6in] shadow-[0_12px_40px_rgba(58,37,25,0.18)]"
+            : "w-[8.5in] min-h-[11in] px-[0.6in] pt-[0.6in] pb-[0.6in] shadow-[0_12px_40px_rgba(58,37,25,0.18)]",
+        borderWidth > 0 && borderClass,
+      )}
+      style={
+        borderWidth > 0 ? { borderWidth: `${borderWidth}px`, borderStyle: "solid" } : undefined
+      }
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-4 sm:inset-6 border border-brass-soft/40"
+      />
+      {chrome}
+      {children}
+    </div>
+  );
+}

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef } from "react";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { RichTextPlugin } from "@lexical/react/LexicalRichTextPlugin";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { LexicalErrorBoundary } from "@lexical/react/LexicalErrorBoundary";
+import { HistoryPlugin } from "@lexical/react/LexicalHistoryPlugin";
+import { LinkPlugin } from "@lexical/react/LexicalLinkPlugin";
+import { ListPlugin } from "@lexical/react/LexicalListPlugin";
+import { HorizontalRulePlugin } from "@lexical/react/LexicalHorizontalRulePlugin";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import type { Klass, LexicalEditor, LexicalNode } from "lexical";
+import { FloatingSelectionToolbar } from "@/features/program-templates/FloatingSelectionToolbar";
+import { lexicalTheme } from "@/features/program-templates/lexicalTheme";
+
+interface Props {
+  /** Stable namespace — drives editor identity for collaborative state
+   *  + DOM debugging. */
+  namespace: string;
+  /** Node classes the editor knows about. Host editors compose
+   *  `PAGE_EDITOR_BASE_NODES` with their own domain nodes. */
+  nodes: ReadonlyArray<Klass<LexicalNode>>;
+  /** Initial editor state — either a JSON string (Lexical state) or
+   *  an `(editor) => void` callback that builds the seed state. */
+  initialState: string | null | ((editor: LexicalEditor) => void);
+  /** Fires on every user edit with the editor state serialised as
+   *  Lexical JSON. The host owns dirty-tracking + persistence. */
+  onChange: (stateJson: string) => void;
+  /** Aria-label for the contenteditable surface. */
+  ariaLabel: string;
+  /** Optional content slot for the page-level toolbar (block-type +
+   *  lists + Insert Variable + page-style trigger). Omit when the
+   *  editor surfaces formatting only via the floating selection
+   *  toolbar. */
+  pageToolbar?: React.ReactNode;
+  /** The chrome-wrapped page surface — typically `<PageCanvas>` with
+   *  `<LetterChrome>` already inside. The composer renders the
+   *  contenteditable as its child. */
+  page: (contentEditable: React.ReactNode) => React.ReactNode;
+}
+
+/** Wraps `LexicalComposer` with the union of plugins every WYSIWYG
+ *  page editor needs (rich-text, history, lists, link, horizontal
+ *  rule, floating selection toolbar). Host editors layer their own
+ *  domain plugins (slash commands, paginator) on top by passing them
+ *  as `pageToolbar` siblings or by mounting them inside the `page`
+ *  render slot. */
+export function PageEditorComposer({
+  namespace,
+  nodes,
+  initialState,
+  onChange,
+  ariaLabel,
+  pageToolbar,
+  page,
+}: Props) {
+  const initialConfig = {
+    namespace,
+    theme: lexicalTheme,
+    nodes: [...nodes],
+    onError: (e: Error) => {
+      console.error(`[PageEditorComposer:${namespace}]`, e);
+      throw e;
+    },
+    editorState: initialState,
+  };
+
+  return (
+    <LexicalComposer initialConfig={initialConfig}>
+      {pageToolbar}
+      {page(
+        <RichTextPlugin
+          contentEditable={
+            <ContentEditable
+              aria-label={ariaLabel}
+              className="prose prose-sm max-w-none font-serif text-walnut text-[16.5px] leading-[1.65] focus:outline-none [&_em]:text-bordeaux [&_strong]:text-walnut"
+            />
+          }
+          placeholder={null}
+          ErrorBoundary={LexicalErrorBoundary}
+        />,
+      )}
+      <HistoryPlugin />
+      <ListPlugin />
+      <LinkPlugin />
+      <HorizontalRulePlugin />
+      <FloatingSelectionToolbar />
+      <StateJsonOnChangePlugin onChange={onChange} />
+    </LexicalComposer>
+  );
+}
+
+/** Surfaces the editor state as Lexical JSON. Skips the initial
+ *  hydration so the parent doesn't get its own `initialState` echoed
+ *  back. Pulled out of the composer so the file stays under the
+ *  150-LOC cap. */
+function StateJsonOnChangePlugin({ onChange }: { onChange: (json: string) => void }): null {
+  const [editor] = useLexicalComposerContext();
+  const onChangeRef = useRef(onChange);
+  const skipFirst = useRef(true);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
+      if (skipFirst.current) {
+        skipFirst.current = false;
+        return;
+      }
+      if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
+      onChangeRef.current(JSON.stringify(editorState.toJSON()));
+    });
+  }, [editor]);
+  return null;
+}

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -129,20 +129,10 @@ function StateJsonOnChangePlugin({ onChange, onInitial }: StatePluginProps): nul
 
   useEffect(() => {
     const initialJson = JSON.stringify(editor.getEditorState().toJSON());
-    console.log("[wysiwyg-plugin] capture-initial", {
-      jsonLen: initialJson.length,
-      jsonHead: initialJson.slice(0, 60),
-    });
     onInitialRef.current?.(initialJson);
     return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
       if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
-      const json = JSON.stringify(editorState.toJSON());
-      console.log("[wysiwyg-plugin] dirty update", {
-        jsonLen: json.length,
-        dirtyElements: dirtyElements.size,
-        dirtyLeaves: dirtyLeaves.size,
-      });
-      onChangeRef.current(json);
+      onChangeRef.current(JSON.stringify(editorState.toJSON()));
     });
   }, [editor]);
   return null;

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -129,10 +129,20 @@ function StateJsonOnChangePlugin({ onChange, onInitial }: StatePluginProps): nul
 
   useEffect(() => {
     const initialJson = JSON.stringify(editor.getEditorState().toJSON());
+    console.log("[wysiwyg-plugin] capture-initial", {
+      jsonLen: initialJson.length,
+      jsonHead: initialJson.slice(0, 60),
+    });
     onInitialRef.current?.(initialJson);
     return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
       if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
-      onChangeRef.current(JSON.stringify(editorState.toJSON()));
+      const json = JSON.stringify(editorState.toJSON());
+      console.log("[wysiwyg-plugin] dirty update", {
+        jsonLen: json.length,
+        dirtyElements: dirtyElements.size,
+        dirtyLeaves: dirtyLeaves.size,
+      });
+      onChangeRef.current(json);
     });
   }, [editor]);
   return null;

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -11,6 +11,7 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import type { Klass, LexicalEditor, LexicalNode } from "lexical";
 import { FloatingSelectionToolbar } from "@/features/program-templates/FloatingSelectionToolbar";
 import { lexicalTheme } from "@/features/program-templates/lexicalTheme";
+import { ImagePlugin } from "./plugins/ImagePlugin";
 import { PageEditorAutoLink } from "./plugins/PageEditorAutoLink";
 import { PageEditorMarkdownShortcuts } from "./plugins/PageEditorMarkdownShortcuts";
 
@@ -94,6 +95,7 @@ export function PageEditorComposer({
       <HorizontalRulePlugin />
       <PageEditorAutoLink />
       <PageEditorMarkdownShortcuts />
+      <ImagePlugin />
       <FloatingSelectionToolbar />
       <StateJsonOnChangePlugin onChange={onChange} onInitial={onInitial} />
     </LexicalComposer>

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -11,6 +11,8 @@ import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext
 import type { Klass, LexicalEditor, LexicalNode } from "lexical";
 import { FloatingSelectionToolbar } from "@/features/program-templates/FloatingSelectionToolbar";
 import { lexicalTheme } from "@/features/program-templates/lexicalTheme";
+import { PageEditorAutoLink } from "./plugins/PageEditorAutoLink";
+import { PageEditorMarkdownShortcuts } from "./plugins/PageEditorMarkdownShortcuts";
 
 interface Props {
   /** Stable namespace — drives editor identity for collaborative state
@@ -83,6 +85,8 @@ export function PageEditorComposer({
       <ListPlugin />
       <LinkPlugin />
       <HorizontalRulePlugin />
+      <PageEditorAutoLink />
+      <PageEditorMarkdownShortcuts />
       <FloatingSelectionToolbar />
       <StateJsonOnChangePlugin onChange={onChange} />
     </LexicalComposer>

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -14,6 +14,8 @@ import { lexicalTheme } from "@/features/program-templates/lexicalTheme";
 import { ImagePlugin } from "./plugins/ImagePlugin";
 import { PageEditorAutoLink } from "./plugins/PageEditorAutoLink";
 import { PageEditorMarkdownShortcuts } from "./plugins/PageEditorMarkdownShortcuts";
+import { SlashCommandPlugin } from "./plugins/SlashCommandPlugin";
+import type { SlashCommand } from "./plugins/SlashCommandRegistry";
 
 interface Props {
   /** Stable namespace — drives editor identity for collaborative state
@@ -45,6 +47,10 @@ interface Props {
    *  `<LetterChrome>` already inside. The composer renders the
    *  contenteditable as its child. */
   page: (contentEditable: React.ReactNode) => React.ReactNode;
+  /** Optional slash-command palette. Each editor surface hands in
+   *  its own commands (letter / program / message-template) — host
+   *  editors that don't want a slash menu omit this. */
+  slashCommands?: ReadonlyArray<SlashCommand>;
 }
 
 /** Wraps `LexicalComposer` with the union of plugins every WYSIWYG
@@ -62,6 +68,7 @@ export function PageEditorComposer({
   ariaLabel,
   pageToolbar,
   page,
+  slashCommands,
 }: Props) {
   const initialConfig = {
     namespace,
@@ -96,6 +103,7 @@ export function PageEditorComposer({
       <PageEditorAutoLink />
       <PageEditorMarkdownShortcuts />
       <ImagePlugin />
+      {slashCommands && <SlashCommandPlugin commands={slashCommands} />}
       <FloatingSelectionToolbar />
       <StateJsonOnChangePlugin onChange={onChange} onInitial={onInitial} />
     </LexicalComposer>

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -27,6 +27,12 @@ interface Props {
   /** Fires on every user edit with the editor state serialised as
    *  Lexical JSON. The host owns dirty-tracking + persistence. */
   onChange: (stateJson: string) => void;
+  /** Fires once after hydration with the initial editor state. The
+   *  host should use this to seed *both* the working state and the
+   *  saved baseline so dirty-tracking starts clean — without it the
+   *  bishop's pageStyle-only edits couldn't be saved (the editor's
+   *  current content was never available to the writer). */
+  onInitial?: (stateJson: string) => void;
   /** Aria-label for the contenteditable surface. */
   ariaLabel: string;
   /** Optional content slot for the page-level toolbar (block-type +
@@ -51,6 +57,7 @@ export function PageEditorComposer({
   nodes,
   initialState,
   onChange,
+  onInitial,
   ariaLabel,
   pageToolbar,
   page,
@@ -88,32 +95,44 @@ export function PageEditorComposer({
       <PageEditorAutoLink />
       <PageEditorMarkdownShortcuts />
       <FloatingSelectionToolbar />
-      <StateJsonOnChangePlugin onChange={onChange} />
+      <StateJsonOnChangePlugin onChange={onChange} onInitial={onInitial} />
     </LexicalComposer>
   );
 }
 
-/** Surfaces the editor state as Lexical JSON. Skips the initial
- *  hydration so the parent doesn't get its own `initialState` echoed
- *  back. Pulled out of the composer so the file stays under the
- *  150-LOC cap. */
-function StateJsonOnChangePlugin({ onChange }: { onChange: (json: string) => void }): null {
+interface StatePluginProps {
+  onChange: (json: string) => void;
+  onInitial?: (json: string) => void;
+}
+
+/** Surfaces the editor state as Lexical JSON. The very first update
+ *  (the hydration tick) goes to `onInitial` so the host can seed
+ *  both its working state and saved baseline; subsequent dirty
+ *  updates flow to `onChange`. Pulled out of the composer so the
+ *  file stays under the 150-LOC cap. */
+function StateJsonOnChangePlugin({ onChange, onInitial }: StatePluginProps): null {
   const [editor] = useLexicalComposerContext();
   const onChangeRef = useRef(onChange);
-  const skipFirst = useRef(true);
+  const onInitialRef = useRef(onInitial);
+  const seenFirst = useRef(false);
 
   useEffect(() => {
     onChangeRef.current = onChange;
   }, [onChange]);
+  useEffect(() => {
+    onInitialRef.current = onInitial;
+  }, [onInitial]);
 
   useEffect(() => {
     return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
-      if (skipFirst.current) {
-        skipFirst.current = false;
+      const json = JSON.stringify(editorState.toJSON());
+      if (!seenFirst.current) {
+        seenFirst.current = true;
+        onInitialRef.current?.(json);
         return;
       }
       if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
-      onChangeRef.current(JSON.stringify(editorState.toJSON()));
+      onChangeRef.current(json);
     });
   }, [editor]);
   return null;

--- a/src/features/page-editor/PageEditorComposer.tsx
+++ b/src/features/page-editor/PageEditorComposer.tsx
@@ -105,16 +105,20 @@ interface StatePluginProps {
   onInitial?: (json: string) => void;
 }
 
-/** Surfaces the editor state as Lexical JSON. The very first update
- *  (the hydration tick) goes to `onInitial` so the host can seed
- *  both its working state and saved baseline; subsequent dirty
- *  updates flow to `onChange`. Pulled out of the composer so the
- *  file stays under the 150-LOC cap. */
+/** Surfaces the editor state as Lexical JSON. Lexical commits the
+ *  initial hydration synchronously during render (inside the
+ *  composer's `useMemo`), which is *before* this effect can register
+ *  an update listener — so the hydration tick never reaches the
+ *  listener. We capture the post-hydration state synchronously when
+ *  the effect runs, then let the listener emit only dirty updates.
+ *  Without this, the bishop's first keystroke gets mis-classified as
+ *  "initial" and silently re-baselined, which surfaced as "save
+ *  doesn't persist" because the bishop's intent never registered as
+ *  a dirty edit. */
 function StateJsonOnChangePlugin({ onChange, onInitial }: StatePluginProps): null {
   const [editor] = useLexicalComposerContext();
   const onChangeRef = useRef(onChange);
   const onInitialRef = useRef(onInitial);
-  const seenFirst = useRef(false);
 
   useEffect(() => {
     onChangeRef.current = onChange;
@@ -124,15 +128,11 @@ function StateJsonOnChangePlugin({ onChange, onInitial }: StatePluginProps): nul
   }, [onInitial]);
 
   useEffect(() => {
+    const initialJson = JSON.stringify(editor.getEditorState().toJSON());
+    onInitialRef.current?.(initialJson);
     return editor.registerUpdateListener(({ editorState, dirtyElements, dirtyLeaves }) => {
-      const json = JSON.stringify(editorState.toJSON());
-      if (!seenFirst.current) {
-        seenFirst.current = true;
-        onInitialRef.current?.(json);
-        return;
-      }
       if (dirtyElements.size === 0 && dirtyLeaves.size === 0) return;
-      onChangeRef.current(json);
+      onChangeRef.current(JSON.stringify(editorState.toJSON()));
     });
   }, [editor]);
   return null;

--- a/src/features/page-editor/PageStylePanel.tsx
+++ b/src/features/page-editor/PageStylePanel.tsx
@@ -43,7 +43,18 @@ export function PageStylePanel({ value, onChange, disabled }: Props) {
   const style = value ?? DEFAULT_STYLE;
 
   function patch(partial: Partial<LetterPageStyle>) {
-    onChange({ ...style, ...partial });
+    const next = { ...style, ...partial };
+    // Auto-couple color & width so the bishop never sets a color
+    // they can't see (and never sets a width without a color).
+    if ("borderColor" in partial) {
+      if (next.borderColor !== "none" && next.borderWidth < 1) next.borderWidth = 2;
+      if (next.borderColor === "none") next.borderWidth = 0;
+    }
+    if ("borderWidth" in partial) {
+      if (next.borderWidth === 0) next.borderColor = "none";
+      else if (next.borderColor === "none") next.borderColor = "walnut";
+    }
+    onChange(next);
   }
 
   return (

--- a/src/features/page-editor/PageStylePanel.tsx
+++ b/src/features/page-editor/PageStylePanel.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import type { LetterPageStyle } from "@/lib/types/template";
+import { cn } from "@/lib/cn";
+
+type BorderColor = LetterPageStyle["borderColor"];
+type Paper = LetterPageStyle["paper"];
+
+const BORDER_COLOR_SWATCH: Record<BorderColor, string> = {
+  none: "bg-transparent border border-dashed border-border-strong",
+  walnut: "bg-walnut",
+  "brass-deep": "bg-brass-deep",
+  bordeaux: "bg-bordeaux",
+};
+
+const PAPER_SWATCH: Record<Paper, string> = {
+  chalk: "bg-chalk border border-border-strong",
+  parchment: "bg-parchment border border-border-strong",
+  "parchment-2": "bg-parchment-2 border border-border-strong",
+};
+
+const DEFAULT_STYLE: LetterPageStyle = {
+  borderColor: "none",
+  borderWidth: 0,
+  borderStyle: "solid",
+  paper: "chalk",
+};
+
+interface Props {
+  value: LetterPageStyle | null | undefined;
+  onChange: (next: LetterPageStyle) => void;
+  /** When true, the panel renders read-only swatches (no click handlers). */
+  disabled?: boolean;
+}
+
+/** Pill-button + popover that edits the page-frame styling (border
+ *  color/width/style + paper color). Mounts at the top-right of the
+ *  page editor's parchment area so it doesn't compete with the
+ *  letter's own chrome. Auto-applies on every change so the bishop
+ *  sees the canvas update live. Persistence happens in the route
+ *  via the same dual-writing `writeSpeakerLetterTemplate`. */
+export function PageStylePanel({ value, onChange, disabled }: Props) {
+  const [open, setOpen] = useState(false);
+  const style = value ?? DEFAULT_STYLE;
+
+  function patch(partial: Partial<LetterPageStyle>) {
+    onChange({ ...style, ...partial });
+  }
+
+  return (
+    <div className="absolute top-2 right-2 z-20">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        disabled={disabled}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-full border border-border-strong bg-chalk px-3 py-1 font-mono text-[10.5px] uppercase tracking-[0.14em] text-walnut-2 hover:bg-parchment-2 disabled:opacity-50"
+      >
+        <span aria-hidden>⚙</span>
+        Page style
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="Page style"
+          className="absolute right-0 mt-2 w-72 rounded-lg border border-border-strong bg-chalk shadow-elev-3 p-4 flex flex-col gap-4"
+        >
+          <Section label="Border color">
+            <div className="flex gap-2">
+              {(Object.keys(BORDER_COLOR_SWATCH) as BorderColor[]).map((c) => (
+                <Swatch
+                  key={c}
+                  active={style.borderColor === c}
+                  className={BORDER_COLOR_SWATCH[c]}
+                  label={c}
+                  onClick={() => patch({ borderColor: c })}
+                />
+              ))}
+            </div>
+          </Section>
+          <Section label="Border width">
+            <input
+              type="range"
+              min={0}
+              max={4}
+              step={1}
+              value={style.borderWidth}
+              onChange={(e) => patch({ borderWidth: Number(e.target.value) })}
+              className="w-full accent-walnut"
+            />
+            <div className="font-mono text-[10px] text-walnut-3 tabular-nums">
+              {style.borderWidth}px
+            </div>
+          </Section>
+          <Section label="Paper">
+            <div className="flex gap-2">
+              {(Object.keys(PAPER_SWATCH) as Paper[]).map((p) => (
+                <Swatch
+                  key={p}
+                  active={style.paper === p}
+                  className={PAPER_SWATCH[p]}
+                  label={p}
+                  onClick={() => patch({ paper: p })}
+                />
+              ))}
+            </div>
+          </Section>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+interface SwatchProps {
+  active: boolean;
+  className: string;
+  label: string;
+  onClick: () => void;
+}
+
+function Swatch({ active, className, label, onClick }: SwatchProps) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+      className={cn(
+        "h-7 w-7 rounded-full transition-shadow",
+        className,
+        active && "ring-2 ring-offset-2 ring-walnut",
+      )}
+    />
+  );
+}

--- a/src/features/page-editor/chrome/LetterChrome.tsx
+++ b/src/features/page-editor/chrome/LetterChrome.tsx
@@ -1,0 +1,47 @@
+interface Props {
+  wardName: string;
+  /** Today's date label, e.g. "April 21, 2026". The bishop's letter
+   *  shows this near the top so it reads like a real letter. */
+  today: string;
+  /** Footer rule decoration: ✦ ornament + scripture or motto. The
+   *  scripture lives inside the editable region as an ordinary
+   *  paragraph (post-WYSIWYG migration); only the ornament + rule
+   *  ship as chrome. */
+  children: React.ReactNode;
+}
+
+/** Render-only chrome around the editable letter content: the brass
+ *  ornament + ward eyebrow + "Invitation to Speak" title + "From the
+ *  Bishopric" sub-eyebrow + today's date + a closing rule with the
+ *  ✦ ornament. Verbatim extract from `LetterCanvas`'s LetterHeader +
+ *  the date + bottom rule, minus the editable signature row (now
+ *  `SignatureBlockNode`) and minus the assigned-Sunday callout (now
+ *  `AssignedSundayCalloutNode`). */
+export function LetterChrome({ wardName, today, children }: Props) {
+  return (
+    <>
+      <div className="text-center pb-5 border-b border-border mb-8">
+        <div className="flex items-center justify-center gap-3.5 mb-3.5">
+          <span className="w-9 h-9 border border-brass-soft rounded-full inline-flex items-center justify-center text-brass-deep text-lg">
+            ✦
+          </span>
+        </div>
+        <div className="font-mono text-[11px] tracking-[0.3em] uppercase text-walnut-3 mb-2">
+          Sacrament Meeting{wardName ? ` · ${wardName}` : ""}
+        </div>
+        <div className="font-display text-[28px] italic text-walnut tracking-[-0.01em]">
+          Invitation to Speak
+        </div>
+        <div className="mt-2.5 font-mono text-[10px] tracking-[0.22em] uppercase text-walnut-3">
+          From the Bishopric
+        </div>
+      </div>
+
+      <div className="font-mono text-[11px] tracking-[0.14em] uppercase text-walnut-3 mb-5">
+        {today}
+      </div>
+
+      {children}
+    </>
+  );
+}

--- a/src/features/page-editor/letterEditorConfig.ts
+++ b/src/features/page-editor/letterEditorConfig.ts
@@ -9,6 +9,8 @@ import { $createSignatureBlockNode } from "./nodes/SignatureBlockNode";
 import { PAGE_EDITOR_BASE_NODES } from "./pageEditorNodes";
 import { PAGE_EDITOR_MARKDOWN_TRANSFORMERS } from "./plugins/PageEditorMarkdownShortcuts";
 
+export { LETTER_SLASH_COMMANDS } from "./letterSlashCommands";
+
 export const LETTER_EDITOR_NODES = PAGE_EDITOR_BASE_NODES;
 
 /** Transformer list used for hydrating legacy `bodyMarkdown` /

--- a/src/features/page-editor/letterEditorConfig.ts
+++ b/src/features/page-editor/letterEditorConfig.ts
@@ -1,21 +1,22 @@
 import {
   $convertFromMarkdownString,
   $convertToMarkdownString,
-  TRANSFORMERS,
   type Transformer,
 } from "@lexical/markdown";
 import { $createParagraphNode, $createTextNode, $getRoot, type LexicalEditor } from "lexical";
-import { VARIABLE_CHIP_MARKDOWN_TRANSFORMER } from "@/features/program-templates/nodes/variableChipMarkdown";
 import { $createAssignedSundayCalloutNode } from "./nodes/AssignedSundayCalloutNode";
 import { $createSignatureBlockNode } from "./nodes/SignatureBlockNode";
 import { PAGE_EDITOR_BASE_NODES } from "./pageEditorNodes";
+import { PAGE_EDITOR_MARKDOWN_TRANSFORMERS } from "./plugins/PageEditorMarkdownShortcuts";
 
 export const LETTER_EDITOR_NODES = PAGE_EDITOR_BASE_NODES;
 
-export const LETTER_MARKDOWN_TRANSFORMERS: Transformer[] = [
-  VARIABLE_CHIP_MARKDOWN_TRANSFORMER,
-  ...TRANSFORMERS,
-];
+/** Transformer list used for hydrating legacy `bodyMarkdown` /
+ *  `footerMarkdown` into the editor (and serializing back to markdown
+ *  during the dual-write window). Reuses the curated set from the
+ *  shortcut plugin so hydration can't reference nodes the editor
+ *  doesn't register. */
+export const LETTER_MARKDOWN_TRANSFORMERS: Transformer[] = PAGE_EDITOR_MARKDOWN_TRANSFORMERS;
 
 interface BuildOpts {
   bodyMarkdown: string;

--- a/src/features/page-editor/letterEditorConfig.ts
+++ b/src/features/page-editor/letterEditorConfig.ts
@@ -1,0 +1,89 @@
+import {
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+  TRANSFORMERS,
+  type Transformer,
+} from "@lexical/markdown";
+import { $createParagraphNode, $createTextNode, $getRoot, type LexicalEditor } from "lexical";
+import { VARIABLE_CHIP_MARKDOWN_TRANSFORMER } from "@/features/program-templates/nodes/variableChipMarkdown";
+import { $createAssignedSundayCalloutNode } from "./nodes/AssignedSundayCalloutNode";
+import { $createSignatureBlockNode } from "./nodes/SignatureBlockNode";
+import { PAGE_EDITOR_BASE_NODES } from "./pageEditorNodes";
+
+export const LETTER_EDITOR_NODES = PAGE_EDITOR_BASE_NODES;
+
+export const LETTER_MARKDOWN_TRANSFORMERS: Transformer[] = [
+  VARIABLE_CHIP_MARKDOWN_TRANSFORMER,
+  ...TRANSFORMERS,
+];
+
+interface BuildOpts {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+}
+
+const SIGNATURE_CLOSING_PATTERN =
+  /^(with gratitude|with appreciation|sincerely|in faith)\s*[,.]?\s*$/i;
+
+/** Builds a Lexical EditorState for a brand-new editor by hydrating
+ *  legacy markdown into chips + paragraphs, splicing an
+ *  `AssignedSundayCalloutNode` after the greeting, replacing any
+ *  trailing "With gratitude,"-style paragraph with a
+ *  `SignatureBlockNode`, and finishing with the footer scripture as
+ *  a final paragraph. Used for both seed states (brand-new wards)
+ *  and migration (existing wards that only have markdown stored).
+ *
+ *  When the ward already has `editorStateJson` saved, the route
+ *  passes the JSON directly to `LexicalComposer` and this function
+ *  isn't invoked. */
+export function buildInitialLetterState({ bodyMarkdown, footerMarkdown }: BuildOpts) {
+  return () => {
+    $convertFromMarkdownString(bodyMarkdown, LETTER_MARKDOWN_TRANSFORMERS);
+    const root = $getRoot();
+    const children = root.getChildren();
+    // Insert assigned-Sunday callout after the greeting (first paragraph).
+    if (children.length >= 1) {
+      children[0].insertAfter($createAssignedSundayCalloutNode());
+    } else {
+      root.append($createAssignedSundayCalloutNode());
+    }
+    // If the body ended in a "With gratitude,"-style closing paragraph,
+    // remove it — the signature block decorator renders its own closing.
+    const last = root.getChildren().at(-1);
+    const lastText = last?.getTextContent().trim() ?? "";
+    if (last && SIGNATURE_CLOSING_PATTERN.test(lastText)) {
+      last.remove();
+    }
+    root.append($createSignatureBlockNode());
+    if (footerMarkdown.trim().length > 0) {
+      const footerPara = $createParagraphNode();
+      footerPara.append($createTextNode(footerMarkdown));
+      root.append(footerPara);
+    }
+  };
+}
+
+/** Read-side helper: when the dual-write window is still open and a
+ *  caller (Cloud Function, receipt-email payload) needs markdown
+ *  even though the new editor wrote JSON, reproduce the legacy body
+ *  + footer fields by serializing the JSON state through the same
+ *  markdown transformers used at authoring time, then split on the
+ *  signature-block boundary. */
+export function legacyMarkdownFromEditor(editor: LexicalEditor): {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+} {
+  const md = editor
+    .getEditorState()
+    .read(() => $convertToMarkdownString(LETTER_MARKDOWN_TRANSFORMERS));
+  const sigIndex = md.indexOf("With gratitude,");
+  if (sigIndex < 0) return { bodyMarkdown: md, footerMarkdown: "" };
+  const before = md.slice(0, sigIndex).trimEnd();
+  const after = md.slice(sigIndex);
+  const lines = after
+    .split(/\n{2,}/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const footer = lines.length > 0 ? lines[lines.length - 1] : "";
+  return { bodyMarkdown: before, footerMarkdown: footer };
+}

--- a/src/features/page-editor/letterRenderContext.tsx
+++ b/src/features/page-editor/letterRenderContext.tsx
@@ -1,0 +1,29 @@
+import { createContext, useContext } from "react";
+
+interface LetterRenderContextValue {
+  /** Resolved assigned date for the speaker, e.g. "Sunday, May 31, 2026".
+   *  `null` at template-authoring time when no specific speaker is bound;
+   *  the AssignedSundayCalloutNode falls back to a friendly placeholder. */
+  assignedDate: string | null;
+}
+
+const LetterRenderContext = createContext<LetterRenderContextValue>({ assignedDate: null });
+
+interface ProviderProps {
+  assignedDate: string | null;
+  children: React.ReactNode;
+}
+
+/** Supplies per-render values that decorator nodes can read without
+ *  storing them in the editor state. Scope: a single editor instance
+ *  + its print preview. Wrap whichever subtree owns the editor +
+ *  preview pair (route page, wizard step, print portal). */
+export function LetterRenderContextProvider({ assignedDate, children }: ProviderProps) {
+  return (
+    <LetterRenderContext.Provider value={{ assignedDate }}>{children}</LetterRenderContext.Provider>
+  );
+}
+
+export function useAssignedDate(): string | null {
+  return useContext(LetterRenderContext).assignedDate;
+}

--- a/src/features/page-editor/letterSlashCommands.ts
+++ b/src/features/page-editor/letterSlashCommands.ts
@@ -1,0 +1,115 @@
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from "lexical";
+import {
+  $createHeadingNode,
+  $createQuoteNode,
+  type HeadingTagType,
+} from "@lexical/rich-text";
+import { $setBlocksType } from "@lexical/selection";
+import {
+  INSERT_ORDERED_LIST_COMMAND,
+  INSERT_UNORDERED_LIST_COMMAND,
+} from "@lexical/list";
+import { INSERT_HORIZONTAL_RULE_COMMAND } from "@lexical/react/LexicalHorizontalRuleNode";
+import { INSERT_IMAGE_COMMAND } from "./plugins/ImagePlugin";
+import type { SlashCommand } from "./plugins/SlashCommandRegistry";
+
+function setBlock(editor: LexicalEditor, factory: () => ReturnType<typeof $createParagraphNode>) {
+  editor.update(() => {
+    const sel = $getSelection();
+    if ($isRangeSelection(sel)) $setBlocksType(sel, factory);
+  });
+}
+
+const BRASS_ORNAMENT_SVG =
+  "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><circle cx='12' cy='12' r='10' fill='none' stroke='%238e6a36' stroke-width='1.5'/><text x='12' y='16' text-anchor='middle' font-family='serif' font-size='14' fill='%238e6a36'>%E2%9C%A6</text></svg>";
+
+/** Slash-command palette for the speaker-letter editor. Mounted by
+ *  `LetterPageEditor` via `PageEditorComposer`. Bishops type `/` at
+ *  the start of a paragraph to open the menu. */
+export const LETTER_SLASH_COMMANDS: readonly SlashCommand[] = [
+  {
+    id: "heading-1",
+    label: "Heading 1",
+    description: "Large section heading",
+    keywords: "h1, title",
+    icon: "H1",
+    onSelect: (editor) => setBlock(editor, () => $createHeadingNode("h1" as HeadingTagType) as never),
+  },
+  {
+    id: "heading-2",
+    label: "Heading 2",
+    description: "Medium section heading",
+    keywords: "h2",
+    icon: "H2",
+    onSelect: (editor) => setBlock(editor, () => $createHeadingNode("h2" as HeadingTagType) as never),
+  },
+  {
+    id: "heading-3",
+    label: "Heading 3",
+    description: "Small section heading",
+    keywords: "h3",
+    icon: "H3",
+    onSelect: (editor) => setBlock(editor, () => $createHeadingNode("h3" as HeadingTagType) as never),
+  },
+  {
+    id: "bullet-list",
+    label: "Bullet list",
+    keywords: "ul, unordered, list",
+    icon: "•",
+    onSelect: (editor) => editor.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined),
+  },
+  {
+    id: "numbered-list",
+    label: "Numbered list",
+    keywords: "ol, ordered, list",
+    icon: "1.",
+    onSelect: (editor) => editor.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined),
+  },
+  {
+    id: "quote",
+    label: "Quote",
+    description: "Set off a scripture or saying",
+    keywords: "blockquote, scripture",
+    icon: "❝",
+    onSelect: (editor) => setBlock(editor, () => $createQuoteNode() as never),
+  },
+  {
+    id: "divider",
+    label: "Divider",
+    description: "Horizontal rule",
+    keywords: "hr, line, separator",
+    icon: "—",
+    onSelect: (editor) => editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined),
+  },
+  {
+    id: "image",
+    label: "Image",
+    description: "Insert an image by URL",
+    keywords: "img, picture, photo",
+    icon: "🖼",
+    onSelect: (editor) => {
+      const src = window.prompt("Image URL");
+      if (!src) return;
+      const alt = window.prompt("Alt text", "") ?? "";
+      editor.dispatchCommand(INSERT_IMAGE_COMMAND, { src, alt });
+    },
+  },
+  {
+    id: "ornament",
+    label: "Brass ornament",
+    description: "Decorative ✦ ornament",
+    keywords: "decoration, flourish, brass",
+    icon: "✦",
+    onSelect: (editor) =>
+      editor.dispatchCommand(INSERT_IMAGE_COMMAND, {
+        src: BRASS_ORNAMENT_SVG,
+        alt: "Brass ornament",
+        widthPct: 8,
+      }),
+  },
+];

--- a/src/features/page-editor/nodes/AssignedSundayCalloutNode.tsx
+++ b/src/features/page-editor/nodes/AssignedSundayCalloutNode.tsx
@@ -1,0 +1,105 @@
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  type DOMConversionMap,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type SerializedLexicalNode,
+} from "lexical";
+import { useAssignedDate } from "../letterRenderContext";
+
+export type SerializedAssignedSundayCalloutNode = SerializedLexicalNode;
+
+/** Block-level decorator: the gradient bordeaux+brass callout that
+ *  marks the speaker's assigned Sunday in the letter body. Lifted out
+ *  of `LetterCanvas`'s fragile `splitParagraphs` heuristic — now an
+ *  explicit Lexical node the bishop can drag, delete, or duplicate.
+ *
+ *  The visible date is supplied via `LetterRenderContextProvider` so
+ *  the same template renders with a different date for every speaker
+ *  without mutating the editor state. */
+export class AssignedSundayCalloutNode extends DecoratorNode<React.ReactElement> {
+  static getType(): string {
+    return "assigned-sunday-callout";
+  }
+
+  static clone(node: AssignedSundayCalloutNode): AssignedSundayCalloutNode {
+    return new AssignedSundayCalloutNode(node.__key);
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  isKeyboardSelectable(): boolean {
+    return true;
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const div = document.createElement("div");
+    div.style.display = "block";
+    return div;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const div = document.createElement("div");
+    div.setAttribute("data-assigned-sunday-callout", "true");
+    return { element: div };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      div: (el: HTMLElement) => {
+        if (el.getAttribute("data-assigned-sunday-callout") !== "true") return null;
+        return {
+          conversion: () => ({ node: $createAssignedSundayCalloutNode() }),
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  exportJSON(): SerializedAssignedSundayCalloutNode {
+    return { type: AssignedSundayCalloutNode.getType(), version: 1 };
+  }
+
+  static importJSON(_json: SerializedAssignedSundayCalloutNode): AssignedSundayCalloutNode {
+    return $createAssignedSundayCalloutNode();
+  }
+
+  decorate(): React.ReactElement {
+    return <AssignedSundayCalloutView />;
+  }
+}
+
+function AssignedSundayCalloutView() {
+  const date = useAssignedDate();
+  return (
+    <div
+      contentEditable={false}
+      className="select-none my-5 px-6 py-4 bg-linear-to-b from-brass-soft/15 to-brass-soft/5 border-l-2 border-brass rounded-r-md"
+    >
+      <div className="font-mono text-[9.5px] tracking-[0.22em] uppercase text-brass-deep mb-2">
+        Assigned Sunday
+      </div>
+      <div className="font-display text-[22px] italic text-walnut">
+        {date ?? "Assigned Sunday — set per speaker"}
+      </div>
+    </div>
+  );
+}
+
+export function $createAssignedSundayCalloutNode(): AssignedSundayCalloutNode {
+  return $applyNodeReplacement(new AssignedSundayCalloutNode());
+}
+
+export function $isAssignedSundayCalloutNode(
+  node: LexicalNode | null | undefined,
+): node is AssignedSundayCalloutNode {
+  return node instanceof AssignedSundayCalloutNode;
+}

--- a/src/features/page-editor/nodes/ImageNode.tsx
+++ b/src/features/page-editor/nodes/ImageNode.tsx
@@ -1,0 +1,146 @@
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  type DOMConversionMap,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from "lexical";
+
+export type SerializedImageNode = Spread<
+  { src: string; alt: string; widthPct: number; caption?: string },
+  SerializedLexicalNode
+>;
+
+interface ImageOpts {
+  src: string;
+  alt: string;
+  widthPct?: number;
+  caption?: string;
+}
+
+/** Inline-image block. Renders an `<img>` with an optional caption,
+ *  centered on the page at a percentage of the canvas width. Phase 1
+ *  ships data-URL + remote-URL sources only — Firebase Storage upload
+ *  glue lands in Phase 5 polish. */
+export class ImageNode extends DecoratorNode<React.ReactElement> {
+  __src: string;
+  __alt: string;
+  __widthPct: number;
+  __caption: string | undefined;
+
+  static getType(): string {
+    return "image";
+  }
+
+  static clone(node: ImageNode): ImageNode {
+    return new ImageNode(
+      { src: node.__src, alt: node.__alt, widthPct: node.__widthPct, caption: node.__caption },
+      node.__key,
+    );
+  }
+
+  constructor(opts: ImageOpts, key?: NodeKey) {
+    super(key);
+    this.__src = opts.src;
+    this.__alt = opts.alt;
+    this.__widthPct = opts.widthPct ?? 60;
+    this.__caption = opts.caption;
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  isKeyboardSelectable(): boolean {
+    return true;
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const div = document.createElement("div");
+    div.style.display = "block";
+    return div;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const fig = document.createElement("figure");
+    fig.setAttribute("data-image-node", "true");
+    const img = document.createElement("img");
+    img.src = this.__src;
+    img.alt = this.__alt;
+    img.style.width = `${this.__widthPct}%`;
+    fig.appendChild(img);
+    if (this.__caption) {
+      const cap = document.createElement("figcaption");
+      cap.textContent = this.__caption;
+      fig.appendChild(cap);
+    }
+    return { element: fig };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      img: (el: HTMLElement) => {
+        const img = el as HTMLImageElement;
+        return {
+          conversion: () => ({
+            node: $createImageNode({ src: img.src, alt: img.alt || "" }),
+          }),
+          priority: 0,
+        };
+      },
+    };
+  }
+
+  exportJSON(): SerializedImageNode {
+    return {
+      type: ImageNode.getType(),
+      version: 1,
+      src: this.__src,
+      alt: this.__alt,
+      widthPct: this.__widthPct,
+      caption: this.__caption,
+    };
+  }
+
+  static importJSON(json: SerializedImageNode): ImageNode {
+    return $createImageNode({
+      src: json.src,
+      alt: json.alt,
+      widthPct: json.widthPct,
+      caption: json.caption,
+    });
+  }
+
+  decorate(): React.ReactElement {
+    return (
+      <figure
+        contentEditable={false}
+        className="select-none my-4 mx-auto flex flex-col items-center"
+        style={{ width: `${this.__widthPct}%` }}
+      >
+        <img src={this.__src} alt={this.__alt} className="max-w-full block" />
+        {this.__caption && (
+          <figcaption className="mt-1 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
+            {this.__caption}
+          </figcaption>
+        )}
+      </figure>
+    );
+  }
+}
+
+export function $createImageNode(opts: ImageOpts): ImageNode {
+  return $applyNodeReplacement(new ImageNode(opts));
+}
+
+export function $isImageNode(node: LexicalNode | null | undefined): node is ImageNode {
+  return node instanceof ImageNode;
+}

--- a/src/features/page-editor/nodes/SignatureBlockNode.tsx
+++ b/src/features/page-editor/nodes/SignatureBlockNode.tsx
@@ -1,0 +1,121 @@
+import {
+  $applyNodeReplacement,
+  DecoratorNode,
+  type DOMConversionMap,
+  type DOMExportOutput,
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+} from "lexical";
+
+export type SerializedSignatureBlockNode = Spread<
+  { closing: string; signatory: string },
+  SerializedLexicalNode
+>;
+
+const DEFAULT_CLOSING = "With gratitude,";
+const DEFAULT_SIGNATORY = "The Bishopric";
+
+/** Block-level decorator that renders the closing-of-letter signature
+ *  line: a soft phrase ("With gratitude,"), a short walnut underline,
+ *  and the signatory in uppercase mono ("The Bishopric"). Promoted
+ *  from chrome to a Lexical node so the bishop can edit either piece
+ *  without touching the page frame. */
+export class SignatureBlockNode extends DecoratorNode<React.ReactElement> {
+  __closing: string;
+  __signatory: string;
+
+  static getType(): string {
+    return "signature-block";
+  }
+
+  static clone(node: SignatureBlockNode): SignatureBlockNode {
+    return new SignatureBlockNode(node.__closing, node.__signatory, node.__key);
+  }
+
+  constructor(closing = DEFAULT_CLOSING, signatory = DEFAULT_SIGNATORY, key?: NodeKey) {
+    super(key);
+    this.__closing = closing;
+    this.__signatory = signatory;
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  isKeyboardSelectable(): boolean {
+    return true;
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const div = document.createElement("div");
+    div.style.display = "block";
+    return div;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  exportDOM(): DOMExportOutput {
+    const div = document.createElement("div");
+    div.setAttribute("data-signature-block", "true");
+    div.setAttribute("data-closing", this.__closing);
+    div.setAttribute("data-signatory", this.__signatory);
+    return { element: div };
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      div: (el: HTMLElement) => {
+        if (el.getAttribute("data-signature-block") !== "true") return null;
+        const closing = el.getAttribute("data-closing") ?? DEFAULT_CLOSING;
+        const signatory = el.getAttribute("data-signatory") ?? DEFAULT_SIGNATORY;
+        return {
+          conversion: () => ({ node: $createSignatureBlockNode(closing, signatory) }),
+          priority: 1,
+        };
+      },
+    };
+  }
+
+  exportJSON(): SerializedSignatureBlockNode {
+    return {
+      type: SignatureBlockNode.getType(),
+      version: 1,
+      closing: this.__closing,
+      signatory: this.__signatory,
+    };
+  }
+
+  static importJSON(json: SerializedSignatureBlockNode): SignatureBlockNode {
+    return $createSignatureBlockNode(json.closing, json.signatory);
+  }
+
+  decorate(): React.ReactElement {
+    return (
+      <div contentEditable={false} className="select-none mt-7 mb-2 [&_.sig-rule]:border-walnut-3">
+        <div className="font-serif italic text-[16px] text-walnut mb-2">{this.__closing}</div>
+        <div className="sig-rule border-b border-walnut-3 w-[260px] mb-1.5" />
+        <div className="font-mono text-[10px] tracking-[0.18em] uppercase text-walnut-3">
+          {this.__signatory}
+        </div>
+      </div>
+    );
+  }
+}
+
+export function $createSignatureBlockNode(
+  closing?: string,
+  signatory?: string,
+): SignatureBlockNode {
+  return $applyNodeReplacement(new SignatureBlockNode(closing, signatory));
+}
+
+export function $isSignatureBlockNode(
+  node: LexicalNode | null | undefined,
+): node is SignatureBlockNode {
+  return node instanceof SignatureBlockNode;
+}

--- a/src/features/page-editor/pageEditorNodes.ts
+++ b/src/features/page-editor/pageEditorNodes.ts
@@ -1,6 +1,6 @@
 import type { Klass, LexicalNode } from "lexical";
 import { HeadingNode, QuoteNode } from "@lexical/rich-text";
-import { LinkNode } from "@lexical/link";
+import { AutoLinkNode, LinkNode } from "@lexical/link";
 import { ListItemNode, ListNode } from "@lexical/list";
 import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
 import { VariableChipNode } from "@/features/program-templates/nodes/VariableChipNode";
@@ -17,6 +17,7 @@ export const PAGE_EDITOR_BASE_NODES: ReadonlyArray<Klass<LexicalNode>> = [
   ListNode,
   ListItemNode,
   LinkNode,
+  AutoLinkNode,
   HorizontalRuleNode,
   VariableChipNode,
   SignatureBlockNode,

--- a/src/features/page-editor/pageEditorNodes.ts
+++ b/src/features/page-editor/pageEditorNodes.ts
@@ -1,0 +1,24 @@
+import type { Klass, LexicalNode } from "lexical";
+import { HeadingNode, QuoteNode } from "@lexical/rich-text";
+import { LinkNode } from "@lexical/link";
+import { ListItemNode, ListNode } from "@lexical/list";
+import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
+import { VariableChipNode } from "@/features/program-templates/nodes/VariableChipNode";
+import { SignatureBlockNode } from "./nodes/SignatureBlockNode";
+import { AssignedSundayCalloutNode } from "./nodes/AssignedSundayCalloutNode";
+
+/** Union of every node the WYSIWYG page editor knows about. Each
+ *  host editor (letter, conducting program, congregation program)
+ *  layers its own domain nodes onto this base via
+ *  `letterEditorConfig` / `programEditorConfig`. */
+export const PAGE_EDITOR_BASE_NODES: ReadonlyArray<Klass<LexicalNode>> = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+  HorizontalRuleNode,
+  VariableChipNode,
+  SignatureBlockNode,
+  AssignedSundayCalloutNode,
+];

--- a/src/features/page-editor/pageEditorNodes.ts
+++ b/src/features/page-editor/pageEditorNodes.ts
@@ -6,6 +6,7 @@ import { HorizontalRuleNode } from "@lexical/react/LexicalHorizontalRuleNode";
 import { VariableChipNode } from "@/features/program-templates/nodes/VariableChipNode";
 import { SignatureBlockNode } from "./nodes/SignatureBlockNode";
 import { AssignedSundayCalloutNode } from "./nodes/AssignedSundayCalloutNode";
+import { ImageNode } from "./nodes/ImageNode";
 
 /** Union of every node the WYSIWYG page editor knows about. Each
  *  host editor (letter, conducting program, congregation program)
@@ -22,4 +23,5 @@ export const PAGE_EDITOR_BASE_NODES: ReadonlyArray<Klass<LexicalNode>> = [
   VariableChipNode,
   SignatureBlockNode,
   AssignedSundayCalloutNode,
+  ImageNode,
 ];

--- a/src/features/page-editor/plugins/ImagePlugin.tsx
+++ b/src/features/page-editor/plugins/ImagePlugin.tsx
@@ -1,0 +1,37 @@
+import { useEffect } from "react";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { COMMAND_PRIORITY_EDITOR, createCommand, type LexicalCommand } from "lexical";
+import { $insertNodeToNearestRoot } from "@lexical/utils";
+import { $createImageNode } from "../nodes/ImageNode";
+
+interface InsertImagePayload {
+  src: string;
+  alt: string;
+  widthPct?: number;
+  caption?: string;
+}
+
+/** Command host editors can dispatch to drop an image into the
+ *  document at the current selection. The slash command and the
+ *  brass-ornament preset both fire this same command. */
+export const INSERT_IMAGE_COMMAND: LexicalCommand<InsertImagePayload> =
+  createCommand("INSERT_IMAGE_COMMAND");
+
+/** Listens for `INSERT_IMAGE_COMMAND` and inserts an `ImageNode` at
+ *  the nearest root location. Mounted by `PageEditorComposer` so any
+ *  WYSIWYG surface gains image insertion for free. */
+export function ImagePlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    return editor.registerCommand(
+      INSERT_IMAGE_COMMAND,
+      (payload) => {
+        const node = $createImageNode(payload);
+        $insertNodeToNearestRoot(node);
+        return true;
+      },
+      COMMAND_PRIORITY_EDITOR,
+    );
+  }, [editor]);
+  return null;
+}

--- a/src/features/page-editor/plugins/PageEditorAutoLink.tsx
+++ b/src/features/page-editor/plugins/PageEditorAutoLink.tsx
@@ -1,0 +1,36 @@
+import { AutoLinkPlugin, type LinkMatcher } from "@lexical/react/LexicalAutoLinkPlugin";
+
+const URL_RE = /(https?:\/\/[\w\-._~:/?#[\]@!$&'()*+,;=%]+|www\.[\w\-._~:/?#[\]@!$&'()*+,;=%]+)/i;
+const EMAIL_RE = /[\w._%+-]+@[\w.-]+\.[A-Za-z]{2,}/i;
+
+const MATCHERS: LinkMatcher[] = [
+  (text) => {
+    const m = URL_RE.exec(text);
+    if (!m) return null;
+    const matched = m[0];
+    return {
+      index: m.index,
+      length: matched.length,
+      text: matched,
+      url: matched.startsWith("http") ? matched : `https://${matched}`,
+    };
+  },
+  (text) => {
+    const m = EMAIL_RE.exec(text);
+    if (!m) return null;
+    return {
+      index: m.index,
+      length: m[0].length,
+      text: m[0],
+      url: `mailto:${m[0]}`,
+    };
+  },
+];
+
+/** Detects URLs + email addresses as the bishop types and wraps them
+ *  in `LinkNode` automatically. Pairs with `LinkPlugin` (already
+ *  mounted in `PageEditorComposer`) so links render with the editor's
+ *  link styling and round-trip through markdown. */
+export function PageEditorAutoLink() {
+  return <AutoLinkPlugin matchers={MATCHERS} />;
+}

--- a/src/features/page-editor/plugins/PageEditorMarkdownShortcuts.tsx
+++ b/src/features/page-editor/plugins/PageEditorMarkdownShortcuts.tsx
@@ -1,10 +1,44 @@
 import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
-import { TRANSFORMERS } from "@lexical/markdown";
+import {
+  BOLD_ITALIC_STAR,
+  BOLD_ITALIC_UNDERSCORE,
+  BOLD_STAR,
+  BOLD_UNDERSCORE,
+  HEADING,
+  ITALIC_STAR,
+  ITALIC_UNDERSCORE,
+  LINK,
+  ORDERED_LIST,
+  QUOTE,
+  STRIKETHROUGH,
+  UNORDERED_LIST,
+} from "@lexical/markdown";
 import { VARIABLE_CHIP_MARKDOWN_TRANSFORMER } from "@/features/program-templates/nodes/variableChipMarkdown";
 
-const PAGE_EDITOR_MARKDOWN_TRANSFORMERS = [VARIABLE_CHIP_MARKDOWN_TRANSFORMER, ...TRANSFORMERS];
+/** Hand-picked transformer set — excludes CODE / INLINE_CODE / CHECK_LIST
+ *  / HIGHLIGHT because those require nodes (`CodeNode`,
+ *  `CodeHighlightNode`, etc.) we don't register on the page editors.
+ *  `MarkdownShortcutPlugin` validates dependencies up front and throws
+ *  if any transformer references an unregistered node. Exported so
+ *  `letterEditorConfig` can use the same set for hydration via
+ *  `$convertFromMarkdownString`. */
+export const PAGE_EDITOR_MARKDOWN_TRANSFORMERS = [
+  VARIABLE_CHIP_MARKDOWN_TRANSFORMER,
+  HEADING,
+  QUOTE,
+  UNORDERED_LIST,
+  ORDERED_LIST,
+  LINK,
+  BOLD_ITALIC_STAR,
+  BOLD_ITALIC_UNDERSCORE,
+  BOLD_STAR,
+  BOLD_UNDERSCORE,
+  ITALIC_STAR,
+  ITALIC_UNDERSCORE,
+  STRIKETHROUGH,
+];
 
-/** Wires `# `, `> `, `* `, `1. `, `---`, `**bold**`, `*italic*`,
+/** Wires `# `, `> `, `* `, `1. `, `**bold**`, `*italic*`, `~~strike~~`,
  *  `[link](url)`, and `{{token}}` shortcuts through Lexical's official
  *  markdown shortcut plugin. The variable-chip transformer turns
  *  `{{speakerName}}` typed mid-paragraph into a chip the moment the

--- a/src/features/page-editor/plugins/PageEditorMarkdownShortcuts.tsx
+++ b/src/features/page-editor/plugins/PageEditorMarkdownShortcuts.tsx
@@ -1,0 +1,15 @@
+import { MarkdownShortcutPlugin } from "@lexical/react/LexicalMarkdownShortcutPlugin";
+import { TRANSFORMERS } from "@lexical/markdown";
+import { VARIABLE_CHIP_MARKDOWN_TRANSFORMER } from "@/features/program-templates/nodes/variableChipMarkdown";
+
+const PAGE_EDITOR_MARKDOWN_TRANSFORMERS = [VARIABLE_CHIP_MARKDOWN_TRANSFORMER, ...TRANSFORMERS];
+
+/** Wires `# `, `> `, `* `, `1. `, `---`, `**bold**`, `*italic*`,
+ *  `[link](url)`, and `{{token}}` shortcuts through Lexical's official
+ *  markdown shortcut plugin. The variable-chip transformer turns
+ *  `{{speakerName}}` typed mid-paragraph into a chip the moment the
+ *  closing `}` is typed (matching the trigger we already use in the
+ *  program-template editor). */
+export function PageEditorMarkdownShortcuts() {
+  return <MarkdownShortcutPlugin transformers={PAGE_EDITOR_MARKDOWN_TRANSFORMERS} />;
+}

--- a/src/features/page-editor/plugins/SlashCommandPlugin.tsx
+++ b/src/features/page-editor/plugins/SlashCommandPlugin.tsx
@@ -1,0 +1,95 @@
+import { useCallback, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import {
+  LexicalTypeaheadMenuPlugin,
+  MenuOption,
+  useBasicTypeaheadTriggerMatch,
+} from "@lexical/react/LexicalTypeaheadMenuPlugin";
+import { cn } from "@/lib/cn";
+import { filterSlashCommands, type SlashCommand } from "./SlashCommandRegistry";
+
+class SlashOption extends MenuOption {
+  constructor(public command: SlashCommand) {
+    super(command.id);
+  }
+}
+
+interface Props {
+  commands: ReadonlyArray<SlashCommand>;
+}
+
+/** Slash-command menu. Type `/` at the start of a paragraph to open
+ *  a typeahead with the host editor's registered commands; ↑/↓
+ *  navigate, Enter commits, Esc closes. Built on Lexical's official
+ *  `LexicalTypeaheadMenuPlugin` so it integrates with the editor's
+ *  selection / undo / IME handling for free. */
+export function SlashCommandPlugin({ commands }: Props) {
+  const [editor] = useLexicalComposerContext();
+  const [query, setQuery] = useState<string | null>(null);
+  const checkForSlash = useBasicTypeaheadTriggerMatch("/", { minLength: 0 });
+
+  const filtered = useMemo(
+    () => filterSlashCommands(commands, query ?? "").map((c) => new SlashOption(c)),
+    [commands, query],
+  );
+
+  const onSelect = useCallback(
+    (option: SlashOption, _nodeToReplace: unknown, closeMenu: () => void) => {
+      editor.update(() => option.command.onSelect(editor));
+      closeMenu();
+    },
+    [editor],
+  );
+
+  return (
+    <LexicalTypeaheadMenuPlugin<SlashOption>
+      onQueryChange={setQuery}
+      onSelectOption={onSelect}
+      triggerFn={checkForSlash}
+      options={filtered}
+      menuRenderFn={(
+        anchorElementRef,
+        { selectedIndex, selectOptionAndCleanUp, setHighlightedIndex },
+      ) => {
+        if (anchorElementRef.current === null || filtered.length === 0) return null;
+        return createPortal(
+          <div className="z-50 w-72 rounded-lg border border-border-strong bg-chalk shadow-elev-3 py-1 max-h-72 overflow-y-auto">
+            {filtered.map((option, idx) => (
+              <button
+                key={option.key}
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onMouseEnter={() => setHighlightedIndex(idx)}
+                onClick={() => selectOptionAndCleanUp(option)}
+                className={cn(
+                  "w-full px-3 py-2 flex items-start gap-2.5 text-left transition-colors",
+                  selectedIndex === idx
+                    ? "bg-parchment-2"
+                    : "bg-transparent hover:bg-parchment-2/60",
+                )}
+              >
+                {option.command.icon && (
+                  <span className="shrink-0 w-5 h-5 grid place-items-center font-mono text-walnut-2">
+                    {option.command.icon}
+                  </span>
+                )}
+                <span className="flex-1 min-w-0">
+                  <span className="block font-sans text-[13px] text-walnut">
+                    {option.command.label}
+                  </span>
+                  {option.command.description && (
+                    <span className="block font-serif italic text-[11.5px] text-walnut-3">
+                      {option.command.description}
+                    </span>
+                  )}
+                </span>
+              </button>
+            ))}
+          </div>,
+          anchorElementRef.current,
+        );
+      }}
+    />
+  );
+}

--- a/src/features/page-editor/plugins/SlashCommandRegistry.ts
+++ b/src/features/page-editor/plugins/SlashCommandRegistry.ts
@@ -1,0 +1,33 @@
+import type { LexicalEditor } from "lexical";
+
+export interface SlashCommand {
+  /** Stable identifier — drives keys + filter matching. */
+  id: string;
+  /** Display label shown in the typeahead menu. */
+  label: string;
+  /** Optional one-line description rendered under the label. */
+  description?: string;
+  /** Comma-separated alias keywords for filter matching, e.g.
+   *  "img, picture, photo" so the bishop can find image with multiple
+   *  natural words. */
+  keywords?: string;
+  /** Single-character icon glyph rendered in the menu (✦, ⌘, ¶, etc.).
+   *  We avoid icon fonts here to keep the slash menu lightweight. */
+  icon?: string;
+  /** Fired when the option is committed via Enter or click. The
+   *  registry passes the live editor so commands can dispatch
+   *  custom commands or call `editor.update`. */
+  onSelect: (editor: LexicalEditor) => void;
+}
+
+export function filterSlashCommands(
+  commands: ReadonlyArray<SlashCommand>,
+  query: string,
+): SlashCommand[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return [...commands];
+  return commands.filter((c) => {
+    const haystack = `${c.label} ${c.id} ${c.keywords ?? ""}`.toLowerCase();
+    return haystack.includes(q);
+  });
+}

--- a/src/features/page-editor/serializeForInterpolation.test.ts
+++ b/src/features/page-editor/serializeForInterpolation.test.ts
@@ -1,0 +1,109 @@
+import type { SerializedEditorState } from "lexical";
+import { describe, expect, it } from "vitest";
+import { legacyFieldsFromState, serializeForInterpolation } from "./serializeForInterpolation";
+
+function state(children: object[]): SerializedEditorState {
+  return {
+    root: {
+      type: "root",
+      version: 1,
+      direction: null,
+      format: "",
+      indent: 0,
+      children,
+    },
+  } as unknown as SerializedEditorState;
+}
+
+function paragraph(...inline: object[]) {
+  return { type: "paragraph", version: 1, children: inline };
+}
+function text(t: string, format = 0) {
+  return { type: "text", version: 1, text: t, format };
+}
+function chip(token: string) {
+  return { type: "variable-chip", version: 1, token };
+}
+function callout() {
+  return { type: "assigned-sunday-callout", version: 1 };
+}
+function signature(closing = "With gratitude,", signatory = "The Bishopric") {
+  return { type: "signature-block", version: 1, closing, signatory };
+}
+
+describe("serializeForInterpolation", () => {
+  it("emits paragraphs joined by blank lines", () => {
+    const s = state([paragraph(text("Hello")), paragraph(text("World"))]);
+    expect(serializeForInterpolation(s)).toBe("Hello\n\nWorld");
+  });
+
+  it("emits variable chips as {{token}} text", () => {
+    const s = state([paragraph(text("Dear "), chip("speakerName"), text(","))]);
+    expect(serializeForInterpolation(s)).toBe("Dear {{speakerName}},");
+  });
+
+  it("emits assigned-Sunday callout as bold {{date}} for email/SMS paths", () => {
+    const s = state([paragraph(text("First")), callout(), paragraph(text("After"))]);
+    expect(serializeForInterpolation(s)).toBe("First\n\n**{{date}}**\n\nAfter");
+  });
+
+  it("emits signature block as closing + signatory paragraphs", () => {
+    const s = state([paragraph(text("Body")), signature("In faith,", "Bishop Reeves")]);
+    expect(serializeForInterpolation(s)).toBe("Body\n\nIn faith,\n\nBishop Reeves");
+  });
+});
+
+describe("legacyFieldsFromState", () => {
+  it("splits at the signature block — body before, footer is the last paragraph after", () => {
+    const s = state([
+      paragraph(text("Greeting")),
+      paragraph(text("Body")),
+      signature(),
+      paragraph(text("Closing scripture")),
+    ]);
+    expect(legacyFieldsFromState(s)).toEqual({
+      bodyMarkdown: "Greeting\n\nBody",
+      footerMarkdown: "Closing scripture",
+    });
+  });
+
+  it("omits the assigned-Sunday callout from the body — print chrome already inserts it", () => {
+    const s = state([
+      paragraph(text("Dear "), chip("speakerName"), text(",")),
+      callout(),
+      paragraph(text("Topic: "), chip("topic")),
+      signature(),
+      paragraph(text("Scripture")),
+    ]);
+    expect(legacyFieldsFromState(s)).toEqual({
+      bodyMarkdown: "Dear {{speakerName}},\n\nTopic: {{topic}}",
+      footerMarkdown: "Scripture",
+    });
+  });
+
+  it("returns empty footer when no post-signature paragraph exists", () => {
+    const s = state([paragraph(text("Body")), signature()]);
+    expect(legacyFieldsFromState(s)).toEqual({ bodyMarkdown: "Body", footerMarkdown: "" });
+  });
+
+  it("treats all blocks as body when no signature-block exists", () => {
+    const s = state([paragraph(text("A")), paragraph(text("B"))]);
+    expect(legacyFieldsFromState(s)).toEqual({
+      bodyMarkdown: "A\n\nB",
+      footerMarkdown: "",
+    });
+  });
+
+  it("carries multiple post-signature paragraphs into the body — only the last is the footer", () => {
+    const s = state([
+      paragraph(text("Body")),
+      signature(),
+      paragraph(text("Carry")),
+      paragraph(text("Final")),
+    ]);
+    expect(legacyFieldsFromState(s)).toEqual({
+      bodyMarkdown: "Body\n\nCarry",
+      footerMarkdown: "Final",
+    });
+  });
+});

--- a/src/features/page-editor/serializeForInterpolation.ts
+++ b/src/features/page-editor/serializeForInterpolation.ts
@@ -1,0 +1,146 @@
+import type { SerializedEditorState, SerializedLexicalNode } from "lexical";
+
+interface SerializedTextNode extends SerializedLexicalNode {
+  text: string;
+  format?: number;
+}
+
+interface SerializedElementNode extends SerializedLexicalNode {
+  children?: SerializedLexicalNode[];
+  tag?: string;
+  listType?: "bullet" | "number" | "check";
+}
+
+const FORMAT_BOLD = 1;
+const FORMAT_ITALIC = 2;
+const FORMAT_UNDERLINE = 8;
+const FORMAT_CODE = 16;
+
+/** Walks a Lexical EditorState JSON tree and emits a flat
+ *  markdown-ish string suitable for the email/SMS interpolation
+ *  pipeline. Custom nodes (variable chips, signature, callout) emit
+ *  their interpolation tokens or stable text equivalents so the
+ *  existing template-rendering path keeps working unchanged.
+ *
+ *  Not a full markdown serializer — only the constructs the speaker
+ *  letter uses today (paragraphs, lists, headings, bold/italic,
+ *  variable chips, signature line, assigned-Sunday callout). When
+ *  Phase 3 adds program nodes the walker grows. */
+export function serializeForInterpolation(state: SerializedEditorState): string {
+  const root = state.root as SerializedElementNode;
+  const blocks = root.children ?? [];
+  return blocks
+    .map(serializeBlock)
+    .filter((s) => s.length > 0)
+    .join("\n\n");
+}
+
+/** Splits the editor state into the legacy `bodyMarkdown` /
+ *  `footerMarkdown` field pair the existing storage + email path
+ *  expect. The split point is the first `signature-block` node;
+ *  everything before is body, the last paragraph after it is
+ *  footer. Used during the dual-write window so older readers
+ *  (Cloud Functions, receipt emails) keep working unchanged. */
+export function legacyFieldsFromState(state: SerializedEditorState): {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+} {
+  const root = state.root as SerializedElementNode;
+  const blocks = root.children ?? [];
+  const sigIdx = blocks.findIndex((b) => b.type === "signature-block");
+  if (sigIdx < 0) {
+    return {
+      bodyMarkdown: blocks.map(serializeBlock).filter(Boolean).join("\n\n"),
+      footerMarkdown: "",
+    };
+  }
+  const before = blocks.slice(0, sigIdx);
+  const after = blocks.slice(sigIdx + 1);
+  const bodyMarkdown = before.map(serializeBlock).filter(Boolean).join("\n\n");
+  // The footer is conventionally a single trailing paragraph (the
+  // scripture). When there are multiple post-signature paragraphs we
+  // keep the last one as `footerMarkdown` and append the rest to the
+  // body so no content gets dropped.
+  if (after.length === 0) return { bodyMarkdown, footerMarkdown: "" };
+  const footerBlock = after[after.length - 1];
+  const footerMarkdown = serializeBlock(footerBlock);
+  const carry = after.slice(0, -1).map(serializeBlock).filter(Boolean).join("\n\n");
+  return {
+    bodyMarkdown: carry ? `${bodyMarkdown}\n\n${carry}` : bodyMarkdown,
+    footerMarkdown,
+  };
+}
+
+function serializeBlock(node: SerializedLexicalNode): string {
+  switch (node.type) {
+    case "paragraph":
+      return serializeInline((node as SerializedElementNode).children ?? []);
+    case "heading": {
+      const tag = (node as SerializedElementNode).tag ?? "h2";
+      const level = Math.max(1, Math.min(6, parseInt(tag.replace("h", ""), 10) || 2));
+      const inner = serializeInline((node as SerializedElementNode).children ?? []);
+      return `${"#".repeat(level)} ${inner}`;
+    }
+    case "quote":
+      return `> ${serializeInline((node as SerializedElementNode).children ?? [])}`;
+    case "list": {
+      const el = node as SerializedElementNode;
+      const ordered = el.listType === "number";
+      const items = el.children ?? [];
+      return items
+        .map((item, i) => {
+          const inner = serializeInline((item as SerializedElementNode).children ?? []);
+          return ordered ? `${i + 1}. ${inner}` : `- ${inner}`;
+        })
+        .join("\n");
+    }
+    case "horizontalrule":
+      return "---";
+    case "assigned-sunday-callout":
+      // The callout's date resolves at render time from
+      // `LetterRenderContext` — for plain-text interpolation we emit
+      // the {{date}} token so the email/SMS pipeline injects the
+      // assigned Sunday in plain text.
+      return "**{{date}}**";
+    case "signature-block": {
+      const closing = (node as unknown as { closing?: string }).closing ?? "With gratitude,";
+      const signatory = (node as unknown as { signatory?: string }).signatory ?? "The Bishopric";
+      return `${closing}\n\n${signatory}`;
+    }
+    default:
+      return "";
+  }
+}
+
+function serializeInline(children: SerializedLexicalNode[]): string {
+  return children.map(serializeInlineNode).join("");
+}
+
+function serializeInlineNode(node: SerializedLexicalNode): string {
+  switch (node.type) {
+    case "text": {
+      const t = node as SerializedTextNode;
+      let s = t.text;
+      const fmt = t.format ?? 0;
+      if (fmt & FORMAT_CODE) s = `\`${s}\``;
+      if (fmt & FORMAT_BOLD) s = `**${s}**`;
+      if (fmt & FORMAT_ITALIC) s = `*${s}*`;
+      if (fmt & FORMAT_UNDERLINE) s = `<u>${s}</u>`;
+      return s;
+    }
+    case "linebreak":
+      return "\n";
+    case "variable-chip": {
+      const token = (node as unknown as { token?: string }).token ?? "";
+      return `{{${token}}}`;
+    }
+    case "link": {
+      const url = (node as unknown as { url?: string }).url ?? "";
+      const inner = serializeInline((node as SerializedElementNode).children ?? []);
+      return `[${inner}](${url})`;
+    }
+    default:
+      // Unknown inline — fall back to its text children if any.
+      return serializeInline((node as SerializedElementNode).children ?? []);
+  }
+}

--- a/src/features/page-editor/serializeForInterpolation.ts
+++ b/src/features/page-editor/serializeForInterpolation.ts
@@ -36,11 +36,17 @@ export function serializeForInterpolation(state: SerializedEditorState): string 
 }
 
 /** Splits the editor state into the legacy `bodyMarkdown` /
- *  `footerMarkdown` field pair the existing storage + email path
+ *  `footerMarkdown` field pair the existing storage + print path
  *  expect. The split point is the first `signature-block` node;
  *  everything before is body, the last paragraph after it is
- *  footer. Used during the dual-write window so older readers
- *  (Cloud Functions, receipt emails) keep working unchanged. */
+ *  footer.
+ *
+ *  Differs from {@link serializeForInterpolation}: `LetterCanvas`
+ *  inserts the assigned-Sunday callout + signature row as page
+ *  chrome, so we *omit* those nodes from the markdown — emitting
+ *  them would duplicate them on the printed letter. Email/SMS
+ *  paths that don't have chrome continue to use
+ *  `serializeForInterpolation` instead. */
 export function legacyFieldsFromState(state: SerializedEditorState): {
   bodyMarkdown: string;
   footerMarkdown: string;
@@ -48,27 +54,25 @@ export function legacyFieldsFromState(state: SerializedEditorState): {
   const root = state.root as SerializedElementNode;
   const blocks = root.children ?? [];
   const sigIdx = blocks.findIndex((b) => b.type === "signature-block");
-  if (sigIdx < 0) {
-    return {
-      bodyMarkdown: blocks.map(serializeBlock).filter(Boolean).join("\n\n"),
-      footerMarkdown: "",
-    };
-  }
-  const before = blocks.slice(0, sigIdx);
-  const after = blocks.slice(sigIdx + 1);
-  const bodyMarkdown = before.map(serializeBlock).filter(Boolean).join("\n\n");
-  // The footer is conventionally a single trailing paragraph (the
-  // scripture). When there are multiple post-signature paragraphs we
-  // keep the last one as `footerMarkdown` and append the rest to the
-  // body so no content gets dropped.
+  const before = sigIdx < 0 ? blocks : blocks.slice(0, sigIdx);
+  const after = sigIdx < 0 ? [] : blocks.slice(sigIdx + 1);
+  const bodyMarkdown = before.map(serializeBlockForLegacy).filter(Boolean).join("\n\n");
   if (after.length === 0) return { bodyMarkdown, footerMarkdown: "" };
   const footerBlock = after[after.length - 1];
-  const footerMarkdown = serializeBlock(footerBlock);
-  const carry = after.slice(0, -1).map(serializeBlock).filter(Boolean).join("\n\n");
+  const footerMarkdown = serializeBlockForLegacy(footerBlock);
+  const carry = after.slice(0, -1).map(serializeBlockForLegacy).filter(Boolean).join("\n\n");
   return {
     bodyMarkdown: carry ? `${bodyMarkdown}\n\n${carry}` : bodyMarkdown,
     footerMarkdown,
   };
+}
+
+/** Variant of {@link serializeBlock} that omits the assigned-Sunday
+ *  callout + signature block. The legacy print path renders both as
+ *  page chrome, so emitting them as content would double them up. */
+function serializeBlockForLegacy(node: SerializedLexicalNode): string {
+  if (node.type === "assigned-sunday-callout" || node.type === "signature-block") return "";
+  return serializeBlock(node);
 }
 
 function serializeBlock(node: SerializedLexicalNode): string {

--- a/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
+++ b/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
@@ -44,6 +44,13 @@ export function useSpeakerLetterTemplateEditor() {
 
   useEffect(() => {
     if (loading || seeded) return;
+    console.log("[wysiwyg-seed] from snapshot", {
+      hasTemplate: !!template,
+      hasInitialJson: !!initialJson,
+      initialJsonLen: initialJson?.length ?? 0,
+      initialJsonHead: initialJson?.slice(0, 60),
+      initialPageStyle,
+    });
     setSavedJson(initialJson);
     setStateJson(initialJson);
     setSavedPageStyle(initialPageStyle);
@@ -57,7 +64,18 @@ export function useSpeakerLetterTemplateEditor() {
     JSON.stringify(pageStyle) !== JSON.stringify(savedPageStyle);
 
   async function save() {
-    if (!wardId || !stateJson) return;
+    console.log("[wysiwyg-save] called", {
+      wardId,
+      stateJsonLen: stateJson?.length ?? 0,
+      stateJsonHead: stateJson?.slice(0, 60),
+      savedJsonLen: savedJson?.length ?? 0,
+      pageStyle,
+      dirty,
+    });
+    if (!wardId || !stateJson) {
+      console.warn("[wysiwyg-save] aborted — missing wardId or stateJson", { wardId, hasStateJson: !!stateJson });
+      return;
+    }
     setSaving(true);
     setError(null);
     try {
@@ -65,11 +83,13 @@ export function useSpeakerLetterTemplateEditor() {
         editorStateJson: stateJson,
         pageStyle: pageStyle ?? undefined,
       });
+      console.log("[wysiwyg-save] wrote successfully");
       setSavedJson(stateJson);
       setSavedPageStyle(pageStyle);
       setUsingDefault(false);
       setSavedAt(nowLabel());
     } catch (e) {
+      console.error("[wysiwyg-save] write threw", e);
       setError(friendlyWriteError(e));
     } finally {
       setSaving(false);
@@ -88,6 +108,10 @@ export function useSpeakerLetterTemplateEditor() {
    *  false and `save()` always has content to write — even when the
    *  bishop only edits page-style. */
   function captureInitial(json: string) {
+    console.log("[wysiwyg-capture] initial state from editor", {
+      jsonLen: json.length,
+      jsonHead: json.slice(0, 60),
+    });
     setStateJson(json);
     setSavedJson(json);
   }

--- a/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
+++ b/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
@@ -83,6 +83,15 @@ export function useSpeakerLetterTemplateEditor() {
     setError(null);
   }
 
+  /** Called by `PageEditorComposer` once on mount with the hydrated
+   *  state. Seeds both `stateJson` and `savedJson` so dirty starts at
+   *  false and `save()` always has content to write — even when the
+   *  bishop only edits page-style. */
+  function captureInitial(json: string) {
+    setStateJson(json);
+    setSavedJson(json);
+  }
+
   return {
     seeded,
     dirty,
@@ -96,6 +105,7 @@ export function useSpeakerLetterTemplateEditor() {
     editorKey,
     setStateJson,
     setPageStyle,
+    captureInitial,
     save,
     discard,
   };

--- a/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
+++ b/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
@@ -44,13 +44,6 @@ export function useSpeakerLetterTemplateEditor() {
 
   useEffect(() => {
     if (loading || seeded) return;
-    console.log("[wysiwyg-seed] from snapshot", {
-      hasTemplate: !!template,
-      hasInitialJson: !!initialJson,
-      initialJsonLen: initialJson?.length ?? 0,
-      initialJsonHead: initialJson?.slice(0, 60),
-      initialPageStyle,
-    });
     setSavedJson(initialJson);
     setStateJson(initialJson);
     setSavedPageStyle(initialPageStyle);
@@ -64,18 +57,7 @@ export function useSpeakerLetterTemplateEditor() {
     JSON.stringify(pageStyle) !== JSON.stringify(savedPageStyle);
 
   async function save() {
-    console.log("[wysiwyg-save] called", {
-      wardId,
-      stateJsonLen: stateJson?.length ?? 0,
-      stateJsonHead: stateJson?.slice(0, 60),
-      savedJsonLen: savedJson?.length ?? 0,
-      pageStyle,
-      dirty,
-    });
-    if (!wardId || !stateJson) {
-      console.warn("[wysiwyg-save] aborted — missing wardId or stateJson", { wardId, hasStateJson: !!stateJson });
-      return;
-    }
+    if (!wardId || !stateJson) return;
     setSaving(true);
     setError(null);
     try {
@@ -83,13 +65,11 @@ export function useSpeakerLetterTemplateEditor() {
         editorStateJson: stateJson,
         pageStyle: pageStyle ?? undefined,
       });
-      console.log("[wysiwyg-save] wrote successfully");
       setSavedJson(stateJson);
       setSavedPageStyle(pageStyle);
       setUsingDefault(false);
       setSavedAt(nowLabel());
     } catch (e) {
-      console.error("[wysiwyg-save] write threw", e);
       setError(friendlyWriteError(e));
     } finally {
       setSaving(false);
@@ -108,10 +88,6 @@ export function useSpeakerLetterTemplateEditor() {
    *  false and `save()` always has content to write — even when the
    *  bishop only edits page-style. */
   function captureInitial(json: string) {
-    console.log("[wysiwyg-capture] initial state from editor", {
-      jsonLen: json.length,
-      jsonHead: json.slice(0, 60),
-    });
     setStateJson(json);
     setSavedJson(json);
   }

--- a/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
+++ b/src/features/page-editor/useSpeakerLetterTemplateEditor.ts
@@ -1,0 +1,102 @@
+import { useEffect, useMemo, useState } from "react";
+import { useSpeakerLetterTemplate } from "@/features/templates/useSpeakerLetterTemplate";
+import { writeSpeakerLetterTemplate } from "@/features/templates/writeSpeakerLetterTemplate";
+import {
+  DEFAULT_SPEAKER_LETTER_BODY,
+  DEFAULT_SPEAKER_LETTER_FOOTER,
+} from "@/features/templates/speakerLetterDefaults";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import type { LetterPageStyle } from "@/lib/types/template";
+
+function nowLabel(): string {
+  return new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
+/** Hook owning the WYSIWYG speaker-letter template editor's state +
+ *  dual-write persistence. Surfaces seed-from-legacy markdown +
+ *  editor-state-JSON dirty tracking + save / discard handlers, so the
+ *  route component stays inside the 150-LOC cap. */
+export function useSpeakerLetterTemplateEditor() {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const { data: template, loading } = useSpeakerLetterTemplate();
+
+  const [stateJson, setStateJson] = useState<string | null>(null);
+  const [savedJson, setSavedJson] = useState<string | null>(null);
+  const [pageStyle, setPageStyle] = useState<LetterPageStyle | null>(null);
+  const [savedPageStyle, setSavedPageStyle] = useState<LetterPageStyle | null>(null);
+  const [seeded, setSeeded] = useState(false);
+  const [editorKey, setEditorKey] = useState(0);
+  const [usingDefault, setUsingDefault] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const initialMarkdown = useMemo(
+    () => ({
+      bodyMarkdown: template?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+      footerMarkdown: template?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+    }),
+    [template?.bodyMarkdown, template?.footerMarkdown],
+  );
+  const initialJson = template?.editorStateJson ?? null;
+  const initialPageStyle = template?.pageStyle ?? null;
+
+  useEffect(() => {
+    if (loading || seeded) return;
+    setSavedJson(initialJson);
+    setStateJson(initialJson);
+    setSavedPageStyle(initialPageStyle);
+    setPageStyle(initialPageStyle);
+    setUsingDefault(!template);
+    setSeeded(true);
+  }, [loading, seeded, template, initialJson, initialPageStyle]);
+
+  const dirty =
+    (stateJson !== savedJson && stateJson !== null) ||
+    JSON.stringify(pageStyle) !== JSON.stringify(savedPageStyle);
+
+  async function save() {
+    if (!wardId || !stateJson) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeSpeakerLetterTemplate(wardId, {
+        editorStateJson: stateJson,
+        pageStyle: pageStyle ?? undefined,
+      });
+      setSavedJson(stateJson);
+      setSavedPageStyle(pageStyle);
+      setUsingDefault(false);
+      setSavedAt(nowLabel());
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setStateJson(savedJson);
+    setPageStyle(savedPageStyle);
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  return {
+    seeded,
+    dirty,
+    saving,
+    error,
+    savedAt,
+    usingDefault,
+    initialJson,
+    initialPageStyle: pageStyle,
+    initialMarkdown,
+    editorKey,
+    setStateJson,
+    setPageStyle,
+    save,
+    discard,
+  };
+}

--- a/src/features/program-templates/StyleSwatchesPopover.tsx
+++ b/src/features/program-templates/StyleSwatchesPopover.tsx
@@ -1,0 +1,154 @@
+import { useState } from "react";
+import type { LexicalEditor } from "lexical";
+import { $getSelection, $isRangeSelection } from "lexical";
+import { $patchStyleText } from "@lexical/selection";
+import { cn } from "@/lib/cn";
+
+interface ColorToken {
+  label: string;
+  value: string | null;
+  swatch: string;
+}
+
+const COLORS: ColorToken[] = [
+  { label: "Default", value: null, swatch: "transparent" },
+  { label: "Walnut", value: "var(--color-walnut)", swatch: "#3b2a22" },
+  { label: "Walnut 2", value: "var(--color-walnut-2)", swatch: "#5a4636" },
+  { label: "Walnut 3", value: "var(--color-walnut-3)", swatch: "#8a7460" },
+  { label: "Brass deep", value: "var(--color-brass-deep)", swatch: "#8e6a36" },
+  { label: "Bordeaux", value: "var(--color-bordeaux)", swatch: "#8b2e2a" },
+  { label: "Ink", value: "var(--color-ink)", swatch: "#231815" },
+];
+
+interface FontToken {
+  label: string;
+  value: string | null;
+}
+const FONTS: FontToken[] = [
+  { label: "Default", value: null },
+  { label: "Serif", value: "var(--font-serif), serif" },
+  { label: "Sans", value: "var(--font-sans), sans-serif" },
+  { label: "Mono", value: "var(--font-mono), monospace" },
+];
+
+interface SizeToken {
+  label: string;
+  value: string | null;
+}
+const SIZES: SizeToken[] = [
+  { label: "Default", value: null },
+  { label: "Sm", value: "13px" },
+  { label: "Base", value: "15px" },
+  { label: "Lg", value: "17px" },
+  { label: "Xl", value: "20px" },
+];
+
+interface Props {
+  editor: LexicalEditor;
+}
+
+/** Inline style picker — design-token color / font-family / font-size
+ *  applied to the current selection via `@lexical/selection`'s
+ *  `$patchStyleText`. Constrained to the system tokens defined in
+ *  `src/styles/index.css` so authors can stylize without drifting
+ *  off-brand. Mounted from `FloatingSelectionToolbar` behind a small
+ *  "A" trigger so it doesn't crowd the always-visible buttons. */
+export function StyleSwatchesPopover({ editor }: Props) {
+  function applyStyle(patch: Record<string, string | null>) {
+    editor.update(() => {
+      const sel = $getSelection();
+      if ($isRangeSelection(sel)) $patchStyleText(sel, patch);
+    });
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Text style"
+      className="absolute top-[calc(100%+6px)] left-1/2 -translate-x-1/2 w-72 rounded-lg border border-border-strong bg-chalk shadow-elev-3 p-3 flex flex-col gap-3"
+      onMouseDown={(e) => e.preventDefault()}
+    >
+      <Section label="Color">
+        <div className="flex gap-1.5 flex-wrap">
+          {COLORS.map((c) => (
+            <button
+              key={c.label}
+              type="button"
+              aria-label={c.label}
+              title={c.label}
+              onClick={() => applyStyle({ color: c.value })}
+              className={cn(
+                "h-6 w-6 rounded-full border border-border-strong transition-shadow",
+                c.value === null &&
+                  "bg-[repeating-linear-gradient(45deg,_var(--color-border-strong)_0_2px,_transparent_2px_4px)]",
+              )}
+              style={c.value !== null ? { background: c.swatch } : undefined}
+            />
+          ))}
+        </div>
+      </Section>
+      <Section label="Font">
+        <div className="flex gap-1.5 flex-wrap">
+          {FONTS.map((f) => (
+            <button
+              key={f.label}
+              type="button"
+              onClick={() => applyStyle({ "font-family": f.value })}
+              className="px-2.5 h-7 rounded-full border border-border-strong text-[12px] hover:bg-parchment-2"
+              style={f.value ? { fontFamily: f.value } : undefined}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+      </Section>
+      <Section label="Size">
+        <div className="flex gap-1.5 flex-wrap">
+          {SIZES.map((s) => (
+            <button
+              key={s.label}
+              type="button"
+              onClick={() => applyStyle({ "font-size": s.value })}
+              className="px-2.5 h-7 rounded-full border border-border-strong text-[12px] hover:bg-parchment-2"
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">{label}</div>
+      {children}
+    </div>
+  );
+}
+
+/** Toggleable trigger button + popover — exported so `floatingToolbarButtons`
+ *  can drop it into the toolbar pill alongside Bold / Italic / etc. */
+export function StyleSwatchesButton({ editor }: Props) {
+  const [open, setOpen] = useState(false);
+  return (
+    <span className="relative inline-flex">
+      <button
+        type="button"
+        aria-label="Text style"
+        title="Text style"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className={cn(
+          "h-7 min-w-7 px-1.5 rounded-full grid place-items-center text-[12.5px] text-walnut hover:bg-parchment-2 transition-colors",
+          open && "bg-walnut text-parchment hover:bg-walnut-2 hover:text-parchment",
+        )}
+      >
+        A
+      </button>
+      {open && <StyleSwatchesPopover editor={editor} />}
+    </span>
+  );
+}

--- a/src/features/program-templates/floatingToolbarButtons.tsx
+++ b/src/features/program-templates/floatingToolbarButtons.tsx
@@ -2,6 +2,7 @@ import type { LexicalEditor, TextFormatType } from "lexical";
 import { FORMAT_TEXT_COMMAND } from "lexical";
 import { TOGGLE_LINK_COMMAND } from "@lexical/link";
 import { cn } from "@/lib/cn";
+import { StyleSwatchesButton } from "./StyleSwatchesPopover";
 
 export interface ActiveFormats {
   bold: boolean;
@@ -87,6 +88,8 @@ export function ToolbarButtons({ editor, active }: ToolbarButtonsProps) {
       <FmtBtn label="Link" active={active.link} onClick={() => toggleLink(editor, active.link)}>
         <LinkIcon />
       </FmtBtn>
+      <Sep />
+      <StyleSwatchesButton editor={editor} />
     </>
   );
 }

--- a/src/features/program-templates/lexicalTheme.ts
+++ b/src/features/program-templates/lexicalTheme.ts
@@ -21,5 +21,10 @@ export const lexicalTheme: EditorThemeClasses = {
     bold: "font-semibold",
     italic: "italic",
     underline: "underline",
+    strikethrough: "line-through",
+    underlineStrikethrough: "underline line-through",
+    subscript: "align-sub text-[0.75em]",
+    superscript: "align-super text-[0.75em]",
+    code: "font-mono text-[0.92em] bg-parchment-2 px-1 py-px rounded",
   },
 };

--- a/src/features/templates/useSpeakerLetterTemplate.ts
+++ b/src/features/templates/useSpeakerLetterTemplate.ts
@@ -1,3 +1,4 @@
+import { useEffect } from "react";
 import { speakerLetterTemplateSchema } from "@/lib/types";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { useDocSnapshot } from "@/hooks/_sub";
@@ -10,8 +11,19 @@ import { useDocSnapshot } from "@/hooks/_sub";
  */
 export function useSpeakerLetterTemplate() {
   const wardId = useCurrentWardStore((s) => s.wardId);
-  return useDocSnapshot(
+  const result = useDocSnapshot(
     ["wards", wardId, "templates", "speakerLetter"],
     speakerLetterTemplateSchema,
   );
+  useEffect(() => {
+    if (result.error) {
+      console.error("[wysiwyg-read] speakerLetter schema parse failed", result.error);
+    } else if (!result.loading) {
+      console.log("[wysiwyg-read] snapshot result", {
+        hasData: !!result.data,
+        keys: result.data ? Object.keys(result.data) : null,
+      });
+    }
+  }, [result.loading, result.data, result.error]);
+  return result;
 }

--- a/src/features/templates/useSpeakerLetterTemplate.ts
+++ b/src/features/templates/useSpeakerLetterTemplate.ts
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { speakerLetterTemplateSchema } from "@/lib/types";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { useDocSnapshot } from "@/hooks/_sub";
@@ -11,19 +10,8 @@ import { useDocSnapshot } from "@/hooks/_sub";
  */
 export function useSpeakerLetterTemplate() {
   const wardId = useCurrentWardStore((s) => s.wardId);
-  const result = useDocSnapshot(
+  return useDocSnapshot(
     ["wards", wardId, "templates", "speakerLetter"],
     speakerLetterTemplateSchema,
   );
-  useEffect(() => {
-    if (result.error) {
-      console.error("[wysiwyg-read] speakerLetter schema parse failed", result.error);
-    } else if (!result.loading) {
-      console.log("[wysiwyg-read] snapshot result", {
-        hasData: !!result.data,
-        keys: result.data ? Object.keys(result.data) : null,
-      });
-    }
-  }, [result.loading, result.data, result.error]);
-  return result;
 }

--- a/src/features/templates/writeSpeakerLetterTemplate.ts
+++ b/src/features/templates/writeSpeakerLetterTemplate.ts
@@ -1,10 +1,17 @@
 import { doc, serverTimestamp, setDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import type { LetterPageStyle } from "@/lib/types/template";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
 
 export interface SpeakerLetterTemplateInput {
-  bodyMarkdown: string;
-  footerMarkdown: string;
+  /** Lexical EditorState as a JSON string — the new source of truth.
+   *  The writer derives `bodyMarkdown`/`footerMarkdown` from this so
+   *  legacy readers (Cloud Functions, receipt emails) keep working
+   *  during the ~30-day dual-write window. */
+  editorStateJson: string;
+  /** Optional page-frame styling (border + paper). Cleared when null. */
+  pageStyle?: LetterPageStyle | null;
 }
 
 /**
@@ -18,9 +25,13 @@ export async function writeSpeakerLetterTemplate(
 ): Promise<void> {
   reportSaving();
   try {
+    const state = JSON.parse(input.editorStateJson);
+    const { bodyMarkdown, footerMarkdown } = legacyFieldsFromState(state);
     await setDoc(doc(db, "wards", wardId, "templates", "speakerLetter"), {
-      bodyMarkdown: input.bodyMarkdown,
-      footerMarkdown: input.footerMarkdown,
+      editorStateJson: input.editorStateJson,
+      pageStyle: input.pageStyle ?? null,
+      bodyMarkdown,
+      footerMarkdown,
       updatedAt: serverTimestamp(),
     });
     reportSaved();

--- a/src/features/templates/writeSpeakerLetterTemplate.ts
+++ b/src/features/templates/writeSpeakerLetterTemplate.ts
@@ -25,8 +25,18 @@ export async function writeSpeakerLetterTemplate(
 ): Promise<void> {
   reportSaving();
   try {
+    console.log("[wysiwyg-writer] entering", {
+      wardId,
+      jsonLen: input.editorStateJson.length,
+      jsonHead: input.editorStateJson.slice(0, 60),
+      pageStyle: input.pageStyle,
+    });
     const state = JSON.parse(input.editorStateJson);
     const { bodyMarkdown, footerMarkdown } = legacyFieldsFromState(state);
+    console.log("[wysiwyg-writer] derived legacy fields", {
+      bodyLen: bodyMarkdown.length,
+      footerLen: footerMarkdown.length,
+    });
     await setDoc(doc(db, "wards", wardId, "templates", "speakerLetter"), {
       editorStateJson: input.editorStateJson,
       pageStyle: input.pageStyle ?? null,
@@ -34,8 +44,10 @@ export async function writeSpeakerLetterTemplate(
       footerMarkdown,
       updatedAt: serverTimestamp(),
     });
+    console.log("[wysiwyg-writer] setDoc resolved");
     reportSaved();
   } catch (e) {
+    console.error("[wysiwyg-writer] failed", e);
     reportSaveError(e);
     throw e;
   }

--- a/src/features/templates/writeSpeakerLetterTemplate.ts
+++ b/src/features/templates/writeSpeakerLetterTemplate.ts
@@ -25,18 +25,8 @@ export async function writeSpeakerLetterTemplate(
 ): Promise<void> {
   reportSaving();
   try {
-    console.log("[wysiwyg-writer] entering", {
-      wardId,
-      jsonLen: input.editorStateJson.length,
-      jsonHead: input.editorStateJson.slice(0, 60),
-      pageStyle: input.pageStyle,
-    });
     const state = JSON.parse(input.editorStateJson);
     const { bodyMarkdown, footerMarkdown } = legacyFieldsFromState(state);
-    console.log("[wysiwyg-writer] derived legacy fields", {
-      bodyLen: bodyMarkdown.length,
-      footerLen: footerMarkdown.length,
-    });
     await setDoc(doc(db, "wards", wardId, "templates", "speakerLetter"), {
       editorStateJson: input.editorStateJson,
       pageStyle: input.pageStyle ?? null,
@@ -44,10 +34,8 @@ export async function writeSpeakerLetterTemplate(
       footerMarkdown,
       updatedAt: serverTimestamp(),
     });
-    console.log("[wysiwyg-writer] setDoc resolved");
     reportSaved();
   } catch (e) {
-    console.error("[wysiwyg-writer] failed", e);
     reportSaveError(e);
     throw e;
   }

--- a/src/hooks/_sub.test.tsx
+++ b/src/hooks/_sub.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { z } from "zod";
+
+// Mock firebase/firestore so the hook never actually subscribes to a
+// real backend in this unit test. The fix under test is purely about
+// the LOADING flag while the path key is still null — we never need
+// onSnapshot to fire.
+vi.mock("firebase/firestore", () => ({
+  doc: vi.fn(() => ({})),
+  onSnapshot: vi.fn(() => () => {}),
+  collection: vi.fn(() => ({})),
+}));
+vi.mock("@/lib/firebase", () => ({ db: {} }));
+
+// Auth store factory — let each test set the auth status.
+const setAuthStatus = vi.fn();
+vi.mock("@/stores/authStore", () => ({
+  useAuthStore: (selector: (s: { status: string }) => unknown) =>
+    selector({ status: setAuthStatus.getMockImplementation()?.() ?? "signed_in" }),
+}));
+
+import { useDocSnapshot } from "./_sub";
+
+const schema = z.object({ x: z.string() });
+
+beforeEach(() => {
+  setAuthStatus.mockReset();
+  setAuthStatus.mockImplementation(() => "signed_in");
+});
+
+describe("useDocSnapshot loading semantics", () => {
+  it("stays loading=true when a path segment is undefined (e.g. wardId not yet resolved)", () => {
+    const { result } = renderHook(() =>
+      useDocSnapshot(["wards", undefined, "templates", "speakerLetter"], schema),
+    );
+    expect(result.current.loading).toBe(true);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("stays loading=true when a path segment is an empty string", () => {
+    const { result } = renderHook(() =>
+      useDocSnapshot(["wards", "", "templates", "speakerLetter"], schema),
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("stays loading=true when the user is signed out (segments still computable but auth blocks)", () => {
+    setAuthStatus.mockImplementation(() => "signed_out");
+    const { result } = renderHook(() =>
+      useDocSnapshot(["wards", "stv1", "templates", "speakerLetter"], schema),
+    );
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("stays loading=true when auth is still loading and segments are filled in", () => {
+    setAuthStatus.mockImplementation(() => "loading");
+    const { result } = renderHook(() =>
+      useDocSnapshot(["wards", "stv1", "templates", "speakerLetter"], schema),
+    );
+    expect(result.current.loading).toBe(true);
+  });
+});

--- a/src/hooks/_sub.ts
+++ b/src/hooks/_sub.ts
@@ -36,9 +36,14 @@ export function useDocSnapshot<T>(
 
   useEffect(() => {
     if (!key) {
-      // Treat the auth-loading window as "still loading" so callers don't
-      // briefly render empty states while the sign-in handshake resolves.
-      setState({ data: null, loading: authLoading, error: null });
+      // Stay in `loading: true` until every path segment is ready —
+      // including async-resolving ones like `wardId` from the current-
+      // ward store. Without this, the brief window where auth has
+      // resolved but `wardId` hasn't would surface a transient
+      // `loading: false, data: null` and let consumers (e.g. the
+      // speaker-letter editor) seed defaults before the real
+      // subscription even starts.
+      setState({ data: null, loading: true, error: null });
       return;
     }
     setState({ data: null, loading: true, error: null });
@@ -46,12 +51,6 @@ export function useDocSnapshot<T>(
     return onSnapshot(
       ref,
       (snap) => {
-        console.log("[sub-snapshot]", {
-          path: key,
-          exists: snap.exists(),
-          fromCache: snap.metadata.fromCache,
-          hasPendingWrites: snap.metadata.hasPendingWrites,
-        });
         // Firestore fires onSnapshot up to twice on first subscribe:
         // once with `metadata.fromCache: true` (local cache) before
         // the server response arrives, and again with `fromCache:
@@ -76,7 +75,7 @@ export function useDocSnapshot<T>(
       },
       (error) => setState({ data: null, loading: false, error }),
     );
-  }, [key, schema, authLoading]);
+  }, [key, schema]);
 
   return state;
 }
@@ -104,7 +103,9 @@ export function useCollectionSnapshot<T>(
 
   useEffect(() => {
     if (!key) {
-      setState({ data: [], loading: authLoading, error: null });
+      // Match useDocSnapshot — stay loading until every path segment
+      // is ready, including async-resolving wardId etc.
+      setState({ data: [], loading: true, error: null });
       return;
     }
     setState({ data: [], loading: true, error: null });
@@ -126,7 +127,7 @@ export function useCollectionSnapshot<T>(
       },
       (error) => setState({ data: [], loading: false, error }),
     );
-  }, [key, schema, authLoading]);
+  }, [key, schema]);
 
   return state;
 }

--- a/src/hooks/_sub.ts
+++ b/src/hooks/_sub.ts
@@ -24,13 +24,21 @@ export function useDocSnapshot<T>(
 ): DocSubState<T> {
   const authStatus = useAuthStore((s) => s.status);
   const signedIn = authStatus === "signed_in";
-  const authLoading = authStatus === "loading";
   const ready =
     signedIn && segments.every((s): s is string => typeof s === "string" && s.length > 0);
   const key = ready ? segments.join(JOIN) : null;
+  // Always start in `loading: true` — the very first React commit
+  // happens *before* any effect can subscribe, so callers can't be
+  // allowed to treat that pre-subscription frame as "loaded with no
+  // data". (Earlier code used `ready || authLoading` here, which
+  // surfaced loading=false in the brief window where auth had
+  // resolved but `wardId` was still being hydrated from the
+  // current-ward store. The speaker-letter editor read that as "no
+  // template exists, seed defaults" and locked seeded=true before
+  // the real onSnapshot fired.)
   const [state, setState] = useState<DocSubState<T>>({
     data: null,
-    loading: ready || authLoading,
+    loading: true,
     error: null,
   });
 
@@ -91,13 +99,14 @@ export function useCollectionSnapshot<T>(
 ): SubState<WithId<T>[]> {
   const authStatus = useAuthStore((s) => s.status);
   const signedIn = authStatus === "signed_in";
-  const authLoading = authStatus === "loading";
   const ready =
     signedIn && segments.every((s): s is string => typeof s === "string" && s.length > 0);
   const key = ready ? segments.join(JOIN) : null;
+  // Same rationale as useDocSnapshot — always start loading=true so
+  // callers don't read the pre-subscription frame as "loaded empty".
   const [state, setState] = useState<SubState<WithId<T>[]>>({
     data: [],
-    loading: ready || authLoading,
+    loading: true,
     error: null,
   });
 

--- a/src/hooks/_sub.ts
+++ b/src/hooks/_sub.ts
@@ -46,6 +46,17 @@ export function useDocSnapshot<T>(
     return onSnapshot(
       ref,
       (snap) => {
+        // Firestore fires onSnapshot up to twice on first subscribe:
+        // once with `metadata.fromCache: true` (local cache) before
+        // the server response arrives, and again with `fromCache:
+        // false` once it does. When the cache is empty (first visit
+        // OR right after a write that hasn't propagated to the local
+        // listener yet) the cache-miss fire reports `snap.exists() ===
+        // false` even though the server has the doc — handing the
+        // caller a transient "no data" state that races against the
+        // authoritative result. Skip those fires so callers only see
+        // a single, authoritative resolution.
+        if (snap.metadata.fromCache && !snap.exists()) return;
         if (!snap.exists()) {
           setState({ data: null, loading: false, error: null });
           return;

--- a/src/hooks/_sub.ts
+++ b/src/hooks/_sub.ts
@@ -46,6 +46,12 @@ export function useDocSnapshot<T>(
     return onSnapshot(
       ref,
       (snap) => {
+        console.log("[sub-snapshot]", {
+          path: key,
+          exists: snap.exists(),
+          fromCache: snap.metadata.fromCache,
+          hasPendingWrites: snap.metadata.hasPendingWrites,
+        });
         // Firestore fires onSnapshot up to twice on first subscribe:
         // once with `metadata.fromCache: true` (local cache) before
         // the server response arrives, and again with `fromCache:

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -3,19 +3,35 @@ import { z } from "zod";
 /**
  * Ward-level editable template for the speaker invitation letter.
  *
- * The letter renders with a fixed chrome (ornament / eyebrow / title /
- * subtitle / rule / date / callout / signature line / footer rule)
- * around two Markdown blocks authored by the bishopric or clerks:
+ * Shipping migration: the WYSIWYG editor stores the letter as a single
+ * Lexical EditorState JSON in `editorStateJson` (greeting + body +
+ * callout + signature + closing scripture all flow as one document).
+ * The legacy `bodyMarkdown` / `footerMarkdown` pair is dual-written
+ * for ~30 days so older readers (Cloud Functions, receipt-email
+ * payloads, the print path while in flight) keep working. Once the
+ * read-side is fully JSON-aware we'll drop the markdown fields in a
+ * follow-up cleanup.
  *
- * - `bodyMarkdown` sits between the date and the "With gratitude,"
- *   signature — the greeting + letter body.
- * - `footerMarkdown` is the single-line scripture at the bottom.
- *
- * Variables in Markdown (`{{speakerName}}`, `{{topic}}`, `{{date}}`,
- * `{{wardName}}`, `{{inviterName}}`, `{{today}}`) are interpolated at
- * render time — see `src/features/templates/interpolate.ts`.
+ * Variables in either representation use the same `{{token}}` syntax
+ * (`{{speakerName}}`, `{{topic}}`, `{{date}}`, `{{wardName}}`,
+ * `{{inviterName}}`, `{{today}}`) — interpolation happens at render
+ * time. See `src/features/templates/interpolate.ts`.
  */
+export const letterPageStyleSchema = z.object({
+  borderColor: z.enum(["none", "walnut", "brass-deep", "bordeaux"]).default("none"),
+  borderWidth: z.number().min(0).max(4).default(0),
+  borderStyle: z.enum(["solid", "double", "rule-and-ornament"]).default("solid"),
+  paper: z.enum(["chalk", "parchment", "parchment-2"]).default("chalk"),
+});
+export type LetterPageStyle = z.infer<typeof letterPageStyleSchema>;
+
 export const speakerLetterTemplateSchema = z.object({
+  /** Lexical EditorState as a JSON string. New WYSIWYG storage. */
+  editorStateJson: z.string().optional(),
+  /** Optional page-frame style (border + paper) — applied on the
+   *  PageCanvas wrapper, not as Lexical content. */
+  pageStyle: letterPageStyleSchema.nullable().optional(),
+  /** Legacy fields, kept readable + dual-written for ~30 days. */
   bodyMarkdown: z.string(),
   footerMarkdown: z.string(),
   updatedAt: z.any().optional(),


### PR DESCRIPTION
## Summary

Phase 1 of the WYSIWYG case study (plan: \`/Users/oriel/.claude/plans/i-think-we-must-mellow-harp.md\`). Stacked on the Phase 0 floating-toolbar branch (#138) — base merges to develop first, then this PR auto-rebases.

The speaker-letter template page now mounts a single Lexical contenteditable inside the letter chrome (ornament, eyebrow, title, date) instead of the split editor + preview + drag-handle layout. Greeting + body + assigned-Sunday callout + signature + closing scripture all flow as one continuous document.

## What's in
- **\`src/features/page-editor/\`** module:
  - \`PageEditorComposer\`, \`PageCanvas\`, \`LetterChrome\`, \`LetterPageEditor\`
  - DecoratorNodes: \`SignatureBlockNode\`, \`AssignedSundayCalloutNode\`, \`ImageNode\`
  - Plugins: \`ImagePlugin\`, \`PageEditorAutoLink\`, \`PageEditorMarkdownShortcuts\`, \`SlashCommandPlugin\`
  - Slash palette for the letter (H1-3, lists, quote, divider, image, brass-ornament preset)
  - Page-style panel (border + paper) wired through writeSpeakerLetterTemplate
  - Design-token color / font / size swatches in the floating toolbar
  - \`serializeForInterpolation\` + \`legacyFieldsFromState\` walkers for the dual-write window
- Schema gains optional \`editorStateJson\` + \`pageStyle\`. \`bodyMarkdown\` / \`footerMarkdown\` stay required + dual-written for ~30 days.
- Route \`templates-speaker-letter.tsx\` swaps \`SpeakerLetterPanel\` for the new editor.
- \`useDocSnapshot\` race fix: stays \`loading: true\` until path segments + auth resolve, so callers don't read a transient pre-subscription "loaded empty" frame as authoritative. Caught the WYSIWYG persistence bug.

## What's deferred
- **\`BlockDragHandlePlugin\`** + **\`PageStage\` pan/zoom** → Phase 5 polish. Drag is genuinely intricate; pan/zoom needs ~5-browser IME validation.
- **Firebase Storage upload UI** for ImageNode → Phase 5. ImageNode accepts data-URL + remote-URL today.
- **Legacy panel cleanup** (\`SpeakerLetterPanel\` etc.) → Phase 2, after the wizard migrates.

## Verification
- \`npm run typecheck\`, \`npm run lint\` (0 errors), \`npm run test\` (315 unit incl. 4 \`useDocSnapshot\` tests + 9 serializer tests), \`npm run build\` — all green.
- \`FIREBASE_PROJECT=<projectId> pnpm exec playwright test --config playwright.iterate.config.ts\` — 2/2 e2e pass:
  - \`wysiwyg-letter-persist\` — type → save → reload → marker survives.
  - \`wysiwyg-letter-slash\` — \`/divider\` → Enter inserts \`<hr>\`.

## Test plan
- [ ] Edit the letter, click Save, reload — content persists.
- [ ] Open the floating toolbar's "A" → color/font/size swatches apply to selected text.
- [ ] Type \`/\` at start of a paragraph → palette opens; H1/H2/H3, list, quote, divider, image, brass-ornament all insert correctly.
- [ ] Click "⚙ Page style" top-right → border + paper panel opens, changes apply live and persist.
- [ ] Print → PDF: output matches the prior editor (legacy markdown dual-write keeps the print path stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)