### PR TITLE
feat(invite): share PDF of letter via native share sheet

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "@twilio/conversations": "^3.0.0",
     "clsx": "^2.1.1",
     "firebase": "^12.12.0",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^4.2.1",
     "lexical": "^0.43.0",
     "lucide-react": "^1.11.0",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,12 @@ importers:
       firebase:
         specifier: ^12.12.0
         version: 12.12.0
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
       lexical:
         specifier: ^0.43.0
         version: 0.43.0
@@ -1769,8 +1775,14 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/qs@6.15.0':
     resolution: {integrity: sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
@@ -1800,6 +1812,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
@@ -2059,6 +2074,10 @@ packages:
   bare-url@2.4.1:
     resolution: {integrity: sha512-fZapLWNB25gS+etK27NV9KgBNXgo2yeYHuj+OyPblQd6GYAE3JVy6aKxszMV5jhGGFwraXQKA5fldvf3lMyEqw==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2160,6 +2179,10 @@ packages:
 
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -2389,6 +2412,9 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -2508,6 +2534,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.1:
+    resolution: {integrity: sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -2698,6 +2727,9 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
@@ -2727,6 +2759,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   filesize@6.4.0:
     resolution: {integrity: sha512-mjFIpOHC4jbfcTfoh4rkWpI31mF7viw9ikj/JyLoKzqlwG/YsefKfvYlYhdYdg/9mtK2z1AzgN/0LvVQ3zdlSQ==}
@@ -2993,6 +3028,10 @@ packages:
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
@@ -3068,6 +3107,9 @@ packages:
   install-artifact-from-github@1.4.0:
     resolution: {integrity: sha512-+y6WywKZREw5rq7U2jvr2nmZpT7cbWbQQ0N/qfcseYnzHFz2cZz1Et52oY+XttYuYeTkI8Y+R2JNWj68MpQFSg==}
     hasBin: true
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
@@ -3286,6 +3328,9 @@ packages:
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -3923,6 +3968,9 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
@@ -3969,6 +4017,9 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   pg-cloudflare@1.3.0:
     resolution: {integrity: sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==}
@@ -4138,6 +4189,9 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   railroad-diagrams@1.0.0:
     resolution: {integrity: sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==}
 
@@ -4236,6 +4290,9 @@ packages:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   registry-auth-token@5.1.1:
     resolution: {integrity: sha512-P7B4+jq8DeD2nMsAcdfaqHbssgHtZ7Z5+++a5ask90fvmJ8p5je4mOa+wzu+DB4vQ5tdJV/xywY+UnVFeQLV5Q==}
     engines: {node: '>=14'}
@@ -4280,6 +4337,10 @@ packages:
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@5.0.10:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
@@ -4439,6 +4500,10 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   statuses@1.5.0:
     resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
     engines: {node: '>= 0.6'}
@@ -4523,6 +4588,10 @@ packages:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4565,6 +4634,9 @@ packages:
 
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -4756,6 +4828,9 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -6768,7 +6843,12 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/pako@2.0.4': {}
+
   '@types/qs@6.15.0': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/range-parser@1.2.7': {}
 
@@ -6807,6 +6887,9 @@ snapshots:
     optional: true
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@2.0.11': {}
 
@@ -7070,6 +7153,8 @@ snapshots:
     dependencies:
       bare-path: 3.0.0
 
+  base64-arraybuffer@1.0.2: {}
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.20: {}
@@ -7211,6 +7296,18 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001788: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   ccount@2.0.1: {}
 
@@ -7430,6 +7527,10 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
@@ -7515,6 +7616,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   dot-prop@5.3.0:
     dependencies:
@@ -7777,6 +7883,12 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fast-uri@3.1.0: {}
 
   fast-xml-builder@1.1.5:
@@ -7806,6 +7918,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.2: {}
 
   filesize@6.4.0: {}
 
@@ -8314,6 +8428,11 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+
   http-cache-semantics@4.2.0:
     optional: true
 
@@ -8389,6 +8508,8 @@ snapshots:
 
   install-artifact-from-github@1.4.0:
     optional: true
+
+  iobuffer@5.4.0: {}
 
   ip-address@10.1.0: {}
 
@@ -8594,6 +8715,17 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.4
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.1
+      html2canvas: 1.4.1
 
   jwa@2.0.1:
     dependencies:
@@ -9350,6 +9482,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@2.1.0: {}
+
   parse-entities@4.0.2:
     dependencies:
       '@types/unist': 2.0.11
@@ -9399,6 +9533,9 @@ snapshots:
   path-to-regexp@8.4.2: {}
 
   pathe@2.0.3: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   pg-cloudflare@1.3.0:
     optional: true
@@ -9563,6 +9700,11 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   railroad-diagrams@1.0.0: {}
 
   randexp@0.4.6:
@@ -9689,6 +9831,9 @@ snapshots:
       indent-string: 4.0.0
       strip-indent: 3.0.0
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   registry-auth-token@5.1.1:
     dependencies:
       '@pnpm/npm-conf': 3.0.2
@@ -9745,6 +9890,9 @@ snapshots:
       - supports-color
 
   retry@0.13.1: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@5.0.10:
     dependencies:
@@ -9957,6 +10105,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   statuses@1.5.0: {}
 
   statuses@2.0.2: {}
@@ -10070,6 +10221,9 @@ snapshots:
       has-flag: 4.0.0
       supports-color: 7.2.0
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   symbol-tree@3.2.4: {}
 
   tabbable@6.4.0: {}
@@ -10141,6 +10295,10 @@ snapshots:
       - react-native-b4a
 
   text-hex@1.0.0: {}
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
 
   thenify-all@1.6.0:
     dependencies:
@@ -10376,6 +10534,10 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
 
   uuid@11.1.0: {}
 

--- a/src/features/page-editor/letterToPdf.ts
+++ b/src/features/page-editor/letterToPdf.ts
@@ -1,0 +1,58 @@
+import html2canvas from "html2canvas";
+import { jsPDF as JsPDF } from "jspdf";
+
+const PAGE_W_IN = 8.5;
+const PAGE_H_IN = 11;
+const DPI = 96;
+const PAGE_W_PX = PAGE_W_IN * DPI;
+
+/** Snapshot a rendered LetterCanvas DOM subtree into a paginated PDF.
+ *  Targets the existing `[data-print-only-letter]` portal (already
+ *  mounted at true 8.5 × 11 with chips + vars baked in), so the PDF
+ *  matches the on-screen design pixel-for-pixel.
+ *
+ *  Image-based PDF: html2canvas rasterises the subtree, then we slice
+ *  the canvas into 11"-tall pages and embed each slice on a fresh
+ *  jsPDF page. Selectable text isn't preserved — we accept that for
+ *  simplicity; the share path is a hand-delivery alternative, not a
+ *  long-term archival format. */
+export async function letterCanvasToPdf(
+  el: HTMLElement,
+  filename: string,
+): Promise<{ blob: Blob; file: File }> {
+  const canvas = await html2canvas(el, {
+    scale: 2,
+    backgroundColor: "#ffffff",
+    useCORS: true,
+    logging: false,
+    width: PAGE_W_PX,
+    windowWidth: PAGE_W_PX,
+  });
+
+  const pxPerInch = canvas.width / PAGE_W_IN;
+  const pageHeightPx = pxPerInch * PAGE_H_IN;
+  const pages = Math.max(1, Math.ceil(canvas.height / pageHeightPx));
+
+  const pdf = new JsPDF({ unit: "in", format: "letter", orientation: "portrait" });
+
+  for (let i = 0; i < pages; i++) {
+    const sliceY = i * pageHeightPx;
+    const sliceH = Math.min(pageHeightPx, canvas.height - sliceY);
+    const slice = document.createElement("canvas");
+    slice.width = canvas.width;
+    slice.height = sliceH;
+    const ctx = slice.getContext("2d");
+    if (!ctx) throw new Error("PDF generation failed: 2D context unavailable.");
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, slice.width, slice.height);
+    ctx.drawImage(canvas, 0, -sliceY);
+    const imgData = slice.toDataURL("image/jpeg", 0.92);
+    if (i > 0) pdf.addPage();
+    const renderedHIn = sliceH / pxPerInch;
+    pdf.addImage(imgData, "JPEG", 0, 0, PAGE_W_IN, renderedHIn);
+  }
+
+  const blob = pdf.output("blob");
+  const file = new File([blob], filename, { type: "application/pdf" });
+  return { blob, file };
+}

--- a/src/features/page-editor/shareLetterPdf.ts
+++ b/src/features/page-editor/shareLetterPdf.ts
@@ -1,0 +1,45 @@
+/** Hands a generated letter PDF to the OS share sheet (Web Share API)
+ *  when files are supported, otherwise triggers a plain download. The
+ *  share path lets the bishop route the letter through any installed
+ *  app (iMessage, WhatsApp, AirDrop, Mail, Files-as-PDF) without
+ *  surfacing the invitation's capability link, so there's no path
+ *  for a fake speaker response.
+ *
+ *  Returns which path actually fired so callers can adjust UI copy
+ *  ("Letter shared" vs. "Letter downloaded"). */
+export async function shareLetterPdf(
+  file: File,
+  filename: string,
+  title: string,
+): Promise<"shared" | "downloaded"> {
+  if (
+    typeof navigator !== "undefined" &&
+    typeof navigator.canShare === "function" &&
+    navigator.canShare({ files: [file] }) &&
+    typeof navigator.share === "function"
+  ) {
+    try {
+      await navigator.share({ files: [file], title });
+      return "shared";
+    } catch (err) {
+      // User cancelled the OS share sheet — treat as success-no-op so
+      // the wizard still progresses to the post-share confirm. Any
+      // other error falls through to the download fallback.
+      if (err instanceof DOMException && err.name === "AbortError") return "shared";
+    }
+  }
+  download(file, filename);
+  return "downloaded";
+}
+
+function download(file: File, filename: string): void {
+  const url = URL.createObjectURL(file);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  // Defer revoke so the click has time to fire on slow browsers.
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/src/features/plan-speakers/HandDeliveryConfirmPrompt.tsx
+++ b/src/features/plan-speakers/HandDeliveryConfirmPrompt.tsx
@@ -9,11 +9,12 @@ export function HandDeliveryConfirmPrompt({ speakerName }: Props) {
   return (
     <div className="bg-chalk border border-border rounded-lg p-5 flex flex-col gap-4">
       <h2 className="font-display text-[18px] font-semibold text-walnut">
-        Did you hand-deliver to {speakerName}?
+        Did you deliver this letter to {speakerName}?
       </h2>
       <p className="font-serif text-[13.5px] text-walnut-2 leading-relaxed">
-        If you handed off the printed letter, we'll mark them as invited so the schedule reflects
-        it. Otherwise, you can leave them planned and try again later.
+        If you sent the letter through Messages / Mail / AirDrop / WhatsApp, or handed off a
+        printout, we'll mark them as invited so the schedule reflects it. Otherwise, you can leave
+        them planned and try again later.
       </p>
     </div>
   );

--- a/src/features/plan-speakers/ReviewLetterFooter.tsx
+++ b/src/features/plan-speakers/ReviewLetterFooter.tsx
@@ -11,7 +11,7 @@ interface Props {
 const PRIMARY_LABEL: Record<ActionMode, string> = {
   send: "Send invitation →",
   resend: "Resend invitation →",
-  print: "Print →",
+  print: "Share or print →",
 };
 
 export function ReviewLetterFooter({ mode, busy, onBack, onPrimary }: Props) {

--- a/src/features/plan-speakers/SpeakerActionPicker.tsx
+++ b/src/features/plan-speakers/SpeakerActionPicker.tsx
@@ -65,7 +65,7 @@ export function SpeakerActionPicker({ speaker, wardId, date, onPick, onSkip, onB
 
             <p className="font-serif text-[13.5px] text-walnut-2 leading-relaxed">
               {alreadyInvited
-                ? "An invitation has already been sent. Resend it (with any letter edits), print it for hand-delivery, or skip."
+                ? "An invitation has already been sent. Resend it (with any letter edits), share the letter directly, or skip."
                 : "How would you like to invite this speaker?"}
             </p>
 
@@ -95,7 +95,7 @@ export function SpeakerActionPicker({ speaker, wardId, date, onPick, onSkip, onB
                 onClick={() => onPick("print")}
                 className="rounded-md border border-border-strong bg-chalk px-4 py-2.5 font-sans text-[14px] font-semibold text-walnut hover:bg-parchment-2 text-left"
               >
-                Print &amp; hand-deliver →
+                Share or print letter →
               </button>
               <button
                 type="button"

--- a/src/features/plan-speakers/useReviewLetterAction.ts
+++ b/src/features/plan-speakers/useReviewLetterAction.ts
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import type { Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
+import { letterCanvasToPdf } from "@/features/page-editor/letterToPdf";
+import { shareLetterPdf } from "@/features/page-editor/shareLetterPdf";
 import type { ActionMode } from "./SpeakerActionPicker";
 import type { useWizardActions } from "./useWizardActions";
 import type { usePrepareInvitation } from "@/features/templates/usePrepareInvitation";
@@ -72,9 +74,29 @@ export function useReviewLetterAction(args: Args) {
       return;
     }
     await form.persistOverrides();
-    window.print();
-    setPostPrint(true);
+    const target = document.querySelector<HTMLElement>("[data-print-only-letter]");
+    if (!target) {
+      actions.setError("Could not find the letter to share.");
+      return;
+    }
+    try {
+      const filename = pdfFilename(speaker.data.name, date);
+      const { file } = await letterCanvasToPdf(target, filename);
+      await shareLetterPdf(file, filename, `Invitation for ${speaker.data.name}`);
+      setPostPrint(true);
+    } catch (e) {
+      actions.setError(e instanceof Error ? e.message : "Could not share the letter.");
+    }
   }
 
   return { handle, postPrint };
+}
+
+function pdfFilename(speakerName: string, date: string): string {
+  const slug = speakerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `invitation-${slug || "speaker"}-${date}.pdf`;
 }


### PR DESCRIPTION
## Summary

Replaces \`window.print()\` on the wizard's Print & hand-deliver path with a universal PDF-generate + share/download flow. The bishop can now route the letter through any installed app (iMessage, WhatsApp, AirDrop, Mail, Files-as-PDF) on a single tap.

- New [letterToPdf.ts](src/features/page-editor/letterToPdf.ts) — html2canvas snapshots the existing \`[data-print-only-letter]\` portal, jsPDF stitches the canvas into a paginated 8.5×11 PDF
- New [shareLetterPdf.ts](src/features/page-editor/shareLetterPdf.ts) — \`navigator.share({ files: [...] })\` where supported, \`<a download>\` fallback elsewhere
- [useReviewLetterAction.ts](src/features/plan-speakers/useReviewLetterAction.ts) drops \`window.print()\` and calls the share flow instead
- CTA copy: "Print & hand-deliver" → "Share or print letter", "Print →" → "Share or print →"
- PostPrintConfirm copy softens: "Did you hand-deliver?" → "Did you deliver this letter?"

The PDF carries **no capability link** — the artifact is the letter, nothing else. So the fake-response surface stays closed.

## Test plan

- [ ] **iPhone Safari**: wizard step 2 → tap Share or print → PDF generates → iOS share sheet → AirDrop / Messages / Mail / Save to Files all work → confirm "Did you deliver this letter?" → speaker marked invited
- [ ] **Android Chrome**: same gestures via Android share sheet
- [ ] **Desktop Chrome/Edge**: native share sheet
- [ ] **Desktop Safari (macOS)**: macOS share sheet
- [ ] **Desktop Firefox**: PDF downloads silently (fallback)
- [ ] PDF visually matches the on-screen LetterCanvas (chrome / signature / callout / chip styling)

## Notes

Bundle delta is ~180KB gzipped (over the 150KB plan budget). Acceptable for the feature value; can lazy-load both libs as a follow-up if it becomes a Lighthouse concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)