### PR TITLE
fix(rules): defensive field reads in approval + isActiveMember helpers

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -32,12 +32,12 @@ service cloud.firestore {
     function isActiveMember(wardId) {
       return isSignedIn()
         && memberExists(wardId, request.auth.uid)
-        && getMember(wardId, request.auth.uid).active == true;
+        && getMember(wardId, request.auth.uid).get('active', false) == true;
     }
 
     function isActiveBishopric(wardId) {
       return isActiveMember(wardId)
-        && getMember(wardId, request.auth.uid).role == 'bishopric';
+        && getMember(wardId, request.auth.uid).get('role', '') == 'bishopric';
     }
 
     // Status may stay the same, flip to 'draft' (the edit-invalidates-approvals
@@ -55,13 +55,19 @@ service cloud.firestore {
     // `invalidated` flipping false → true (the edit-invalidates-approvals
     // path). Firestore rules don't support list comprehensions, so we
     // unroll positionally for the bounded list length (max 2 approvals).
+    //
+    // Reads use `.get(field, default)` so historical approval entries
+    // that pre-date a given field (e.g. early approvals written without
+    // `invalidated: false`) don't throw an evaluation error here — the
+    // rule should refuse the write or accept it, never crash.
     function approvalEntryPreserved(o, n) {
+      let oInvalid = o.get('invalidated', false);
+      let nInvalid = n.get('invalidated', false);
       return n.uid == o.uid
-        && n.email == o.email
-        && n.displayName == o.displayName
-        && n.approvedVersionHash == o.approvedVersionHash
-        && (n.invalidated == o.invalidated
-            || (o.invalidated == false && n.invalidated == true));
+        && n.get('email', '') == o.get('email', '')
+        && n.get('displayName', '') == o.get('displayName', '')
+        && n.get('approvedVersionHash', '') == o.get('approvedVersionHash', '')
+        && (nInvalid == oInvalid || (oInvalid == false && nInvalid == true));
     }
 
     // Invite-driven member creation: the newly-created member doc must


### PR DESCRIPTION
## Summary

Approving a sacrament-meeting program failed in dev with:
\`\`\`
evaluation error at L191:26 for 'update' @ L191
evaluation error at L218:28 for 'create' @ L218
\`\`\`

Both trace into rule helpers that read fields directly off resources:

- \`approvalEntryPreserved\` reads \`o.email\` / \`o.displayName\` / \`o.approvedVersionHash\` / \`o.invalidated\` on each historical approval entry. If any pre-existing approval was written without one of those fields (e.g. before \`invalidated: false\` defaulting was added), the rule throws.
- \`isActiveMember\` reads \`getMember(...).active\`. If a member doc was written without \`active\`, same crash.

Switches both to \`.get(field, default)\` so missing fields surface as defaults instead of evaluation errors. Well-formed docs see no behavior change.

## Notes
- Hot-reloaded into the user's running dev emulator via the admin REST endpoint while debugging — they were unblocked immediately.
- \`npm run test:rules\` can't run while a local emulator already binds 8080; that should be re-run by reviewer in a clean environment.

## Test plan
- [ ] \`npm run test:rules\` passes against this rules file.
- [ ] Approving a meeting in dev no longer surfaces evaluation errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)