### PR TITLE
fix(invite): unblock Share-PDF on real letters (oklab + 0-canvas)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@twilio/conversations": "^3.0.0",
     "clsx": "^2.1.1",
     "firebase": "^12.12.0",
-    "html2canvas": "^1.4.1",
+    "html2canvas-pro": "^2.0.2",
     "jspdf": "^4.2.1",
     "lexical": "^0.43.0",
     "lucide-react": "^1.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,9 @@ importers:
       firebase:
         specifier: ^12.12.0
         version: 12.12.0
-      html2canvas:
-        specifier: ^1.4.1
-        version: 1.4.1
+      html2canvas-pro:
+        specifier: ^2.0.2
+        version: 2.0.2
       jspdf:
         specifier: ^4.2.1
         version: 4.2.1
@@ -3027,6 +3027,10 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html2canvas-pro@2.0.2:
+    resolution: {integrity: sha512-9G/t0XgCZWonLwL0JwI7su6NdbOPUY7Ur4Ihpp8+XMaW9ibA2nDXF181Jr6tm94k8lX6sthpaXB3XqEnsMd5Cw==}
+    engines: {node: '>=16.0.0'}
 
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
@@ -8428,10 +8432,16 @@ snapshots:
 
   html-url-attributes@3.0.1: {}
 
+  html2canvas-pro@2.0.2:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+
   html2canvas@1.4.1:
     dependencies:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
+    optional: true
 
   http-cache-semantics@4.2.0:
     optional: true

--- a/src/features/page-editor/letterToPdf.ts
+++ b/src/features/page-editor/letterToPdf.ts
@@ -1,4 +1,4 @@
-import html2canvas from "html2canvas";
+import html2canvas from "html2canvas-pro";
 import { jsPDF as JsPDF } from "jspdf";
 
 const PAGE_W_IN = 8.5;

--- a/src/features/page-editor/letterToPdf.ts
+++ b/src/features/page-editor/letterToPdf.ts
@@ -20,14 +20,26 @@ export async function letterCanvasToPdf(
   el: HTMLElement,
   filename: string,
 ): Promise<{ blob: Blob; file: File }> {
-  const canvas = await html2canvas(el, {
-    scale: 2,
-    backgroundColor: "#ffffff",
-    useCORS: true,
-    logging: false,
-    width: PAGE_W_PX,
-    windowWidth: PAGE_W_PX,
-  });
+  // The PrintOnlyLetter portal is `display: none` on screen so the
+  // print path can rely on it (see styles/index.css). html2canvas
+  // would otherwise snapshot a 0-by-0 canvas and the slice drawImage
+  // would throw "image argument is a canvas element with a width or
+  // height of 0". Park it off-screen for the duration of the capture
+  // so it lays out at full 8.5×11 without flashing on the user.
+  const restore = unhideOffscreen(el);
+  let canvas: HTMLCanvasElement;
+  try {
+    canvas = await html2canvas(el, {
+      scale: 2,
+      backgroundColor: "#ffffff",
+      useCORS: true,
+      logging: false,
+      width: PAGE_W_PX,
+      windowWidth: PAGE_W_PX,
+    });
+  } finally {
+    restore();
+  }
 
   const pxPerInch = canvas.width / PAGE_W_IN;
   const pageHeightPx = pxPerInch * PAGE_H_IN;
@@ -55,4 +67,33 @@ export async function letterCanvasToPdf(
   const blob = pdf.output("blob");
   const file = new File([blob], filename, { type: "application/pdf" });
   return { blob, file };
+}
+
+const OFFSCREEN_STYLES = {
+  display: "block",
+  position: "fixed",
+  top: "0",
+  left: "-100000px",
+  visibility: "visible",
+  pointerEvents: "none",
+} as const;
+
+function unhideOffscreen(el: HTMLElement): () => void {
+  const previous: Record<string, string> = {};
+  for (const key of Object.keys(OFFSCREEN_STYLES) as (keyof typeof OFFSCREEN_STYLES)[]) {
+    previous[key] = el.style.getPropertyValue(camelToKebab(key));
+    el.style.setProperty(camelToKebab(key), OFFSCREEN_STYLES[key], "important");
+  }
+  return () => {
+    for (const key of Object.keys(previous)) {
+      const prop = camelToKebab(key);
+      const prev = previous[key];
+      if (prev) el.style.setProperty(prop, prev);
+      else el.style.removeProperty(prop);
+    }
+  };
+}
+
+function camelToKebab(s: string): string {
+  return s.replace(/[A-Z]/g, (c) => `-${c.toLowerCase()}`);
 }


### PR DESCRIPTION
## Summary

Two stacked fixes for the just-shipped Share-PDF flow that surfaced when the bishop tapped "Share or print letter" on a real letter:

1. **html2canvas → html2canvas-pro** — upstream html2canvas can't parse Tailwind v4's modern CSS colour functions (\`oklch\`, \`oklab\`, \`color-mix\`) and threw \`'Attempting to parse an unsupported color function "oklab"'\`. \`html2canvas-pro\` is a maintained drop-in fork that supports them.

2. **Park PrintOnlyLetter off-screen during snapshot** — the portal is \`display: none\` on screen so the print path can rely on it. html2canvas-pro therefore snapshotted a 0×0 canvas and the slice \`drawImage\` threw \`"image argument is a canvas element with a width or height of 0"\`. Solution: set inline \`position: fixed; left: -100000px; display: block\` (with \`!important\`) on the portal for the duration of the capture, then restore the original styles.

## Test plan

- [ ] Tap Share or print letter on the wizard's review step — no console error, PDF generates and the OS share sheet (or download) fires
- [ ] PDF visually matches the on-screen LetterCanvas (chrome / signature / callout / chip styling)
- [ ] No flash of the off-screen portal on the user's screen during capture
- [ ] Existing tests still pass (340/340)

🤖 Generated with [Claude Code](https://claude.com/claude-code)