### PR TITLE
feat(print): wire program print pages to template JSON (Phase 4)

### DIFF
--- a/src/features/print/ConductingProgram.tsx
+++ b/src/features/print/ConductingProgram.tsx
@@ -1,15 +1,13 @@
-import type { ReactNode } from "react";
 import { useParams, Navigate } from "react-router";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
+import { useProgramTemplate } from "@/features/program-templates/useProgramTemplate";
+import { renderProgramState } from "@/features/program-templates/programTemplateRender";
 import { PrintLayout } from "./PrintLayout";
-import { formatLongDate, orderedSpeakers, personName, speakerSequence } from "./programData";
-import { RowFreeform, RowHymn, RowLabeled, ScriptLine } from "./programRows";
-
-function Group({ children }: { children: ReactNode }) {
-  return <section className="mt-3.5 mb-1.5 flex flex-col">{children}</section>;
-}
+import { buildMeetingVariables } from "./buildMeetingVariables";
+import { LegacyConductingCopy } from "./LegacyConductingCopy";
+import { formatLongDate, orderedSpeakers, speakerSequence } from "./programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -19,11 +17,12 @@ export function ConductingProgram() {
   const ward = useWardSettings();
   const meeting = useMeeting(date ?? null);
   const speakers = useSpeakers(date ?? null);
+  const template = useProgramTemplate("conductingProgram");
 
   if (!date || !ISO_DATE.test(date)) return <Navigate to="/schedule" replace />;
   if (!authed) return <Navigate to="/login" replace />;
 
-  const ready = !ward.loading && !meeting.loading && !speakers.loading;
+  const ready = !ward.loading && !meeting.loading && !speakers.loading && !template.loading;
   const m = meeting.data;
   const approved = m?.status === "approved";
 
