### PR TITLE
fix(mobile): respect safe-area-inset-bottom on save bar and wizard footer

### DIFF
--- a/src/features/meetings/program/ProgramSaveBar.tsx
+++ b/src/features/meetings/program/ProgramSaveBar.tsx
@@ -27,7 +27,7 @@ export function ProgramSaveBar({
           message ("Couldn't save — Connection failed…") doesn't wrap
           inside a cramped row next to a big CTA. Desktop: everything
           on one line. */}
-      <div className="flex flex-col gap-2 px-4 py-2.5 sm:flex-row sm:items-center sm:gap-3.5 sm:px-8 sm:py-3">
+      <div className="flex flex-col gap-2 px-4 py-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))] sm:flex-row sm:items-center sm:gap-3.5 sm:px-8 sm:py-3 sm:pb-[max(0.75rem,env(safe-area-inset-bottom))]">
         <SaveIndicator />
         <span className="hidden sm:block sm:flex-1" />
         <div className="flex items-center gap-2.5">

--- a/src/features/plan-speakers/WizardFooter.tsx
+++ b/src/features/plan-speakers/WizardFooter.tsx
@@ -13,7 +13,7 @@ interface Props {
  *  child and `shrink-0` so it never gets squeezed out. */
 export function WizardFooter({ children, align = "between" }: Props) {
   return (
-    <div className="shrink-0 border-t border-border bg-parchment px-5 sm:px-8 py-3">
+    <div className="shrink-0 border-t border-border bg-parchment px-5 sm:px-8 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
       <div
         className={cn(
           "max-w-3xl w-full mx-auto flex items-center gap-2",


### PR DESCRIPTION
## Summary

- `ProgramSaveBar` (fixed-bottom save/approval bar in the week editor) and `WizardFooter` (last child of the `h-dvh` plan-speakers wizard) sat against the viewport edge with no bottom inset, so on iPhones with a home indicator the buttons collided with the safe area.
- Both now apply `pb-[max(<base>,env(safe-area-inset-bottom))]`, matching the pattern already used by [`SaveBar`](src/components/ui/SaveBar.tsx) and the speaker-invite FAB in [`invite-speaker-chat-drawer`](src/app/routes/invite-speaker-chat-drawer.tsx).
- The viewport meta in `index.html` already includes `viewport-fit=cover`, so the env() vars are available — no other changes needed.

Other absolutely-positioned controls flagged during the audit (`JumpToLatest`, `LetterPreviewZoomControls`) were intentionally left alone: they sit inside non-viewport-edge scroll regions, not against the bottom of the screen.

## Test plan

- [ ] Open `/week/:date` on an iPhone (or Safari device-mode w/ a home-indicator preset) — the Request approval / Preview print row clears the home indicator.
- [ ] Open `/schedule` → "Plan speakers" wizard on the same device — Back / Send/Print buttons clear the home indicator on every step (Roster, Invitations, Summary).
- [ ] Desktop: the bars look unchanged (the `max()` fallback keeps the existing `py-3` padding).
- [ ] CI: lint + typecheck + unit + rules + e2e all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)