### PR TITLE
feat(page-editor): wizard + prepare-invitation per-speaker WYSIWYG (Phase 2)

### DIFF
--- a/src/app/routes/prepare-invitation.tsx
+++ b/src/app/routes/prepare-invitation.tsx
@@ -127,11 +127,13 @@ export function PrepareInvitationPage() {
       <div className="flex-1 min-h-0 lg:overflow-hidden px-5 sm:px-8 pt-5 pb-4">
         {form.hydrated ? (
           <PrepareInvitationLetterTab
-            key={form.resetKey}
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
             body={form.letterBody}
             footer={form.letterFooter}
-            setBody={form.setLetterBody}
-            setFooter={form.setLetterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
             vars={vars}
             previewToolbar={<PrepareInvitationActionBar {...toolbarProps} />}
           />

--- a/src/features/page-editor/letterSlashCommands.ts
+++ b/src/features/page-editor/letterSlashCommands.ts
@@ -4,16 +4,9 @@ import {
   $isRangeSelection,
   type LexicalEditor,
 } from "lexical";
-import {
-  $createHeadingNode,
-  $createQuoteNode,
-  type HeadingTagType,
-} from "@lexical/rich-text";
+import { $createHeadingNode, $createQuoteNode, type HeadingTagType } from "@lexical/rich-text";
 import { $setBlocksType } from "@lexical/selection";
-import {
-  INSERT_ORDERED_LIST_COMMAND,
-  INSERT_UNORDERED_LIST_COMMAND,
-} from "@lexical/list";
+import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list";
 import { INSERT_HORIZONTAL_RULE_COMMAND } from "@lexical/react/LexicalHorizontalRuleNode";
 import { INSERT_IMAGE_COMMAND } from "./plugins/ImagePlugin";
 import type { SlashCommand } from "./plugins/SlashCommandRegistry";
@@ -38,7 +31,8 @@ export const LETTER_SLASH_COMMANDS: readonly SlashCommand[] = [
     description: "Large section heading",
     keywords: "h1, title",
     icon: "H1",
-    onSelect: (editor) => setBlock(editor, () => $createHeadingNode("h1" as HeadingTagType) as never),
+    onSelect: (editor) =>
+      setBlock(editor, () => $createHeadingNode("h1" as HeadingTagType) as never),
   },
   {
     id: "heading-2",
@@ -46,7 +40,8 @@ export const LETTER_SLASH_COMMANDS: readonly SlashCommand[] = [
     description: "Medium section heading",
     keywords: "h2",
     icon: "H2",
-    onSelect: (editor) => setBlock(editor, () => $createHeadingNode("h2" as HeadingTagType) as never),
+    onSelect: (editor) =>
+      setBlock(editor, () => $createHeadingNode("h2" as HeadingTagType) as never),
   },
   {
     id: "heading-3",
@@ -54,7 +49,8 @@ export const LETTER_SLASH_COMMANDS: readonly SlashCommand[] = [
     description: "Small section heading",
     keywords: "h3",
     icon: "H3",
-    onSelect: (editor) => setBlock(editor, () => $createHeadingNode("h3" as HeadingTagType) as never),
+    onSelect: (editor) =>
+      setBlock(editor, () => $createHeadingNode("h3" as HeadingTagType) as never),
   },
   {
     id: "bullet-list",

--- a/src/features/plan-speakers/ReviewLetterStep.tsx
+++ b/src/features/plan-speakers/ReviewLetterStep.tsx
@@ -10,7 +10,7 @@ import { usePrepareInvitation } from "@/features/templates/usePrepareInvitation"
 import { interpolate } from "@/features/templates/interpolate";
 import { formatAssignedDate, formatToday } from "@/features/templates/letterDates";
 import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
-import { SpeakerLetterPanel } from "@/features/speaker-letter-template/SpeakerLetterPanel";
+import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
 import { PostPrintConfirmStep } from "./PostPrintConfirmStep";
 import { ReviewLetterFooter } from "./ReviewLetterFooter";
 import { useReviewLetterAction } from "./useReviewLetterAction";
@@ -107,23 +107,19 @@ export function ReviewLetterStep({ wardId, date, speaker, mode, onBack, onComple
         bodyMarkdown={renderedBody}
         footerMarkdown={renderedFooter}
       />
-      <SpeakerLetterPanel
-        wardName={wardName}
-        sampleDate={vars.date}
-        sampleToday={vars.today}
-        body={form.letterBody}
-        footer={form.letterFooter}
-        renderedBody={renderedBody}
-        renderedFooter={renderedFooter}
-        canEdit={true}
-        usingDefault={false}
-        resetKey={form.resetKey}
-        onBodyChange={form.setLetterBody}
-        onFooterChange={form.setLetterFooter}
-        description={`Edit the letter for ${speaker.data.name}. Variables resolve at send time.`}
-        namespace="speakerInviteWizard"
-        reserveBottomGap={false}
-      />
+      <div className="flex-1 min-h-0 overflow-y-auto bg-parchment py-6 px-4 sm:px-8 pb-4">
+        <LetterPageEditor
+          key={form.resetKey}
+          wardName={wardName}
+          today={vars.today}
+          assignedDate={vars.date}
+          initialJson={form.initialJson}
+          initialMarkdown={form.initialMarkdown}
+          onChange={form.setLetterStateJson}
+          onInitial={form.captureInitial}
+          ariaLabel={`Letter for ${speaker.data.name}`}
+        />
+      </div>
       {(form.error || actions.error) && (
         <p className="shrink-0 px-5 sm:px-8 pb-2 font-sans text-[12.5px] text-bordeaux">
           {form.error ?? actions.error}

--- a/src/features/templates/PrepareInvitationLetterTab.tsx
+++ b/src/features/templates/PrepareInvitationLetterTab.tsx
@@ -1,41 +1,42 @@
-import { useMemo, useState } from "react";
-import { cn } from "@/lib/cn";
-import { EditPreviewToggle, type LetterViewMode } from "./EditPreviewToggle";
+import { useMemo } from "react";
+import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
 import { PrintOnlyLetter } from "./PrintOnlyLetter";
-import { ScaledLetterPreview } from "./ScaledLetterPreview";
-import { EditorSection } from "./MarkdownEditor";
 import { interpolate } from "./interpolate";
 import type { LetterVars } from "./prepareInvitationVars";
 
 interface Props {
+  initialJson: string | null;
+  initialMarkdown: { bodyMarkdown: string; footerMarkdown: string };
   body: string;
   footer: string;
-  setBody: (v: string) => void;
-  setFooter: (v: string) => void;
+  onChange: (json: string) => void;
+  onInitial: (json: string) => void;
+  resetKey: number;
   vars: LetterVars;
-  /** Desktop-only toolbar rendered absolute-top-right inside the
-   *  preview container. Mobile uses the page-header toolbar instead. */
+  /** Optional toolbar slot rendered absolute-top-right of the editor
+   *  surface. Phase 2 keeps the existing per-speaker action bar
+   *  composed by the parent. */
   previewToolbar?: React.ReactNode;
 }
 
-/** Letter-editor column on the left, paper-sized preview on the right.
- *  The preview mimics a real 8.5×11 sheet so the bishop sees the
- *  letter at its true proportions before printing or sending. On
- *  mobile the right column is hidden and a tab toggle lets the bishop
- *  flip between Edit and Preview in the same column — keeping the
- *  page's primary CTA the only red button on screen. */
+/** Per-speaker letter editor on the prepare-invitation route — same
+ *  WYSIWYG canvas as the ward template page. The legacy split-pane
+ *  preview is gone; the editor IS the preview. PrintOnlyLetter
+ *  continues to portal a true 8.5×11 sheet for the print path during
+ *  the JSON dual-write window. */
 export function PrepareInvitationLetterTab({
+  initialJson,
+  initialMarkdown,
   body,
   footer,
-  setBody,
-  setFooter,
+  onChange,
+  onInitial,
+  resetKey,
   vars,
   previewToolbar,
 }: Props) {
   const renderedBody = useMemo(() => interpolate(body, vars), [body, vars]);
   const renderedFooter = useMemo(() => interpolate(footer, vars), [footer, vars]);
-  const [viewMode, setViewMode] = useState<LetterViewMode>("edit");
-  const showPreviewOnMobile = viewMode === "preview";
 
   return (
     <>
@@ -46,46 +47,19 @@ export function PrepareInvitationLetterTab({
         bodyMarkdown={renderedBody}
         footerMarkdown={renderedFooter}
       />
-      <div className="grid gap-6 lg:grid-cols-[minmax(0,26rem)_minmax(0,1fr)] items-start lg:h-full lg:min-h-0">
-        <div className="flex flex-col gap-4 min-w-0 lg:h-full lg:min-h-0 lg:overflow-y-auto lg:pr-2">
-          <EditPreviewToggle className="lg:hidden" value={viewMode} onChange={setViewMode} />
-          {showPreviewOnMobile && (
-            <div className="lg:hidden h-[70dvh] min-h-105">
-              <ScaledLetterPreview
-                wardName={vars.wardName}
-                assignedDate={vars.date}
-                today={vars.today}
-                bodyMarkdown={renderedBody}
-                footerMarkdown={renderedFooter}
-                height="100%"
-              />
-            </div>
-          )}
-          <div className={cn("flex flex-col gap-8", showPreviewOnMobile && "hidden lg:flex")}>
-            <EditorSection label="Letter body" initialMarkdown={body} onChange={setBody} />
-            <EditorSection
-              label="Footer (scripture)"
-              initialMarkdown={footer}
-              onChange={setFooter}
-            />
-          </div>
-        </div>
-        <aside className="hidden lg:flex flex-col gap-2 min-w-0 lg:h-full lg:min-h-0">
-          <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3">
-            Preview — 8.5 × 11 in
-          </div>
-          <div className="relative flex-1 min-h-0">
-            <ScaledLetterPreview
-              wardName={vars.wardName}
-              assignedDate={vars.date}
-              today={vars.today}
-              bodyMarkdown={renderedBody}
-              footerMarkdown={renderedFooter}
-              height="100%"
-            />
-            {previewToolbar && <div className="absolute top-3 right-3 z-10">{previewToolbar}</div>}
-          </div>
-        </aside>
+      <div className="relative h-full overflow-y-auto bg-parchment py-6 px-2 sm:px-4">
+        {previewToolbar && <div className="absolute top-3 right-3 z-10">{previewToolbar}</div>}
+        <LetterPageEditor
+          key={resetKey}
+          wardName={vars.wardName}
+          today={vars.today}
+          assignedDate={vars.date}
+          initialJson={initialJson}
+          initialMarkdown={initialMarkdown}
+          onChange={onChange}
+          onInitial={onInitial}
+          ariaLabel={`Letter for ${vars.speakerName}`}
+        />
       </div>
     </>
   );

--- a/src/features/templates/speakerLetterOverride.ts
+++ b/src/features/templates/speakerLetterOverride.ts
@@ -1,21 +1,25 @@
 import { deleteField, doc, serverTimestamp, updateDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
 
 function speakerRef(wardId: string, date: string, speakerId: string) {
   return doc(db, "wards", wardId, "meetings", date, "speakers", speakerId);
 }
 
 export interface LetterOverrideInput {
-  bodyMarkdown: string;
-  footerMarkdown: string;
+  /** Lexical EditorState JSON — the new source of truth. Required so
+   *  the writer can derive legacy markdown fields. */
+  editorStateJson: string;
 }
 
 /**
  * Write a per-speaker override of the ward invitation letter template.
- * Stored as Markdown with `{{variable}}` tokens intact — variables are
- * resolved at send time (see `sendSpeakerInvitation`). The override
- * persists on the speaker doc until explicitly cleared.
+ * Dual-writes: stores Lexical EditorState JSON alongside derived
+ * `bodyMarkdown` / `footerMarkdown` fields so older readers (the
+ * Cloud Function send path, receipt emails, the print path during
+ * migration) keep working unchanged. The override persists on the
+ * speaker doc until explicitly cleared.
  */
 export async function saveSpeakerLetterOverride(
   wardId: string,
@@ -25,10 +29,13 @@ export async function saveSpeakerLetterOverride(
 ): Promise<void> {
   reportSaving();
   try {
+    const state = JSON.parse(input.editorStateJson);
+    const { bodyMarkdown, footerMarkdown } = legacyFieldsFromState(state);
     await updateDoc(speakerRef(wardId, date, speakerId), {
       letterOverride: {
-        bodyMarkdown: input.bodyMarkdown,
-        footerMarkdown: input.footerMarkdown,
+        editorStateJson: input.editorStateJson,
+        bodyMarkdown,
+        footerMarkdown,
         updatedAt: serverTimestamp(),
       },
       updatedAt: serverTimestamp(),

--- a/src/features/templates/usePrepareInvitation.ts
+++ b/src/features/templates/usePrepareInvitation.ts
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { doc, getDoc } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { type SpeakerLetterTemplate, speakerSchema } from "@/lib/types";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
 import {
   DEFAULT_SPEAKER_LETTER_BODY,
   DEFAULT_SPEAKER_LETTER_FOOTER,
@@ -17,22 +18,32 @@ interface Args {
   letterTemplate: SpeakerLetterTemplate | null;
 }
 
+interface InitialMarkdown {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+}
+
 /**
- * Hydration + persistence helpers for `PrepareInvitationDialog`. Holds
- * the letter editor state, tracks whether a per-speaker override
- * currently exists, and exposes save / clear handlers. The dialog
- * owns the action orchestration (Send / Print / Mark invited); this
- * hook only manages the Firestore-facing state.
+ * Hydration + persistence helpers for the wizard's per-speaker letter
+ * override. Holds the editor state as a Lexical JSON string and
+ * exposes save / clear handlers. The dialog owns the action
+ * orchestration (Send / Print / Mark invited); this hook only manages
+ * the Firestore-facing state.
  *
- * The email body is NOT edited in the modal — the user tweaks it in
- * their mail client after Send email opens the mailto. Only the ward
- * template at `/settings/templates/speaker-email` is editable, and
- * it seeds the mailto body directly at send time.
+ * Read precedence: override.editorStateJson → ward template
+ * editorStateJson → ward template legacy markdown → app defaults. The
+ * hook also derives `letterBody` / `letterFooter` from the current
+ * JSON via `legacyFieldsFromState` so the existing send/print
+ * pipelines (which still take markdown) keep working unchanged.
  */
 export function usePrepareInvitation(args: Args) {
   const { wardId, date, speakerId, open, letterTemplate } = args;
-  const [letterBody, setLetterBody] = useState("");
-  const [letterFooter, setLetterFooter] = useState("");
+  const [initialJson, setInitialJson] = useState<string | null>(null);
+  const [initialMarkdown, setInitialMarkdown] = useState<InitialMarkdown>({
+    bodyMarkdown: DEFAULT_SPEAKER_LETTER_BODY,
+    footerMarkdown: DEFAULT_SPEAKER_LETTER_FOOTER,
+  });
+  const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
   const [letterHasOverride, setLetterHasOverride] = useState(false);
   const [hydrated, setHydrated] = useState(false);
   const [resetKey, setResetKey] = useState(0);
@@ -47,16 +58,20 @@ export function usePrepareInvitation(args: Args) {
       const snap = await getDoc(doc(db, "wards", wardId, "meetings", date, "speakers", speakerId));
       if (cancelled) return;
       const parsed = snap.exists() ? speakerSchema.safeParse(snap.data()) : null;
-      const letterOverride = parsed?.success ? parsed.data.letterOverride : undefined;
-      setLetterBody(
-        letterOverride?.bodyMarkdown ?? letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
-      );
-      setLetterFooter(
-        letterOverride?.footerMarkdown ??
+      const override = parsed?.success ? parsed.data.letterOverride : undefined;
+      const json = override?.editorStateJson ?? letterTemplate?.editorStateJson ?? null;
+      const md: InitialMarkdown = {
+        bodyMarkdown:
+          override?.bodyMarkdown ?? letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+        footerMarkdown:
+          override?.footerMarkdown ??
           letterTemplate?.footerMarkdown ??
           DEFAULT_SPEAKER_LETTER_FOOTER,
-      );
-      setLetterHasOverride(Boolean(letterOverride));
+      };
+      setInitialJson(json);
+      setInitialMarkdown(md);
+      setLetterStateJson(json);
+      setLetterHasOverride(Boolean(override));
       setError(null);
       setHydrated(true);
     })();
@@ -65,17 +80,43 @@ export function usePrepareInvitation(args: Args) {
     };
   }, [open, wardId, date, speakerId, letterTemplate]);
 
+  const { letterBody, letterFooter } = useMemo(() => {
+    if (!letterStateJson) {
+      return {
+        letterBody: initialMarkdown.bodyMarkdown,
+        letterFooter: initialMarkdown.footerMarkdown,
+      };
+    }
+    try {
+      const state = JSON.parse(letterStateJson);
+      const fields = legacyFieldsFromState(state);
+      return { letterBody: fields.bodyMarkdown, letterFooter: fields.footerMarkdown };
+    } catch {
+      return {
+        letterBody: initialMarkdown.bodyMarkdown,
+        letterFooter: initialMarkdown.footerMarkdown,
+      };
+    }
+  }, [letterStateJson, initialMarkdown]);
+
+  function captureInitial(json: string) {
+    setLetterStateJson(json);
+    setInitialJson((prev) => prev ?? json);
+  }
+
   async function persistOverrides() {
-    await saveSpeakerLetterOverride(wardId, date, speakerId, {
-      bodyMarkdown: letterBody,
-      footerMarkdown: letterFooter,
-    });
+    if (!letterStateJson) return;
+    await saveSpeakerLetterOverride(wardId, date, speakerId, { editorStateJson: letterStateJson });
     setLetterHasOverride(true);
   }
 
   function revertLetterToWardDefault() {
-    setLetterBody(letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY);
-    setLetterFooter(letterTemplate?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER);
+    setLetterStateJson(letterTemplate?.editorStateJson ?? null);
+    setInitialJson(letterTemplate?.editorStateJson ?? null);
+    setInitialMarkdown({
+      bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+      footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+    });
     setResetKey((k) => k + 1);
   }
 
@@ -94,10 +135,13 @@ export function usePrepareInvitation(args: Args) {
   }
 
   return {
+    initialJson,
+    initialMarkdown,
+    letterStateJson,
+    setLetterStateJson,
+    captureInitial,
     letterBody,
     letterFooter,
-    setLetterBody,
-    setLetterFooter,
     letterHasOverride,
     hydrated,
     resetKey,

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -114,6 +114,10 @@ export type SacramentMeeting = z.infer<typeof sacramentMeetingSchema>;
 // resolved at send time so `{{today}}` etc. stay current. Absent
 // override means "use the ward default template".
 export const speakerLetterOverrideSchema = z.object({
+  /** Lexical EditorState JSON — new WYSIWYG storage for per-speaker
+   *  overrides. Optional during the dual-write window so existing
+   *  overrides written before the migration keep parsing. */
+  editorStateJson: z.string().optional(),
   bodyMarkdown: z.string(),
   footerMarkdown: z.string(),
   updatedAt: z.any().optional(),


### PR DESCRIPTION
## Summary

Phase 2 of the WYSIWYG case study. Stacked on Phase 1 (#139). Migrates both per-speaker letter editing surfaces to the same \`LetterPageEditor\` shipped in Phase 1:

- **Wizard's \`ReviewLetterStep\`** — drops \`SpeakerLetterPanel\` + the split editor.
- **Standalone \`/prepare-invitation/:date/:speakerId\` route** — \`PrepareInvitationLetterTab\` rewritten as a thin host around \`LetterPageEditor\`.

Schema + writer dual-write \`editorStateJson\` alongside the legacy \`bodyMarkdown\` / \`footerMarkdown\` fields so the Cloud Function send path + receipt emails keep working during migration.

\`usePrepareInvitation\` now keys off Lexical JSON; \`letterBody\` / \`letterFooter\` are derived via \`useMemo\` so consumers (\`useReviewLetterAction\`, \`usePrepareInvitationActions\`, action bars) work unchanged.

Read precedence stays: override.editorStateJson → template.editorStateJson → template legacy markdown → app defaults.

## Verification
- typecheck / lint / 315 unit tests / build all green.
- Iterate harness: persistence + slash specs both pass.

## Test plan
- [ ] Wizard "Send" / "Resend" / "Print" flow: edit letter, save, verify override persists.
- [ ] \`/prepare-invitation/...\` route: edit letter, save via top-right action bar.
- [ ] Send email — derived \`bodyMarkdown\` / \`footerMarkdown\` reach the recipient unchanged.
- [ ] Print preview: portal renders the same content as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)