@@ -31,121 +30,51 @@ export function ConductingProgram() {
 
   const wardName = ward.data?.name ?? "our ward";
   const dateLong = formatLongDate(date);
+
+  const header = (
+    <header className="mb-3 border-b-2 border-walnut pb-2">
+      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        Conductor's copy · {wardName}
+      </div>
+      <h1 className="font-display text-[22px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
+        {dateLong}
+      </h1>
+    </header>
+  );
+
+  // Template-driven rendering closes the loop between the WYSIWYG
+  // editor and the printed output. Falls back to the hardcoded
+  // layout for wards that haven't customized yet.
+  if (template.data?.editorStateJson) {
+    const variables = buildMeetingVariables({
+      date,
+      meeting: m ?? null,
+      speakers: speakers.data,
+      ward: ward.data ?? null,
+    });
+    return (
+      <PrintLayout ready={ready && approved} dense>
+        {header}
+        {renderProgramState(template.data.editorStateJson, variables)}
+      </PrintLayout>
+    );
+  }
+
   const speakerList = orderedSpeakers(speakers.data);
   const sequence = speakerSequence(speakerList, m?.mid);
   const visitors = (m?.visitors ?? []).filter((v) => v.name.trim().length > 0);
-  const speaker1 = speakerList[0]?.name;
-  const speaker2 = speakerList[1]?.name;
 
   return (
     <PrintLayout ready={ready && approved} dense>
-      <header className="mb-3 border-b-2 border-walnut pb-2">
-        <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
-          Conductor's copy · {wardName}
-        </div>
-        <h1 className="font-display text-[22px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
-          {dateLong}
-        </h1>
-      </header>
-
-      <ScriptLine dense>
-        Welcome to sacrament meeting of the <strong className="not-italic">{wardName}</strong>.
-        Today is <strong className="not-italic">{dateLong}</strong>.
-      </ScriptLine>
-
-      <Group>
-        <RowLabeled label="Presiding" value={personName(m?.presiding)} dense />
-        <RowLabeled label="Conducting" value={personName(m?.conducting)} dense />
-        {visitors.length > 0 ? (
-          visitors.map((v, i) => (
-            <RowLabeled
-              key={`v-${i}`}
-              label={i === 0 ? "Visitors" : ""}
-              value={v.details ? `${v.name} — ${v.details}` : v.name}
-              dense
-            />
-          ))
-        ) : (
-          <RowLabeled label="Visitors" value="" dense />
-        )}
-      </Group>
-
-      <Group>
-        <RowFreeform label="Announcements" value={m?.announcements ?? ""} dense lines={3} />
-      </Group>
-
-      <Group>
-        <RowLabeled label="Pianist" value={personName(m?.pianist)} dense />
-        <RowLabeled label="Chorister" value={personName(m?.chorister)} dense />
-      </Group>
-
-      <Group>
-        <RowHymn
-          label="Opening hymn"
-          number={m?.openingHymn?.number}
-          title={m?.openingHymn?.title}
-          dense
-        />
-        <RowLabeled label="Invocation" value={personName(m?.openingPrayer)} dense />
-      </Group>
-
-      <Group>
-        <RowFreeform label="Ward business" value={m?.wardBusiness ?? ""} dense lines={2} />
-        <RowFreeform label="Stake business" value={m?.stakeBusiness ?? ""} dense lines={1} />
-      </Group>
-
-      <ScriptLine dense>
-        We will now turn our thoughts to the sacred ordinance of the sacrament.
-      </ScriptLine>
-
-      <Group>
-        <RowHymn
-          label="Sacrament hymn"
-          number={m?.sacramentHymn?.number}
-          title={m?.sacramentHymn?.title}
-          dense
-        />
-      </Group>
-
-      <ScriptLine dense>Thank the congregation for their reverence.</ScriptLine>
-
-      <Group>
-        <ScriptLine dense>
-          Introduce <strong className="not-italic">{speaker1 ?? "Speaker 1"}</strong>
-          {sequence.some((e) => e.kind === "mid") && (
-            <> and the musical number / rest hymn that follows.</>
-          )}
-        </ScriptLine>
-        {sequence.map((entry, i) =>
-          entry.kind === "speaker" ? (
-            <RowLabeled
-              key={`s-${entry.data.id}`}
-              label={`Speaker ${entry.index + 1}`}
-              value={entry.data.name}
-              dense
-            />
-          ) : (
-            <RowLabeled key={`mid-${i}`} label="Interlude" value={entry.label} dense />
-          ),
-        )}
-        {speaker2 && (
-          <ScriptLine dense>
-            Thank the pianist / chorister and earlier participants. Introduce{" "}
-            <strong className="not-italic">{speaker2}</strong>, then mention the closing hymn and
-            benediction.
-          </ScriptLine>
-        )}
-      </Group>
-
-      <Group>
-        <RowHymn
-          label="Closing hymn"
-          number={m?.closingHymn?.number}
-          title={m?.closingHymn?.title}
-          dense
-        />
-        <RowLabeled label="Benediction" value={personName(m?.benediction)} dense />
-      </Group>
+      {header}
+      <LegacyConductingCopy
+        m={m ?? null}
+        wardName={wardName}
+        dateLong={dateLong}
+        speakerList={speakerList}
+        sequence={sequence}
+        visitors={visitors}
+      />
     </PrintLayout>
   );
 }

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -2,16 +2,12 @@ import { useParams, Navigate } from "react-router";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
+import { useProgramTemplate } from "@/features/program-templates/useProgramTemplate";
+import { renderProgramState } from "@/features/program-templates/programTemplateRender";
 import { PrintLayout } from "./PrintLayout";
-import {
-  formatLongDate,
-  orderedSpeakers,
-  personName,
-  speakerSequence,
-  type SequenceEntry,
-} from "./programData";
-import { RowFreeform, RowHymn, RowLabeled, RowSection } from "./programRows";
-import type { SacramentMeeting } from "@/lib/types";
+import { buildMeetingVariables } from "./buildMeetingVariables";
+import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
+import { formatLongDate, orderedSpeakers, speakerSequence } from "./programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -21,11 +17,12 @@ export function CongregationProgram() {
   const ward = useWardSettings();
   const meeting = useMeeting(date ?? null);
   const speakers = useSpeakers(date ?? null);
+  const template = useProgramTemplate("congregationProgram");
 
   if (!date || !ISO_DATE.test(date)) return <Navigate to="/schedule" replace />;
   if (!authed) return <Navigate to="/login" replace />;
 
