### PR TITLE
feat(templates): gate WYSIWYG editors behind a desktop breakpoint

### DIFF
--- a/src/app/routes/templates-programs.tsx
+++ b/src/app/routes/templates-programs.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
 import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
@@ -10,6 +11,7 @@ import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
 import { defaultProgramTemplate } from "@/features/program-templates/programTemplateDefaults";
 import { useProgramTemplate } from "@/features/program-templates/useProgramTemplate";
 import { writeProgramTemplate } from "@/features/program-templates/writeProgramTemplate";
+import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
 import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
 
 const TABS: { key: ProgramTemplateKey; label: string }[] = [
@@ -17,16 +19,13 @@ const TABS: { key: ProgramTemplateKey; label: string }[] = [
   { key: "congregationProgram", label: "Congregation copy" },
 ];
 
-function nowLabel(): string {
-  return new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-}
-
 /** /settings/templates/programs — WYSIWYG editor for both program
  *  copies. The editor IS the page; chrome (eyebrow + paper frame)
  *  renders around a single contenteditable. Tab switches between
  *  conducting + congregation copies, each with its own draft state. */
 export function ProgramTemplatesPage(): React.ReactElement {
   useFullViewportLayout();
+  const isMobile = useIsMobile();
   const wardId = useCurrentWardStore((s) => s.wardId);
   const me = useCurrentMember();
   const canEdit = Boolean(me?.data.active);
@@ -75,7 +74,7 @@ export function ProgramTemplatesPage(): React.ReactElement {
       await writeProgramTemplate(wardId, activeKey, jsonToSave, margins, pageStyleToSave);
       setDraft((d) => ({ ...d, [activeKey]: null }));
       setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-      setSavedAt(nowLabel());
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
     } catch (e) {
       setError(friendlyWriteError(e));
     } finally {
@@ -89,6 +88,8 @@ export function ProgramTemplatesPage(): React.ReactElement {
     setEditorKey((k) => k + 1);
     setError(null);
   }
+
+  if (isMobile) return <DesktopOnlyNotice title="Program templates" />;
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">

--- a/src/app/routes/templates-speaker-letter.tsx
+++ b/src/app/routes/templates-speaker-letter.tsx
@@ -2,7 +2,9 @@ import { Link } from "react-router";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { useMemo } from "react";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
+import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
 import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
 import { LETTER_VARIABLE_SAMPLES } from "@/features/page-editor/letterVariables";
 import { resolveChipsInState } from "@/features/page-editor/serializeForInterpolation";
@@ -24,11 +26,14 @@ const SAMPLE = {
  *  persist/discard/status. */
 export function SpeakerLetterTemplatePage(): React.ReactElement {
   useFullViewportLayout();
+  const isMobile = useIsMobile();
   const ward = useWardSettings();
   const me = useCurrentMember();
   const editor = useSpeakerLetterTemplateEditor();
   const canEdit = Boolean(me?.data.active);
   const wardName = ward.data?.name ?? "";
+
+  if (isMobile) return <DesktopOnlyNotice title="Speaker invitation letter" />;
 
   // Live editor JSON, baked against sample vars (chip resolution +
   // {{token}} interpolation) so the OS print dialog renders the

--- a/src/features/page-editor/DesktopOnlyNotice.tsx
+++ b/src/features/page-editor/DesktopOnlyNotice.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { Link } from "react-router";
+
+interface Props {
+  /** Headline shown above the explainer copy. e.g. "Speaker invitation
+   *  letter". */
+  title: string;
+  /** Absolute URL the bishop can paste into a desktop browser to
+   *  reach this editor. Defaults to the current `window.location.href`
+   *  on click. */
+  url?: string;
+}
+
+/** Empty-state shown in place of the WYSIWYG template editors when
+ *  the viewport is narrower than `md`. The editor canvas is an 8.5×11
+ *  page at print scale — usable on tablet+ but cramped on phones —
+ *  so we render a friendly explainer with a "Copy link" button the
+ *  bishop can paste into their laptop browser instead of half-
+ *  rendering an editor that can't be operated. */
+export function DesktopOnlyNotice({ title, url }: Props): React.ReactElement {
+  const [copied, setCopied] = useState(false);
+
+  function copyLink() {
+    const target = url ?? (typeof window === "undefined" ? "" : window.location.href);
+    if (!target || !navigator.clipboard) return;
+    void navigator.clipboard.writeText(target).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }
+
+  return (
+    <main className="min-h-dvh bg-parchment flex flex-col">
+      <header className="shrink-0 border-b border-border bg-chalk px-5 py-4">
+        <Link
+          to="/settings/templates"
+          className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep hover:text-walnut"
+        >
+          ← Templates
+        </Link>
+        <h1 className="font-display text-[22px] font-semibold text-walnut leading-tight mt-1">
+          {title}
+        </h1>
+      </header>
+
+      <div className="flex-1 flex items-center justify-center px-5 py-10">
+        <div className="max-w-sm w-full bg-chalk border border-border rounded-lg p-6 text-center shadow-elev-1">
+          <div
+            aria-hidden
+            className="w-11 h-11 mx-auto mb-4 rounded-full border border-brass-soft bg-brass-soft/30 flex items-center justify-center text-brass-deep"
+          >
+            <DesktopIcon />
+          </div>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1.5">
+            Desktop only
+          </div>
+          <h2 className="font-display text-[20px] font-semibold text-walnut mb-2">
+            Open this on a larger screen
+          </h2>
+          <p className="font-serif text-[14px] text-walnut-2 mb-5">
+            Template editing needs the full width of a laptop or tablet — the page is laid out at
+            print size (8.5 × 11). Open this link on your desktop to keep editing.
+          </p>
+          <button
+            type="button"
+            onClick={copyLink}
+            className="w-full inline-flex items-center justify-center gap-2 rounded-md border border-walnut bg-walnut text-parchment hover:bg-ink shadow-[0_1px_0_rgba(35,24,21,0.18)] transition-colors px-4 py-2 font-sans text-[13px] font-semibold"
+          >
+            {copied ? "Link copied" : "Copy link"}
+            {copied ? <CheckIcon /> : <CopyIcon />}
+          </button>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function DesktopIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="12" rx="1.5" />
+      <path d="M8 20h8M12 16v4" />
+    </svg>
+  );
+}
+
+function CopyIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="9" y="9" width="11" height="11" rx="1.5" />
+      <path d="M5 15V5a1 1 0 0 1 1-1h10" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg
+      width="13"
+      height="13"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M4 12l5 5L20 6" />
+    </svg>
+  );
+}

--- a/src/features/page-editor/LetterPageEditor.tsx
+++ b/src/features/page-editor/LetterPageEditor.tsx
@@ -48,6 +48,13 @@ interface Props {
   onPageStyleChange?: (next: LetterPageStyle) => void;
   ariaLabel: string;
   editorDisabled?: boolean;
+  /** Read-only render — used on mobile where the canvas isn't
+   *  operable. Hides the toolbar, swaps in a "Editing is desktop-only"
+   *  notice, and blocks pointer interaction on the page surface so
+   *  the bishop sees the same paper preview as desktop without being
+   *  able to type into it. Distinct from `editorDisabled` (which dims
+   *  the page for inactive members). */
+  readOnly?: boolean;
 }
 
 /** WYSIWYG speaker-letter editor — Word-style layout: full-width
@@ -67,6 +74,7 @@ export function LetterPageEditor({
   onPageStyleChange,
   ariaLabel,
   editorDisabled,
+  readOnly,
 }: Props) {
   const initialState = initialJson ?? buildInitialLetterState(initialMarkdown);
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -99,20 +107,28 @@ export function LetterPageEditor({
             onInitial={onInitial}
             ariaLabel={ariaLabel}
             slashCommands={LETTER_SLASH_COMMANDS}
-            pageToolbar={
-              <PageToolbar
-                slashCommands={LETTER_SLASH_COMMANDS}
-                variables={LETTER_VARIABLES}
-                variableGroupLabels={LETTER_VARIABLE_GROUP_LABEL}
-                pageStyle={pageStyle}
-                zoom={zoom}
-                zoomMode={zoomMode}
-                onZoomMode={setZoomMode}
-                {...(onPageStyleChange ? { onPageStyleChange } : {})}
-              />
-            }
+            {...(readOnly
+              ? {}
+              : {
+                  pageToolbar: (
+                    <PageToolbar
+                      slashCommands={LETTER_SLASH_COMMANDS}
+                      variables={LETTER_VARIABLES}
+                      variableGroupLabels={LETTER_VARIABLE_GROUP_LABEL}
+                      pageStyle={pageStyle}
+                      zoom={zoom}
+                      zoomMode={zoomMode}
+                      onZoomMode={setZoomMode}
+                      {...(onPageStyleChange ? { onPageStyleChange } : {})}
+                    />
+                  ),
+                })}
             noticeBar={
-              showSampleNotice ? (
+              readOnly ? (
+                <div className="w-full bg-walnut text-chalk text-center font-mono text-[11px] uppercase tracking-[0.16em] py-2 px-4">
+                  Editing is desktop-only — open this on a laptop to customize this letter.
+                </div>
+              ) : showSampleNotice ? (
                 <div className="w-full bg-bordeaux text-chalk text-center font-mono text-[11px] uppercase tracking-[0.16em] py-2 px-4">
                   Preview — variable chips show sample values. Actual speaker / ward values fill in
                   when sent.
@@ -120,12 +136,14 @@ export function LetterPageEditor({
               ) : undefined
             }
             page={(contentEditable) => (
-              <div className="flex-1 min-h-0">
+              <div className={`flex-1 min-h-0 ${readOnly ? "pointer-events-none" : ""}`}>
                 <PaginatedPageStage
                   variant="letter"
                   pageStyle={pageStyle}
                   zoom={zoom}
-                  onZoomChange={(v) => setZoomMode({ kind: "manual", value: v })}
+                  {...(readOnly
+                    ? {}
+                    : { onZoomChange: (v) => setZoomMode({ kind: "manual", value: v }) })}
                   scrollRef={scrollRef}
                 >
                   <div className="font-serif text-[16.5px] leading-[1.65] text-walnut-2">

--- a/src/features/plan-speakers/ReviewLetterStep.tsx
+++ b/src/features/plan-speakers/ReviewLetterStep.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { LetterPageStyle, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
 import { useLatestInvitation } from "@/features/invitations/useLatestInvitation";
@@ -31,6 +32,7 @@ export function ReviewLetterStep({ wardId, date, speaker, mode, onBack, onComple
   const me = useCurrentMember();
   const authUser = useAuthStore((s) => s.user);
   const ward = useWardSettings();
+  const isMobile = useIsMobile();
   const { data: letterTemplate } = useSpeakerLetterTemplate();
   const { invitation } = useLatestInvitation(wardId, date, speaker.id);
   const actions = useWizardActions();
@@ -133,11 +135,12 @@ export function ReviewLetterStep({ wardId, date, speaker, mode, onBack, onComple
           initialJson={form.initialJson}
           initialMarkdown={form.initialMarkdown}
           {...(effectivePageStyle ? { pageStyle: effectivePageStyle } : {})}
-          onPageStyleChange={setPageStyle}
+          {...(isMobile ? {} : { onPageStyleChange: setPageStyle })}
           vars={vars}
           onChange={form.setLetterStateJson}
           onInitial={form.captureInitial}
           ariaLabel={`Letter for ${speaker.data.name}`}
+          readOnly={isMobile}
         />
       </div>
       {(form.error || actions.error) && (

--- a/src/features/program-templates/ProgramTemplatesSection.tsx
+++ b/src/features/program-templates/ProgramTemplatesSection.tsx
@@ -1,17 +1,28 @@
 import { Link } from "react-router";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 
 /** Templates → Program templates section. The conducting + congregation
  *  program editors share a dedicated full-viewport page (Lexical with
  *  variable chips and a live preview), so this section is a CTA card
- *  that links out in a new tab. */
+ *  that links out in a new tab. The CTA is disabled on phone-class
+ *  viewports — the editor itself shows a "Desktop only" notice if
+ *  the user reaches the URL another way. */
 export function ProgramTemplatesSection(): React.ReactElement {
+  const isMobile = useIsMobile();
   return (
     <section
       id="sec-program-templates"
       className="bg-chalk border border-border rounded-lg p-6 mb-4 scroll-mt-24"
     >
-      <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1">
-        Templates
+      <div className="flex items-center gap-2 mb-1">
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium">
+          Templates
+        </span>
+        {isMobile && (
+          <span className="inline-flex items-center rounded-full border border-border bg-parchment-2 px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3">
+            Desktop only
+          </span>
+        )}
       </div>
       <h2 className="font-display text-[22px] font-semibold text-walnut mb-1">
         Sacrament meeting program
@@ -23,17 +34,29 @@ export function ProgramTemplatesSection(): React.ReactElement {
 
       <div className="flex items-center justify-between gap-4 p-4 rounded-md border border-border bg-parchment/70">
         <p className="font-serif text-[13.5px] text-walnut-2 max-w-md">
-          Editor opens in a dedicated tab with a side-by-side preview using sample meeting data.
+          {isMobile
+            ? "Open this on a laptop or tablet — the editor lays out the program at print size."
+            : "Editor opens in a dedicated tab with a side-by-side preview using sample meeting data."}
         </p>
-        <Link
-          to="/settings/templates/programs"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 shrink-0 font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-walnut bg-walnut text-parchment hover:bg-ink shadow-[0_1px_0_rgba(35,24,21,0.18)] transition-colors"
-        >
-          Open editor
-          <NewTabIcon />
-        </Link>
+        {isMobile ? (
+          <span
+            aria-disabled="true"
+            className="inline-flex items-center gap-1.5 shrink-0 font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-border bg-parchment-2 text-walnut-3 cursor-not-allowed"
+          >
+            Open editor
+            <NewTabIcon />
+          </span>
+        ) : (
+          <Link
+            to="/settings/templates/programs"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 shrink-0 font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-walnut bg-walnut text-parchment hover:bg-ink shadow-[0_1px_0_rgba(35,24,21,0.18)] transition-colors"
+          >
+            Open editor
+            <NewTabIcon />
+          </Link>
+        )}
       </div>
     </section>
   );

--- a/src/features/templates/PrepareInvitationLetterTab.tsx
+++ b/src/features/templates/PrepareInvitationLetterTab.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
 import { resolveChipsInState } from "@/features/page-editor/serializeForInterpolation";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { PrintOnlyLetter } from "./PrintOnlyLetter";
 import { interpolate } from "./interpolate";
 import type { LetterVars } from "./prepareInvitationVars";
@@ -43,6 +44,7 @@ export function PrepareInvitationLetterTab({
   vars,
   previewToolbar,
 }: Props) {
+  const isMobile = useIsMobile();
   const renderedBody = useMemo(() => interpolate(body, vars), [body, vars]);
   const renderedFooter = useMemo(() => interpolate(footer, vars), [footer, vars]);
   const printEditorStateJson = useMemo(() => {
@@ -62,7 +64,9 @@ export function PrepareInvitationLetterTab({
         {...(printEditorStateJson ? { editorStateJson: printEditorStateJson } : {})}
       />
       <div className="relative h-full">
-        {previewToolbar && <div className="absolute top-3 right-3 z-10">{previewToolbar}</div>}
+        {previewToolbar && !isMobile && (
+          <div className="absolute top-3 right-3 z-10">{previewToolbar}</div>
+        )}
         <LetterPageEditor
           key={resetKey}
           assignedDate={vars.date}
@@ -72,6 +76,7 @@ export function PrepareInvitationLetterTab({
           onChange={onChange}
           onInitial={onInitial}
           ariaLabel={`Letter for ${vars.speakerName}`}
+          readOnly={isMobile}
         />
       </div>
     </>

--- a/src/features/templates/SpeakerLetterSection.tsx
+++ b/src/features/templates/SpeakerLetterSection.tsx
@@ -1,18 +1,29 @@
 import { Link } from "react-router";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 
 /** Templates → Speaker invitation letter section. The letter editor
  *  needs the full viewport for its 8.5×11 preview, so this section
  *  is a CTA card that links out to the standalone editor in a new
  *  tab. Keeps the combined Templates page coherent without cramping
- *  the preview. */
+ *  the preview. The CTA is disabled on phone-class viewports — the
+ *  editor itself shows a "Desktop only" notice if the user gets there
+ *  another way (typed URL, deep link from elsewhere). */
 export function SpeakerLetterSection(): React.ReactElement {
+  const isMobile = useIsMobile();
   return (
     <section
       id="sec-speaker-letter"
       className="bg-chalk border border-border rounded-lg p-6 mb-4 scroll-mt-24"
     >
-      <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1">
-        Template
+      <div className="flex items-center gap-2 mb-1">
+        <span className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium">
+          Template
+        </span>
+        {isMobile && (
+          <span className="inline-flex items-center rounded-full border border-border bg-parchment-2 px-1.5 py-0.5 font-mono text-[9.5px] uppercase tracking-[0.14em] text-walnut-3">
+            Desktop only
+          </span>
+        )}
       </div>
       <h2 className="font-display text-[22px] font-semibold text-walnut mb-1">
         Speaker invitation letter
@@ -24,18 +35,29 @@ export function SpeakerLetterSection(): React.ReactElement {
 
       <div className="flex items-center justify-between gap-4 p-4 rounded-md border border-border bg-parchment/70">
         <p className="font-serif text-[13.5px] text-walnut-2 max-w-md">
-          Edit the body, footer, and signature of the printed invitation. A live preview shows the
-          letter as speakers will see it.
+          {isMobile
+            ? "Open this on a laptop or tablet — the editor lays out the letter at print size (8.5 × 11)."
+            : "Edit the body, footer, and signature of the printed invitation. A live preview shows the letter as speakers will see it."}
         </p>
-        <Link
-          to="/settings/templates/speaker-letter"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 shrink-0 font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-walnut bg-walnut text-parchment hover:bg-ink shadow-[0_1px_0_rgba(35,24,21,0.18)] transition-colors"
-        >
-          Open editor
-          <NewTabIcon />
-        </Link>
+        {isMobile ? (
+          <span
+            aria-disabled="true"
+            className="inline-flex items-center gap-1.5 shrink-0 font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-border bg-parchment-2 text-walnut-3 cursor-not-allowed"
+          >
+            Open editor
+            <NewTabIcon />
+          </span>
+        ) : (
+          <Link
+            to="/settings/templates/speaker-letter"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 shrink-0 font-sans text-[13px] font-semibold px-3.5 py-1.5 rounded-md border border-walnut bg-walnut text-parchment hover:bg-ink shadow-[0_1px_0_rgba(35,24,21,0.18)] transition-colors"
+          >
+            Open editor
+            <NewTabIcon />
+          </Link>
+        )}
       </div>
     </section>
   );

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+
+/** Subscribes to a CSS media query and returns its current match
+ *  state, re-rendering on every change. SSR-safe — returns `false`
+ *  when `window` isn't available, then hydrates on first effect.
+ *  Use {@link useIsMobile} for the app-wide phone breakpoint instead
+ *  of inlining the same string everywhere. */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    setMatches(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, [query]);
+  return matches;
+}
+
+/** True when the viewport is narrower than Tailwind's `md` breakpoint
+ *  (768px). The WYSIWYG template editors target an 8.5×11 page at
+ *  print scale and need at least a tablet's worth of horizontal room
+ *  to be usable, so anything below `md` is treated as phone-class
+ *  and gated behind a "desktop only" notice. */
+export function useIsMobile(): boolean {
+  return useMediaQuery("(max-width: 767.98px)");
+}


### PR DESCRIPTION
## Summary

- The speaker-letter + program template editors render an 8.5×11 page at print scale and aren't operable on phone-class viewports. Below `md` (768px) the routes now show a friendly **Desktop only** notice with a Copy-link button.
- The Settings → Templates section CTAs stay visible but disabled with a small **Desktop only** badge so the feature is still discoverable when the bishop is back at a laptop.
- New `useMediaQuery` + `useIsMobile` hooks in `src/hooks/useMediaQuery.ts` for reuse anywhere else we hit the same constraint.

## Test plan

- [ ] On `< 768px`: open `/settings/templates/speaker-letter` and `/settings/templates/programs` — both render the Desktop-only card; tapping Copy link writes the current URL to the clipboard
- [ ] On `< 768px`: `/settings/templates` — the Speaker letter + Sacrament meeting program section CTAs are visible with a "Desktop only" pill and the Open editor button is greyed
- [ ] On `≥ 768px`: editors and CTAs work as they always did
- [ ] Resize the window across the breakpoint — UI flips live (no reload required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)