### PR TITLE
fix(mobile-letter): pinch/pan/zoom preview, single page

### DIFF
--- a/src/features/page-editor/LetterPageEditor.tsx
+++ b/src/features/page-editor/LetterPageEditor.tsx
@@ -48,13 +48,6 @@ interface Props {
   onPageStyleChange?: (next: LetterPageStyle) => void;
   ariaLabel: string;
   editorDisabled?: boolean;
-  /** Read-only render — used on mobile where the canvas isn't
-   *  operable. Hides the toolbar, swaps in a "Editing is desktop-only"
-   *  notice, and blocks pointer interaction on the page surface so
-   *  the bishop sees the same paper preview as desktop without being
-   *  able to type into it. Distinct from `editorDisabled` (which dims
-   *  the page for inactive members). */
-  readOnly?: boolean;
 }
 
 /** WYSIWYG speaker-letter editor — Word-style layout: full-width
@@ -74,7 +67,6 @@ export function LetterPageEditor({
   onPageStyleChange,
   ariaLabel,
   editorDisabled,
-  readOnly,
 }: Props) {
   const initialState = initialJson ?? buildInitialLetterState(initialMarkdown);
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -107,28 +99,20 @@ export function LetterPageEditor({
             onInitial={onInitial}
             ariaLabel={ariaLabel}
             slashCommands={LETTER_SLASH_COMMANDS}
-            {...(readOnly
-              ? {}
-              : {
-                  pageToolbar: (
-                    <PageToolbar
-                      slashCommands={LETTER_SLASH_COMMANDS}
-                      variables={LETTER_VARIABLES}
-                      variableGroupLabels={LETTER_VARIABLE_GROUP_LABEL}
-                      pageStyle={pageStyle}
-                      zoom={zoom}
-                      zoomMode={zoomMode}
-                      onZoomMode={setZoomMode}
-                      {...(onPageStyleChange ? { onPageStyleChange } : {})}
-                    />
-                  ),
-                })}
+            pageToolbar={
+              <PageToolbar
+                slashCommands={LETTER_SLASH_COMMANDS}
+                variables={LETTER_VARIABLES}
+                variableGroupLabels={LETTER_VARIABLE_GROUP_LABEL}
+                pageStyle={pageStyle}
+                zoom={zoom}
+                zoomMode={zoomMode}
+                onZoomMode={setZoomMode}
+                {...(onPageStyleChange ? { onPageStyleChange } : {})}
+              />
+            }
             noticeBar={
-              readOnly ? (
-                <div className="w-full bg-walnut text-chalk text-center font-mono text-[11px] uppercase tracking-[0.16em] py-2 px-4">
-                  Editing is desktop-only — open this on a laptop to customize this letter.
-                </div>
-              ) : showSampleNotice ? (
+              showSampleNotice ? (
                 <div className="w-full bg-bordeaux text-chalk text-center font-mono text-[11px] uppercase tracking-[0.16em] py-2 px-4">
                   Preview — variable chips show sample values. Actual speaker / ward values fill in
                   when sent.
@@ -136,14 +120,12 @@ export function LetterPageEditor({
               ) : undefined
             }
             page={(contentEditable) => (
-              <div className={`flex-1 min-h-0 ${readOnly ? "pointer-events-none" : ""}`}>
+              <div className="flex-1 min-h-0">
                 <PaginatedPageStage
                   variant="letter"
                   pageStyle={pageStyle}
                   zoom={zoom}
-                  {...(readOnly
-                    ? {}
-                    : { onZoomChange: (v) => setZoomMode({ kind: "manual", value: v }) })}
+                  onZoomChange={(v) => setZoomMode({ kind: "manual", value: v })}
                   scrollRef={scrollRef}
                 >
                   <div className="font-serif text-[16.5px] leading-[1.65] text-walnut-2">

--- a/src/features/page-editor/MobileLetterPreview.tsx
+++ b/src/features/page-editor/MobileLetterPreview.tsx
@@ -1,0 +1,90 @@
+import { useMemo, useRef } from "react";
+import { TransformComponent, TransformWrapper } from "react-zoom-pan-pinch";
+import { useFitScale } from "@/hooks/useFitScale";
+import { LETTER_CANVAS_WIDTH_PX, LetterCanvas } from "@/features/templates/LetterCanvas";
+import { interpolate } from "@/features/templates/interpolate";
+import { resolveChipsInState } from "./serializeForInterpolation";
+
+interface Props {
+  wardName: string;
+  assignedDate: string;
+  today: string;
+  bodyMarkdown: string;
+  footerMarkdown: string;
+  /** Saved Lexical state. When present, the canvas renders the
+   *  bishop's WYSIWYG content; chips + `{{tokens}}` are pre-resolved
+   *  here so the static walker doesn't need a vars context. */
+  editorStateJson?: string | null;
+  /** Speaker / ward values to bake into chips + `{{tokens}}` before
+   *  rendering. Omit to render the raw template content. */
+  vars?: Readonly<Record<string, string>>;
+}
+
+/** Mobile, read-only letter preview. Renders the saved letter inside
+ *  a single 8.5×11 paper sheet wrapped in `react-zoom-pan-pinch` so
+ *  the bishop can pinch / pan / zoom on a phone. Initial scale fits
+ *  the paper to the viewport width; double-tap resets, pinch zooms
+ *  in to inspect details. No editor, no toolbar — the v0.12.1 walnut
+ *  notice strip explains that editing is desktop-only. */
+export function MobileLetterPreview({
+  wardName,
+  assignedDate,
+  today,
+  bodyMarkdown,
+  footerMarkdown,
+  editorStateJson,
+  vars,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fitScale = useFitScale(containerRef, LETTER_CANVAS_WIDTH_PX);
+
+  const resolvedJson = useMemo(() => {
+    if (!editorStateJson) return undefined;
+    if (!vars) return editorStateJson;
+    return resolveChipsInState(interpolate(editorStateJson, vars), vars);
+  }, [editorStateJson, vars]);
+  const renderedBody = useMemo(
+    () => (vars ? interpolate(bodyMarkdown, vars) : bodyMarkdown),
+    [bodyMarkdown, vars],
+  );
+  const renderedFooter = useMemo(
+    () => (vars ? interpolate(footerMarkdown, vars) : footerMarkdown),
+    [footerMarkdown, vars],
+  );
+
+  return (
+    <div className="flex flex-col h-full bg-parchment">
+      <div className="shrink-0 w-full bg-walnut text-chalk text-center font-mono text-[11px] uppercase tracking-[0.16em] py-2 px-4">
+        Editing is desktop-only — open this on a laptop to customize this letter.
+      </div>
+      <div ref={containerRef} className="flex-1 min-h-0 overflow-hidden select-none">
+        <TransformWrapper
+          key={fitScale}
+          initialScale={fitScale}
+          minScale={fitScale * 0.5}
+          maxScale={3}
+          centerOnInit
+          limitToBounds={false}
+          doubleClick={{ mode: "reset" }}
+          wheel={{ step: 0.1 }}
+          pinch={{ step: 5 }}
+          panning={{ velocityDisabled: true }}
+        >
+          <TransformComponent
+            wrapperStyle={{ width: "100%", height: "100%", cursor: "grab" }}
+            contentStyle={{ width: LETTER_CANVAS_WIDTH_PX, height: "auto" }}
+          >
+            <LetterCanvas
+              wardName={wardName}
+              assignedDate={assignedDate}
+              today={today}
+              bodyMarkdown={renderedBody}
+              footerMarkdown={renderedFooter}
+              {...(resolvedJson ? { editorStateJson: resolvedJson } : {})}
+            />
+          </TransformComponent>
+        </TransformWrapper>
+      </div>
+    </div>
+  );
+}

--- a/src/features/plan-speakers/ReviewLetterStep.tsx
+++ b/src/features/plan-speakers/ReviewLetterStep.tsx
@@ -12,6 +12,7 @@ import { interpolate } from "@/features/templates/interpolate";
 import { formatAssignedDate, formatToday } from "@/features/templates/letterDates";
 import { PrintOnlyLetter } from "@/features/templates/PrintOnlyLetter";
 import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
+import { MobileLetterPreview } from "@/features/page-editor/MobileLetterPreview";
 import { resolveChipsInState } from "@/features/page-editor/serializeForInterpolation";
 import { PostPrintConfirmStep } from "./PostPrintConfirmStep";
 import { ReviewLetterFooter } from "./ReviewLetterFooter";
@@ -129,19 +130,30 @@ export function ReviewLetterStep({ wardId, date, speaker, mode, onBack, onComple
         {...(printEditorStateJson ? { editorStateJson: printEditorStateJson } : {})}
       />
       <div className="flex-1 min-h-0">
-        <LetterPageEditor
-          key={form.resetKey}
-          assignedDate={vars.date}
-          initialJson={form.initialJson}
-          initialMarkdown={form.initialMarkdown}
-          {...(effectivePageStyle ? { pageStyle: effectivePageStyle } : {})}
-          {...(isMobile ? {} : { onPageStyleChange: setPageStyle })}
-          vars={vars}
-          onChange={form.setLetterStateJson}
-          onInitial={form.captureInitial}
-          ariaLabel={`Letter for ${speaker.data.name}`}
-          readOnly={isMobile}
-        />
+        {isMobile ? (
+          <MobileLetterPreview
+            wardName={wardName}
+            assignedDate={vars.date}
+            today={vars.today}
+            bodyMarkdown={renderedBody}
+            footerMarkdown={renderedFooter}
+            editorStateJson={form.letterStateJson ?? form.initialJson}
+            vars={vars}
+          />
+        ) : (
+          <LetterPageEditor
+            key={form.resetKey}
+            assignedDate={vars.date}
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            {...(effectivePageStyle ? { pageStyle: effectivePageStyle } : {})}
+            onPageStyleChange={setPageStyle}
+            vars={vars}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            ariaLabel={`Letter for ${speaker.data.name}`}
+          />
+        )}
       </div>
       {(form.error || actions.error) && (
         <p className="shrink-0 px-5 sm:px-8 pb-2 font-sans text-[12.5px] text-bordeaux">

--- a/src/features/templates/PrepareInvitationLetterTab.tsx
+++ b/src/features/templates/PrepareInvitationLetterTab.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from "react";
 import { LetterPageEditor } from "@/features/page-editor/LetterPageEditor";
+import { MobileLetterPreview } from "@/features/page-editor/MobileLetterPreview";
 import { resolveChipsInState } from "@/features/page-editor/serializeForInterpolation";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { PrintOnlyLetter } from "./PrintOnlyLetter";
@@ -64,20 +65,31 @@ export function PrepareInvitationLetterTab({
         {...(printEditorStateJson ? { editorStateJson: printEditorStateJson } : {})}
       />
       <div className="relative h-full">
-        {previewToolbar && !isMobile && (
-          <div className="absolute top-3 right-3 z-10">{previewToolbar}</div>
+        {isMobile ? (
+          <MobileLetterPreview
+            wardName={vars.wardName}
+            assignedDate={vars.date}
+            today={vars.today}
+            bodyMarkdown={renderedBody}
+            footerMarkdown={renderedFooter}
+            editorStateJson={liveStateJson ?? initialJson}
+            vars={vars}
+          />
+        ) : (
+          <>
+            {previewToolbar && <div className="absolute top-3 right-3 z-10">{previewToolbar}</div>}
+            <LetterPageEditor
+              key={resetKey}
+              assignedDate={vars.date}
+              initialJson={initialJson}
+              initialMarkdown={initialMarkdown}
+              vars={vars}
+              onChange={onChange}
+              onInitial={onInitial}
+              ariaLabel={`Letter for ${vars.speakerName}`}
+            />
+          </>
         )}
-        <LetterPageEditor
-          key={resetKey}
-          assignedDate={vars.date}
-          initialJson={initialJson}
-          initialMarkdown={initialMarkdown}
-          vars={vars}
-          onChange={onChange}
-          onInitial={onInitial}
-          ariaLabel={`Letter for ${vars.speakerName}`}
-          readOnly={isMobile}
-        />
       </div>
     </>
   );


### PR DESCRIPTION
## Summary

The v0.12.1 read-only path kept the Lexical editor + paginated stage and just hid the toolbar. On real iPhones that left the paper visibly tiny while the inner text rendered close to native size, and the bishop got 3 stacked page sheets they couldn't navigate.

Replaces it with a dedicated **MobileLetterPreview**:

- Single 8.5×11 \`LetterCanvas\` (no pagination)
- Wrapped in \`react-zoom-pan-pinch\` — initial scale fits paper to viewport width, pinch zooms in to read, double-tap resets, pan drags
- Walnut "Editing is desktop-only" notice strip stays pinned at top
- Chips + \`{{tokens}}\` are pre-resolved against the speaker's vars so the bishop sees the real letter, not sample values
- Falls through to the legacy chrome+markdown path inside \`LetterCanvas\` when \`editorStateJson\` isn't set

The unused \`readOnly\` prop on \`LetterPageEditor\` is removed (only the wizard + prepare-invitation called it, and they now branch on the consumer side).

## Test plan

- [ ] On iPhone Safari: wizard step 2 — single page visible, pinch to zoom in, pan to scroll, double-tap to reset, walnut notice strip at top
- [ ] On Android Chrome: same gestures work
- [ ] On desktop (≥ 768px): editor still renders normally
- [ ] Print from mobile still produces a real 8.5×11 PDF (PrintOnlyLetter portal unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)