-  const ready = !ward.loading && !meeting.loading && !speakers.loading;
+  const ready = !ward.loading && !meeting.loading && !speakers.loading && !template.loading;
   const m = meeting.data;
   const approved = m?.status === "approved";
 
@@ -40,9 +37,21 @@ export function CongregationProgram() {
     .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
     .join(", ");
 
-  const copy = (
-    <ProgramCopy
-      m={m}
+  const copy = template.data?.editorStateJson ? (
+    <TemplateCopy
+      wardName={wardName}
+      dateLong={dateLong}
+      json={template.data.editorStateJson}
+      variables={buildMeetingVariables({
+        date,
+        meeting: m ?? null,
+        speakers: speakers.data,
+        ward: ward.data ?? null,
+      })}
+    />
+  ) : (
+    <LegacyCongregationCopy
+      m={m ?? null}
       wardName={wardName}
       dateLong={dateLong}
       sequence={sequence}
@@ -67,15 +76,17 @@ export function CongregationProgram() {
   );
 }
 
-interface CopyProps {
-  m: SacramentMeeting | null;
+function TemplateCopy({
+  wardName,
+  dateLong,
+  json,
+  variables,
+}: {
   wardName: string;
   dateLong: string;
-  sequence: readonly SequenceEntry[];
-  visitorText: string;
-}
-
-function ProgramCopy({ m, wardName, dateLong, sequence, visitorText }: CopyProps) {
+  json: string;
+  variables: Record<string, string>;
+}) {
   return (
     <>
       <header className="mb-3 border-b-2 border-walnut pb-2">
@@ -86,67 +97,7 @@ function ProgramCopy({ m, wardName, dateLong, sequence, visitorText }: CopyProps
           {dateLong}
         </h1>
       </header>
-
-      <RowSection title="Presiding & conducting" dense>
-        <RowLabeled label="Presiding" value={personName(m?.presiding)} dense />
-        <RowLabeled label="Conducting" value={personName(m?.conducting)} dense />
-        {visitorText && <RowLabeled label="Visitors" value={visitorText} dense />}
-      </RowSection>
-
-      {m?.showAnnouncements && (m?.announcements ?? "").trim().length > 0 && (
-        <RowSection title="Announcements" dense>
-          <RowFreeform label="Announcements" value={m.announcements} dense />
-        </RowSection>
-      )}
-
-      <RowSection title="Music" dense>
-        <RowLabeled label="Pianist" value={personName(m?.pianist)} dense />
-        <RowLabeled label="Chorister" value={personName(m?.chorister)} dense />
-      </RowSection>
-
-      <RowSection title="Opening" dense>
-        <RowHymn
-          label="Opening hymn"
-          number={m?.openingHymn?.number}
-          title={m?.openingHymn?.title}
-          dense
-        />
-        <RowLabeled label="Invocation" value={personName(m?.openingPrayer)} dense />
-      </RowSection>
-
-      <RowSection title="Sacrament" dense>
-        <RowHymn
-          label="Sacrament hymn"
-          number={m?.sacramentHymn?.number}
-          title={m?.sacramentHymn?.title}
-          dense
-        />
-      </RowSection>
-
-      <RowSection title="Speakers & music" dense>
-        {sequence.map((entry, i) =>
-          entry.kind === "speaker" ? (
-            <RowLabeled
-              key={`s-${entry.data.id}`}
-              label={`Speaker ${entry.index + 1}`}
-              value={entry.data.name}
-              dense
-            />
-          ) : (
-            <RowLabeled key={`mid-${i}`} label="Interlude" value={entry.label} dense />
-          ),
-        )}
-      </RowSection>
-
-      <RowSection title="Closing" dense>
-        <RowHymn
-          label="Closing hymn"
-          number={m?.closingHymn?.number}
-          title={m?.closingHymn?.title}
-          dense
-        />
-        <RowLabeled label="Benediction" value={personName(m?.benediction)} dense />
-      </RowSection>
+      {renderProgramState(json, variables)}
     </>
   );
 }

--- a/src/features/print/LegacyConductingCopy.tsx
+++ b/src/features/print/LegacyConductingCopy.tsx
@@ -1,0 +1,134 @@
+import type { ReactNode } from "react";
+import type { SacramentMeeting } from "@/lib/types";
+import { type OrderedSpeaker, personName, type SequenceEntry } from "./programData";
+import { RowFreeform, RowHymn, RowLabeled, ScriptLine } from "./programRows";
+
+function Group({ children }: { children: ReactNode }) {
+  return <section className="mt-3.5 mb-1.5 flex flex-col">{children}</section>;
+}
+
+interface Props {
+  m: SacramentMeeting | null;
+  wardName: string;
+  dateLong: string;
+  speakerList: readonly OrderedSpeaker[];
+  sequence: readonly SequenceEntry[];
+  visitors: readonly { name: string; details?: string | undefined }[];
+}
+
+/** Hand-built conducting copy used for wards that haven't authored a
+ *  custom template yet. The template-driven path in
+ *  `ConductingProgram` takes precedence once a template is saved. */
+export function LegacyConductingCopy({
+  m,
+  wardName,
+  dateLong,
+  speakerList,
+  sequence,
+  visitors,
+}: Props) {
+  const speaker1 = speakerList[0]?.name;
+  const speaker2 = speakerList[1]?.name;
+  return (
+    <>
+      <ScriptLine dense>
+        Welcome to sacrament meeting of the <strong className="not-italic">{wardName}</strong>.
+        Today is <strong className="not-italic">{dateLong}</strong>.
+      </ScriptLine>
+
+      <Group>
+        <RowLabeled label="Presiding" value={personName(m?.presiding)} dense />
+        <RowLabeled label="Conducting" value={personName(m?.conducting)} dense />
+        {visitors.length > 0 ? (
+          visitors.map((v, i) => (
+            <RowLabeled
+              key={`v-${i}`}
+              label={i === 0 ? "Visitors" : ""}
+              value={v.details ? `${v.name} — ${v.details}` : v.name}
+              dense
+            />
+          ))
+        ) : (
+          <RowLabeled label="Visitors" value="" dense />
+        )}
+      </Group>
+
+      <Group>
+        <RowFreeform label="Announcements" value={m?.announcements ?? ""} dense lines={3} />
+      </Group>
+
+      <Group>
+        <RowLabeled label="Pianist" value={personName(m?.pianist)} dense />
+        <RowLabeled label="Chorister" value={personName(m?.chorister)} dense />
+      </Group>
+
+      <Group>
+        <RowHymn
+          label="Opening hymn"
+          number={m?.openingHymn?.number}
+          title={m?.openingHymn?.title}
+          dense
+        />
+        <RowLabeled label="Invocation" value={personName(m?.openingPrayer)} dense />
+      </Group>
+
+      <Group>
+        <RowFreeform label="Ward business" value={m?.wardBusiness ?? ""} dense lines={2} />
+        <RowFreeform label="Stake business" value={m?.stakeBusiness ?? ""} dense lines={1} />
+      </Group>
+
+      <ScriptLine dense>
+        We will now turn our thoughts to the sacred ordinance of the sacrament.
+      </ScriptLine>
+
+      <Group>
+        <RowHymn
+          label="Sacrament hymn"
+          number={m?.sacramentHymn?.number}
+          title={m?.sacramentHymn?.title}
+          dense
+        />
+      </Group>
+
+      <ScriptLine dense>Thank the congregation for their reverence.</ScriptLine>
+
+      <Group>
+        <ScriptLine dense>
+          Introduce <strong className="not-italic">{speaker1 ?? "Speaker 1"}</strong>
+          {sequence.some((e) => e.kind === "mid") && (
+            <> and the musical number / rest hymn that follows.</>
+          )}
+        </ScriptLine>
+        {sequence.map((entry, i) =>
+          entry.kind === "speaker" ? (
+            <RowLabeled
+              key={`s-${entry.data.id}`}
+              label={`Speaker ${entry.index + 1}`}
+              value={entry.data.name}
+              dense
+            />
+          ) : (
+            <RowLabeled key={`mid-${i}`} label="Interlude" value={entry.label} dense />
+          ),
+        )}
+        {speaker2 && (
+          <ScriptLine dense>
+            Thank the pianist / chorister and earlier participants. Introduce{" "}
+            <strong className="not-italic">{speaker2}</strong>, then mention the closing hymn and
+            benediction.
+          </ScriptLine>
+        )}
+      </Group>
+
+      <Group>
+        <RowHymn
+          label="Closing hymn"
+          number={m?.closingHymn?.number}
+          title={m?.closingHymn?.title}
+          dense
+        />
+        <RowLabeled label="Benediction" value={personName(m?.benediction)} dense />
+      </Group>
+    </>
+  );
+}

--- a/src/features/print/LegacyCongregationCopy.tsx
+++ b/src/features/print/LegacyCongregationCopy.tsx
@@ -1,0 +1,90 @@
+import type { SacramentMeeting } from "@/lib/types";
+import { personName, type SequenceEntry } from "./programData";
+import { RowFreeform, RowHymn, RowLabeled, RowSection } from "./programRows";
+
+interface Props {
+  m: SacramentMeeting | null;
+  wardName: string;
+  dateLong: string;
+  sequence: readonly SequenceEntry[];
+  visitorText: string;
+}
+
+/** Hand-built congregation copy used for wards that haven't authored
+ *  a custom template yet. The template-driven path in
+ *  `CongregationProgram` takes precedence once a template is saved. */
+export function LegacyCongregationCopy({ m, wardName, dateLong, sequence, visitorText }: Props) {
+  return (
+    <>
+      <header className="mb-3 border-b-2 border-walnut pb-2">
+        <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
+          Sacrament meeting · {wardName}
+        </div>
+        <h1 className="font-display text-[17px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
+          {dateLong}
+        </h1>
+      </header>
+
+      <RowSection title="Presiding & conducting" dense>
+        <RowLabeled label="Presiding" value={personName(m?.presiding)} dense />
+        <RowLabeled label="Conducting" value={personName(m?.conducting)} dense />
+        {visitorText && <RowLabeled label="Visitors" value={visitorText} dense />}
+      </RowSection>
+
+      {m?.showAnnouncements && (m?.announcements ?? "").trim().length > 0 && (
+        <RowSection title="Announcements" dense>
+          <RowFreeform label="Announcements" value={m.announcements} dense />
+        </RowSection>
+      )}
+
+      <RowSection title="Music" dense>
+        <RowLabeled label="Pianist" value={personName(m?.pianist)} dense />
+        <RowLabeled label="Chorister" value={personName(m?.chorister)} dense />
+      </RowSection>
+
+      <RowSection title="Opening" dense>
+        <RowHymn
+          label="Opening hymn"
+          number={m?.openingHymn?.number}
+          title={m?.openingHymn?.title}
+          dense
+        />
+        <RowLabeled label="Invocation" value={personName(m?.openingPrayer)} dense />
+      </RowSection>
+
+      <RowSection title="Sacrament" dense>
+        <RowHymn
+          label="Sacrament hymn"
+          number={m?.sacramentHymn?.number}
+          title={m?.sacramentHymn?.title}
+          dense
+        />
+      </RowSection>
+
+      <RowSection title="Speakers & music" dense>
+        {sequence.map((entry, i) =>
+          entry.kind === "speaker" ? (
+            <RowLabeled
+              key={`s-${entry.data.id}`}
+              label={`Speaker ${entry.index + 1}`}
+              value={entry.data.name}
+              dense
+            />
+          ) : (
+            <RowLabeled key={`mid-${i}`} label="Interlude" value={entry.label} dense />
+          ),
+        )}
+      </RowSection>
+
+      <RowSection title="Closing" dense>
+        <RowHymn
+          label="Closing hymn"
+          number={m?.closingHymn?.number}
+          title={m?.closingHymn?.title}
+          dense
+        />
+        <RowLabeled label="Benediction" value={personName(m?.benediction)} dense />
+      </RowSection>
+    </>
+  );
+}

--- a/src/features/print/buildMeetingVariables.ts
+++ b/src/features/print/buildMeetingVariables.ts
@@ -1,0 +1,65 @@
+import type { WithId } from "@/hooks/_sub";
+import type { SacramentMeeting, Speaker, Ward } from "@/lib/types";
+import { formatLongDate, midLabel, orderedSpeakers, personName } from "./programData";
+
+function speakerLabel(s: { name: string; topic: string | null }): string {
+  return s.topic ? `${s.name} — ${s.topic}` : s.name;
+}
+
+function hymnLabel(h: { number?: number; title?: string } | undefined): string {
+  if (!h) return "";
+  if (h.number && h.title) return `#${h.number} — ${h.title}`;
+  return h.title ?? (h.number ? `#${h.number}` : "");
+}
+
+interface Args {
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: readonly WithId<Speaker>[];
+  ward: Ward | null;
+}
+
+/** Resolves the runtime variable map a saved program template walks
+ *  against. Mirrors `PROGRAM_VARIABLES` token-for-token; values not
+ *  set on the meeting return empty strings (the renderer falls back
+ *  to a placeholder chip in that case). */
+export function buildMeetingVariables({
+  date,
+  meeting,
+  speakers,
+  ward,
+}: Args): Record<string, string> {
+  const list = orderedSpeakers(speakers);
+  const m = meeting;
+  return {
+    // Meeting metadata
+    date: formatLongDate(date),
+    wardName: ward?.name ?? "",
+    meetingType: "Regular",
+    // Leadership
+    presiding: personName(m?.presiding),
+    conducting: personName(m?.conducting),
+    chorister: personName(m?.chorister),
+    pianist: personName(m?.pianist),
+    // Hymns
+    openingHymn: hymnLabel(m?.openingHymn),
+    sacramentHymn: hymnLabel(m?.sacramentHymn),
+    closingHymn: hymnLabel(m?.closingHymn),
+    // Speakers
+    speaker1: list[0] ? speakerLabel(list[0]) : "",
+    speaker2: list[1] ? speakerLabel(list[1]) : "",
+    speaker3: list[2] ? speakerLabel(list[2]) : "",
+    speaker4: list[3] ? speakerLabel(list[3]) : "",
+    midMeetingInterlude: midLabel(m?.mid) ?? "",
+    // Free-form
+    openingPrayer: personName(m?.openingPrayer),
+    benediction: personName(m?.benediction),
+    visitors: (m?.visitors ?? [])
+      .filter((v) => v.name.trim().length > 0)
+      .map((v) => (v.details ? `${v.name} — ${v.details}` : v.name))
+      .join(", "),
+    announcements: m?.announcements ?? "",
+    wardBusiness: m?.wardBusiness ?? "",
+    stakeBusiness: m?.stakeBusiness ?? "",
+  };
+}


### PR DESCRIPTION
## Summary

Phase 4 of the WYSIWYG case study. Stacked on Phase 3 (#141). Closes the editor → print loop:

- \`ConductingProgram\` + \`CongregationProgram\` now render their content by walking the ward's saved program template via \`renderProgramState(json, variables)\`.
- \`buildMeetingVariables\` mirrors \`PROGRAM_VARIABLES\` token-for-token, sourcing values from the meeting + speakers + ward docs at print time.
- Hand-built layouts move into \`LegacyConductingCopy\` / \`LegacyCongregationCopy\` and serve as fallback for wards that haven't customized their template yet.

## What's in
- \`buildMeetingVariables({ date, meeting, speakers, ward })\` → \`Record<string, string>\`. Drops empty strings for missing fields; the renderer paints those as placeholder chips.
- \`useProgramTemplate(\"conductingProgram\")\` / \`useProgramTemplate(\"congregationProgram\")\` integration in both print routes.
- Template-driven \`<TemplateCopy>\` block for the congregation route (replaces the hand-built \`ProgramCopy\`).
- \`LegacyConductingCopy\` / \`LegacyCongregationCopy\` lifted out — keeps each route file under the 150-LOC cap.

## Verification
- typecheck / lint / 315 unit tests / build all green.
- E2E persistence + slash specs still pass.

## Test plan
- [ ] Ward with no template saved → print routes render the legacy layout (no regression).
- [ ] Author a template, mark a meeting approved → print route reflects the authored content with chips resolved.
- [ ] Variable not set on meeting → renders as placeholder chip (sees the bishop they need to fill in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)