### PR TITLE
feat(page-editor): WYSIWYG program template editor (Phase 3)

### DIFF
--- a/src/app/routes/templates-programs.tsx
+++ b/src/app/routes/templates-programs.tsx
@@ -1,40 +1,30 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link } from "react-router";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
-import type { ProgramMargins, ProgramTemplateKey } from "@/lib/types";
+import type { ProgramTemplateKey } from "@/lib/types";
 import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
-import { ProgramTemplatesPanel } from "@/features/program-templates/ProgramTemplatesPanel";
 import { defaultProgramTemplate } from "@/features/program-templates/programTemplateDefaults";
 import { useProgramTemplate } from "@/features/program-templates/useProgramTemplate";
 import { writeProgramTemplate } from "@/features/program-templates/writeProgramTemplate";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
 
-const TABS: { key: ProgramTemplateKey; label: string; description: string }[] = [
-  {
-    key: "conductingProgram",
-    label: "Conducting copy",
-    description:
-      "Bishop's script-cue edition. Variables can stand in for speakers, hymns, leadership and announcements.",
-  },
-  {
-    key: "congregationProgram",
-    label: "Congregation copy",
-    description:
-      "Two-column printable program seen by the ward. Same variable surface; different layout at print time.",
-  },
+const TABS: { key: ProgramTemplateKey; label: string }[] = [
+  { key: "conductingProgram", label: "Conducting copy" },
+  { key: "congregationProgram", label: "Congregation copy" },
 ];
 
 function nowLabel(): string {
   return new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }
 
-/** /settings/templates/programs — conducting + congregation editors
- *  (Lexical, JSON-state storage). State is the source of truth; the
- *  preview pane resolves variable chips against sample data so the
- *  bishop sees the printed output as they author. */
+/** /settings/templates/programs — WYSIWYG editor for both program
+ *  copies. The editor IS the page; chrome (eyebrow + paper frame)
+ *  renders around a single contenteditable. Tab switches between
+ *  conducting + congregation copies, each with its own draft state. */
 export function ProgramTemplatesPage(): React.ReactElement {
   useFullViewportLayout();
   const wardId = useCurrentWardStore((s) => s.wardId);
@@ -45,39 +35,36 @@ export function ProgramTemplatesPage(): React.ReactElement {
   const conducting = useProgramTemplate("conductingProgram");
   const congregation = useProgramTemplate("congregationProgram");
   const activeDoc = activeKey === "conductingProgram" ? conducting.data : congregation.data;
-  const stored = activeDoc?.editorStateJson;
-  const storedMargins = activeDoc?.margins;
-  const initialJson = stored ?? defaultProgramTemplate(activeKey);
-  const initialMargins = storedMargins ?? DEFAULT_MARGINS[activeKey];
-  const isUsingDefault = !stored;
+  const initialJson = activeDoc?.editorStateJson ?? defaultProgramTemplate(activeKey);
+  const usingDefault = !activeDoc?.editorStateJson;
 
   const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
     conductingProgram: null,
     congregationProgram: null,
   });
-  const [marginDraft, setMarginDraft] = useState<Record<ProgramTemplateKey, ProgramMargins | null>>(
-    { conductingProgram: null, congregationProgram: null },
-  );
+  const [editorKey, setEditorKey] = useState(0);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
+  // Reset the editor's mount key whenever the active tab flips so
+  // Lexical hydrates from the new tab's initial state.
+  useEffect(() => {
+    setEditorKey((k) => k + 1);
+  }, [activeKey]);
+
   const editorJson = draft[activeKey] ?? initialJson;
-  const margins = marginDraft[activeKey] ?? initialMargins;
-  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
-  const marginsDirty =
-    marginDraft[activeKey] !== null &&
-    JSON.stringify(marginDraft[activeKey]) !== JSON.stringify(initialMargins);
-  const dirty = jsonDirty || marginsDirty;
+  const dirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
 
   async function save() {
     if (!wardId) return;
     const jsonToSave = draft[activeKey] ?? initialJson;
-    const marginsToSave = marginDraft[activeKey] ?? initialMargins;
+    const margins = activeDoc?.margins ?? DEFAULT_MARGINS[activeKey];
     setSaving(true);
     setError(null);
     try {
-      await writeProgramTemplate(wardId, activeKey, jsonToSave, marginsToSave);
+      await writeProgramTemplate(wardId, activeKey, jsonToSave, margins);
+      setDraft((d) => ({ ...d, [activeKey]: null }));
       setSavedAt(nowLabel());
     } catch (e) {
       setError(friendlyWriteError(e));
@@ -86,7 +73,11 @@ export function ProgramTemplatesPage(): React.ReactElement {
     }
   }
 
-  const activeTab = TABS.find((t) => t.key === activeKey)!;
+  function discard() {
+    setDraft((d) => ({ ...d, [activeKey]: null }));
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
@@ -102,13 +93,21 @@ export function ProgramTemplatesPage(): React.ReactElement {
             Program templates
           </h1>
         </div>
-        <button
-          type="button"
-          onClick={() => window.close()}
-          className="shrink-0 rounded-md border border-border-strong bg-chalk px-3 py-1.5 font-sans text-[12.5px] font-semibold text-walnut-2 hover:bg-parchment-2"
-        >
-          Close
-        </button>
+        <div className="flex items-center gap-2">
+          {usingDefault && (
+            <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-brass-soft bg-brass-soft/30 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep">
+              <span aria-hidden>★</span>
+              System default — save to lock in
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={() => window.close()}
+            className="shrink-0 rounded-md border border-border-strong bg-chalk px-3 py-1.5 font-sans text-[12.5px] font-semibold text-walnut-2 hover:bg-parchment-2"
+          >
+            Close
+          </button>
+        </div>
       </header>
 
       <nav className="shrink-0 flex gap-1 border-b border-border bg-parchment-2/30 px-5 sm:px-8 pt-3">
@@ -128,28 +127,23 @@ export function ProgramTemplatesPage(): React.ReactElement {
         ))}
       </nav>
 
-      <ProgramTemplatesPanel
-        activeKey={activeKey}
-        description={activeTab.description}
-        ariaLabel={activeTab.label}
-        editorJson={editorJson}
-        margins={margins}
-        canEdit={canEdit}
-        usingDefault={isUsingDefault && draft[activeKey] === null}
-        onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
-        onMarginsChange={(m) => setMarginDraft((d) => ({ ...d, [activeKey]: m }))}
-      />
+      <div className="flex-1 lg:min-h-0 overflow-y-auto bg-parchment py-8 px-4 sm:px-8 pb-24">
+        <ProgramPageEditor
+          key={`${activeKey}-${editorKey}`}
+          variant={activeKey}
+          initialJson={editorJson}
+          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
+          ariaLabel={TABS.find((t) => t.key === activeKey)!.label}
+          editorDisabled={!canEdit}
+        />
+      </div>
 
       <SaveBar
         dirty={dirty && canEdit}
         saving={saving}
         savedAt={savedAt}
         error={error}
-        onDiscard={() => {
-          setDraft((d) => ({ ...d, [activeKey]: null }));
-          setMarginDraft((d) => ({ ...d, [activeKey]: null }));
-          setError(null);
-        }}
+        onDiscard={discard}
         onSave={() => void save()}
       />
     </main>

--- a/src/features/page-editor/ProgramPageEditor.tsx
+++ b/src/features/page-editor/ProgramPageEditor.tsx
@@ -1,0 +1,66 @@
+import type { ProgramTemplateKey } from "@/lib/types";
+import { PAGE_EDITOR_BASE_NODES } from "./pageEditorNodes";
+import { PageCanvas } from "./PageCanvas";
+import { PageEditorComposer } from "./PageEditorComposer";
+import { PROGRAM_SLASH_COMMANDS } from "./programSlashCommands";
+
+interface Props {
+  variant: ProgramTemplateKey;
+  initialJson: string | null;
+  onChange: (json: string) => void;
+  onInitial?: (json: string) => void;
+  ariaLabel: string;
+  editorDisabled?: boolean;
+}
+
+const VARIANT_LABEL: Record<ProgramTemplateKey, string> = {
+  conductingProgram: "Conducting copy",
+  congregationProgram: "Congregation copy",
+};
+
+/** WYSIWYG program template editor — same canvas-as-page paradigm as
+ *  the letter, with program-specific slash commands (variables for
+ *  every PROGRAM_VARIABLES token, plus structural blocks). The page
+ *  itself acts as the visual frame; the bishop authors directly into
+ *  the paper. */
+export function ProgramPageEditor({
+  variant,
+  initialJson,
+  onChange,
+  onInitial,
+  ariaLabel,
+  editorDisabled,
+}: Props) {
+  const canvasVariant = variant === "conductingProgram" ? "conducting" : "congregation";
+  return (
+    <div
+      className={`relative max-w-[8.5in] mx-auto ${editorDisabled ? "opacity-60 pointer-events-none" : ""}`}
+    >
+      <PageEditorComposer
+        namespace={`ProgramPageEditor:${variant}`}
+        nodes={PAGE_EDITOR_BASE_NODES}
+        initialState={initialJson}
+        onChange={onChange}
+        onInitial={onInitial}
+        ariaLabel={ariaLabel}
+        slashCommands={PROGRAM_SLASH_COMMANDS}
+        page={(contentEditable) => (
+          <PageCanvas
+            variant={canvasVariant}
+            chrome={
+              <div className="text-center pb-3 border-b border-border mb-4">
+                <div className="font-mono text-[10px] tracking-[0.22em] uppercase text-walnut-3">
+                  Sacrament Meeting · {VARIANT_LABEL[variant]}
+                </div>
+              </div>
+            }
+          >
+            <div className="font-serif text-[15px] leading-[1.6] text-walnut">
+              {contentEditable}
+            </div>
+          </PageCanvas>
+        )}
+      />
+    </div>
+  );
+}

--- a/src/features/page-editor/programSlashCommands.ts
+++ b/src/features/page-editor/programSlashCommands.ts
@@ -1,0 +1,110 @@
+import {
+  $createParagraphNode,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalEditor,
+} from "lexical";
+import { $createHeadingNode, $createQuoteNode, type HeadingTagType } from "@lexical/rich-text";
+import { $setBlocksType } from "@lexical/selection";
+import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list";
+import { INSERT_HORIZONTAL_RULE_COMMAND } from "@lexical/react/LexicalHorizontalRuleNode";
+import { $createVariableChipNode } from "@/features/program-templates/nodes/VariableChipNode";
+import { PROGRAM_VARIABLES } from "@/features/program-templates/programVariables";
+import { INSERT_IMAGE_COMMAND } from "./plugins/ImagePlugin";
+import type { SlashCommand } from "./plugins/SlashCommandRegistry";
+
+function setBlock(editor: LexicalEditor, factory: () => ReturnType<typeof $createParagraphNode>) {
+  editor.update(() => {
+    const sel = $getSelection();
+    if ($isRangeSelection(sel)) $setBlocksType(sel, factory);
+  });
+}
+
+const STRUCTURAL_COMMANDS: SlashCommand[] = [
+  {
+    id: "heading-1",
+    label: "Heading 1",
+    keywords: "h1, title",
+    icon: "H1",
+    onSelect: (e) => setBlock(e, () => $createHeadingNode("h1" as HeadingTagType) as never),
+  },
+  {
+    id: "heading-2",
+    label: "Heading 2",
+    keywords: "h2",
+    icon: "H2",
+    onSelect: (e) => setBlock(e, () => $createHeadingNode("h2" as HeadingTagType) as never),
+  },
+  {
+    id: "heading-3",
+    label: "Heading 3",
+    keywords: "h3",
+    icon: "H3",
+    onSelect: (e) => setBlock(e, () => $createHeadingNode("h3" as HeadingTagType) as never),
+  },
+  {
+    id: "bullet-list",
+    label: "Bullet list",
+    keywords: "ul, unordered, list",
+    icon: "•",
+    onSelect: (e) => e.dispatchCommand(INSERT_UNORDERED_LIST_COMMAND, undefined),
+  },
+  {
+    id: "numbered-list",
+    label: "Numbered list",
+    keywords: "ol, ordered",
+    icon: "1.",
+    onSelect: (e) => e.dispatchCommand(INSERT_ORDERED_LIST_COMMAND, undefined),
+  },
+  {
+    id: "quote",
+    label: "Quote",
+    keywords: "blockquote, scripture, narration",
+    icon: "❝",
+    onSelect: (e) => setBlock(e, () => $createQuoteNode() as never),
+  },
+  {
+    id: "divider",
+    label: "Divider",
+    description: "Horizontal rule",
+    keywords: "hr, line, separator",
+    icon: "—",
+    onSelect: (e) => e.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, undefined),
+  },
+  {
+    id: "image",
+    label: "Image",
+    description: "Insert an image by URL",
+    keywords: "img, picture",
+    icon: "🖼",
+    onSelect: (e) => {
+      const src = window.prompt("Image URL");
+      if (!src) return;
+      const alt = window.prompt("Alt text", "") ?? "";
+      e.dispatchCommand(INSERT_IMAGE_COMMAND, { src, alt });
+    },
+  },
+];
+
+const VARIABLE_COMMANDS: SlashCommand[] = PROGRAM_VARIABLES.map((v) => ({
+  id: `var-${v.token}`,
+  label: v.label,
+  description: `Variable · ${v.group}`,
+  keywords: `variable, ${v.token}, ${v.group}`,
+  icon: "{{",
+  onSelect: (e) => {
+    e.update(() => {
+      const sel = $getSelection();
+      if ($isRangeSelection(sel)) sel.insertNodes([$createVariableChipNode(v.token)]);
+    });
+  },
+}));
+
+/** Slash-command palette for the conducting + congregation program
+ *  template editors. Mirrors the letter palette's structural commands
+ *  and adds an entry for every program variable so the bishop can
+ *  insert a chip without remembering the exact token. */
+export const PROGRAM_SLASH_COMMANDS: readonly SlashCommand[] = [
+  ...STRUCTURAL_COMMANDS,
+  ...VARIABLE_COMMANDS,
+];


### PR DESCRIPTION
## Summary

Phase 3 of the WYSIWYG case study. Stacked on Phase 2 (#140). Migrates the conducting + congregation program template editors to the same canvas-as-page paradigm as the speaker letter.

The split editor + scaled preview + drag handle layout is gone. The editor IS the page; bishops author directly into the visible 8.5×11 paper. Tab switches between conducting + congregation copies; each tab has its own draft state.

## What's in
- \`ProgramPageEditor\` — composes PageEditorComposer + PageCanvas with a program-flavored eyebrow.
- \`programSlashCommands\` — H1-3, lists, quote, divider, image, plus an entry per PROGRAM_VARIABLES token (\`/openingHymn\`, \`/speaker1\`, etc.) so the bishop never has to remember exact tokens.
- Route \`templates-programs.tsx\` rewired to ProgramPageEditor; tab flip remounts via \`editorKey\` so Lexical hydrates fresh.

## What's deferred (Phase 5)
- Domain DecoratorNodes (HymnBlockNode, SpeakerBlockNode, LeadershipRowNode) — current bold/chip pattern still works.
- PaginationPlugin for conducting copy — content scrolls naturally; multi-page rendering belongs to the print path (Phase 4).
- Landscape variant for congregation copy — both render portrait at edit time; print-time landscape is Phase 4 concern.

## Verification
- typecheck / lint / 315 unit tests / build all green.
- Iterate harness: persistence + slash specs both pass.

## Test plan
- [ ] \`/settings/templates/programs\` → both tabs editable; type / opens palette; \`/openingHymn\` inserts a chip.
- [ ] Save → reload → state survives (uses same persistence path as letter).
- [ ] Existing print view still renders the saved JSON unchanged (Phase 4 will rewire it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)