### PR TITLE
feat(invite): share-as-PDF, bottom-sheet drawer, dev credit

### DIFF
--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from "react-router";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { OnlineStatusBanner } from "./OnlineStatusBanner";
 import { Topbar } from "./Topbar";
 
@@ -15,6 +16,9 @@ export function AppShell() {
       <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
         <Outlet />
       </div>
+      <footer className="flex justify-center py-3 px-4">
+        <BuiltByCredit />
+      </footer>
     </div>
   );
 }

--- a/src/app/routes/accept-invite.tsx
+++ b/src/app/routes/accept-invite.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { doc, getDoc } from "firebase/firestore";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { AcceptInviteBody, type AcceptInviteState } from "@/features/invites/AcceptInviteBody";
 import { acceptInvite, findInvitesForEmail } from "@/features/invites/inviteActions";
 import { db } from "@/lib/firebase";
@@ -92,15 +93,18 @@ export function AcceptInvitePage() {
 
   return (
     <main className="min-h-dvh bg-parchment paper-grain grid place-items-center p-6">
-      <div className="w-full max-w-md rounded-[14px] border border-border-strong bg-chalk p-7 shadow-elev-3">
-        <div className="mb-4 font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
-          Ward invitation
+      <div className="w-full max-w-md flex flex-col items-center gap-4">
+        <div className="w-full rounded-[14px] border border-border-strong bg-chalk p-7 shadow-elev-3">
+          <div className="mb-4 font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+            Ward invitation
+          </div>
+          <AcceptInviteBody
+            state={state}
+            onAccept={() => void accept()}
+            onSignOut={() => void signOut()}
+          />
         </div>
-        <AcceptInviteBody
-          state={state}
-          onAccept={() => void accept()}
-          onSignOut={() => void signOut()}
-        />
+        <BuiltByCredit />
       </div>
     </main>
   );

--- a/src/app/routes/invite-speaker-chat-drawer.tsx
+++ b/src/app/routes/invite-speaker-chat-drawer.tsx
@@ -15,10 +15,14 @@ interface Props {
 }
 
 /** Floating chat drawer for the speaker invite page. Collapsed, it
- *  shows a pill-shaped FAB bottom-right. Opened, it fills the screen
- *  on mobile and docks as a ~420px wide panel bottom-right on sm+.
- *  Body scroll is locked while open to keep the letter behind from
- *  rubber-banding on iOS. */
+ *  shows a pill-shaped FAB bottom-right. Opened on **mobile**, it
+ *  slides up from the bottom as a sheet (with a grab handle and
+ *  rounded top corners) so the top of the letter remains visible
+ *  behind it. Opened on **desktop** (sm+), it docks as a ~420px
+ *  wide panel in the bottom-right with a small inset — the speaker
+ *  has the screen real estate to keep the letter visible alongside
+ *  it. Body scroll is locked while open to keep the letter behind
+ *  from rubber-banding on iOS. */
 export function SpeakerChatFloatingDrawer({
   open,
   onOpenChange,
@@ -71,12 +75,20 @@ export function SpeakerChatFloatingDrawer({
       role="dialog"
       aria-modal="true"
       aria-label="Conversation with the bishopric"
-      className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.42)] flex items-stretch sm:items-end justify-end sm:p-4 animate-[fade_160ms_ease-out]"
+      className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)] flex items-end justify-center sm:justify-end sm:p-4 animate-[fade_160ms_ease-out]"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onOpenChange(false);
       }}
     >
-      <div className="bg-chalk flex flex-col w-full h-dvh sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border sm:border-border-strong sm:shadow-elev-3 overflow-hidden">
+      <div className="bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)] sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b sm:animate-none">
+        <button
+          type="button"
+          aria-label="Close conversation"
+          onClick={() => onOpenChange(false)}
+          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer sm:hidden"
+        >
+          <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
+        </button>
         {children}
       </div>
     </div>

--- a/src/app/routes/invite-speaker-share-toolbar.tsx
+++ b/src/app/routes/invite-speaker-share-toolbar.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { letterCanvasToPdf } from "@/features/page-editor/letterToPdf";
+import { shareLetterPdf } from "@/features/page-editor/shareLetterPdf";
+
+/** Renders the letter PDF and hands it to the OS share sheet (Web
+ *  Share API on iOS / Android), falling back to a download on
+ *  desktop browsers without share support. Targets the existing
+ *  `[data-print-only-letter]` portal that the invite page already
+ *  mounts at true 8.5×11. */
+export function ShareToolbar({
+  speakerName,
+  assignedDate,
+}: {
+  speakerName: string;
+  assignedDate: string;
+}): React.ReactElement {
+  const [busy, setBusy] = useState(false);
+
+  async function handleShare() {
+    if (busy) return;
+    const target = document.querySelector<HTMLElement>("[data-print-only-letter]");
+    if (!target) return;
+    setBusy(true);
+    try {
+      const filename = pdfFilename(speakerName, assignedDate);
+      const { file } = await letterCanvasToPdf(target, filename);
+      await shareLetterPdf(file, filename, `Invitation for ${speakerName}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="print:hidden flex justify-end">
+      <button
+        type="button"
+        onClick={handleShare}
+        disabled={busy}
+        title="Share · Save as PDF"
+        aria-label="Share · Save as PDF"
+        className="inline-flex items-center justify-center rounded-md border border-walnut bg-walnut w-9 h-9 text-chalk hover:bg-walnut-2 shadow-elev-2 disabled:opacity-60 disabled:cursor-progress"
+      >
+        {busy ? <SpinnerIcon /> : <ShareIcon />}
+      </button>
+    </div>
+  );
+}
+
+function pdfFilename(speakerName: string, date: string): string {
+  const slug = speakerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `invitation-${slug || "speaker"}-${date}.pdf`;
+}
+
+function ShareIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3v13" />
+      <path d="m7 8 5-5 5 5" />
+      <path d="M5 14v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+      className="animate-spin"
+    >
+      <path d="M12 3a9 9 0 1 1-6.4 2.6" />
+    </svg>
+  );
+}

--- a/src/app/routes/invite-speaker-states.tsx
+++ b/src/app/routes/invite-speaker-states.tsx
@@ -2,6 +2,7 @@ import type { SpeakerInvitation } from "@/lib/types";
 import type { SpeakerInvitationState } from "@/features/templates/useSpeakerInvitation";
 
 export { SessionGate } from "./invite-speaker-session-gate";
+export { ShareToolbar } from "./invite-speaker-share-toolbar";
 
 /** Non-"ready" sub-states for the invite landing page. Split out so
  *  the main route stays under the 150-LOC ceiling while keeping
@@ -61,40 +62,5 @@ export function ExpiredState({
 function StateFrame({ children }: { children?: React.ReactNode }) {
   return (
     <main className="min-h-dvh bg-[#e6ddc7] flex items-center justify-center p-4">{children}</main>
-  );
-}
-
-export function PrintToolbar(): React.ReactElement {
-  return (
-    <div className="print:hidden flex justify-end">
-      <button
-        type="button"
-        onClick={() => window.print()}
-        title="Print · Save as PDF"
-        aria-label="Print · Save as PDF"
-        className="inline-flex items-center justify-center rounded-md border border-walnut bg-walnut w-9 h-9 text-chalk hover:bg-walnut-2 shadow-elev-2"
-      >
-        <PrinterIcon />
-      </button>
-    </div>
-  );
-}
-
-function PrinterIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M6 9V2h12v7" />
-      <rect x="3" y="9" width="18" height="9" rx="2" />
-      <path d="M6 14h12v7H6z" />
-    </svg>
   );
 }

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -11,7 +11,7 @@ import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation"
 import type { SpeakerInvitation } from "@/lib/types";
 import { SpeakerChatFloatingDrawer } from "./invite-speaker-chat-drawer";
 import { SpeakerChatCTABanner, type CtaVariant } from "./invite-speaker-cta-banner";
-import { ExpiredState, NonReadyState, PrintToolbar, SessionGate } from "./invite-speaker-states";
+import { ExpiredState, NonReadyState, SessionGate, ShareToolbar } from "./invite-speaker-states";
 
 /**
  * Public landing page for an invitation link. The letter fills the
@@ -108,8 +108,12 @@ function InviteLandingContent({
         <SpeakerChatCTABanner variant={promptVariant} onTap={() => setChatOpen(true)} />
       )}
 
-      <div className="absolute top-4 right-4 z-10 pt-[env(safe-area-inset-top)]">
-        <PrintToolbar />
+      <div
+        className={`absolute right-4 z-10 pt-[env(safe-area-inset-top)] transition-[top] duration-200 ${
+          promptVariant ? "top-16" : "top-4"
+        }`}
+      >
+        <ShareToolbar speakerName={invitation.speakerName} assignedDate={invitation.assignedDate} />
       </div>
 
       <SpeakerChatFloatingDrawer

--- a/src/components/BuiltByCredit.tsx
+++ b/src/components/BuiltByCredit.tsx
@@ -1,0 +1,14 @@
+/** Personal-touch developer credit. Single source of truth so the
+ *  copy stays consistent on the app shell footer and on the public
+ *  invite pages. `className` lets the caller position it (footer flow
+ *  in AppShell / accept-invite, absolute bottom-left on the
+ *  full-viewport speaker invite). */
+export function BuiltByCredit({ className = "" }: { className?: string }): React.ReactElement {
+  return (
+    <span
+      className={`font-serif italic text-[10px] text-walnut-3 select-none print:hidden ${className}`}
+    >
+      This app was built with love and prayer, by Oriel Absin.
+    </span>
+  );
+}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { inviteAuth } from "@/lib/firebase";
 import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
@@ -184,6 +185,10 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         ensureReady={ensureReady}
         placeholder="Reply to the bishopric…"
       />
+
+      <div className="flex justify-center py-2 px-4 border-t border-border">
+        <BuiltByCredit />
+      </div>
     </section>
   );
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -246,6 +246,15 @@
   }
 }
 
+@keyframes drawerSlideUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
 /* Soft pulse ring for attention-worthy FABs. Used on the speaker
    invite page to draw the eye to the chat drawer when the speaker
    hasn't responded yet or the bishop has replied. */


### PR DESCRIPTION
## Summary

Three UX improvements to the speaker invite page + a small personal touch across the app, bundled into one PR since the changes share the same surface.

## Changes

### 1. Share-as-PDF on the speaker page (replaces print)

Speakers now tap a share button that renders the letter to PDF and hands it to the OS share sheet (Web Share API on iOS / Android), with a download fallback elsewhere. Reuses the existing `letterCanvasToPdf` + `shareLetterPdf` strategy already used by the bishop-side review-letter wizard, so the speaker's saved/shared PDF matches the bishop's pixel-for-pixel.

The toolbar now shifts from `top-4` to `top-16` with a 200ms transition when the reply/unread CTA banner is visible, avoiding the overlap the old static `top-4` position created.

### 2. Bottom-sheet chat drawer on mobile, docked panel on desktop

**Mobile:** the chat drawer now slides up as an 85dvh bottom sheet with rounded top corners and a grab-handle pill, instead of taking the full screen. The top of the letter peeks above the drawer so the speaker keeps spatial context for what they're replying about.

**Desktop (sm+):** unchanged from prior behavior — bottom-right docked panel at `max-w-105` / `80dvh` with all corners rounded, full border, no entrance slide animation, no grab handle.

Adds a `drawerSlideUp` keyframe scoped to mobile via `sm:animate-none`.

### 3. Personal developer credit

Adds a tiny italic-serif *"This app was built with love and prayer, by Oriel Absin."* line in three places, sourced from a single shared `<BuiltByCredit />` component:

- Bottom of `<AppShell />` — visible on every authenticated bishopric route.
- Below the card on `/accept-invite`.
- Bottom of the speaker chat drawer (placed inside the drawer rather than overlaid on the letter so it doesn't collide with the chat FAB on narrow viewports).

`print:hidden` ensures it can't leak into printed programs or the speaker letter PDF.

## Test plan

- [ ] **Share button — iOS Safari**: open invite, tap share, OS share sheet appears with the PDF; verify Files / Mail / iMessage / AirDrop targets work.
- [ ] **Share button — desktop Chrome**: tap share, PDF downloads with `invitation-<slug>-<YYYY-MM-DD>.pdf` filename.
- [ ] **Share button — busy state**: spinner replaces the icon while the PDF renders, button disabled.
- [ ] **Toolbar offset**: with reply or unread banner visible, share button sits at `top-16` clear of the banner; without banner, sits at `top-4`. Transition is smooth.
- [ ] **Mobile drawer**: open chat → drawer slides up from bottom, 85dvh, top of letter visible; tap grab handle or backdrop → closes. Scroll within drawer doesn't rubber-band the page.
- [ ] **Desktop drawer**: open chat → docked bottom-right panel ~420px wide, no grab handle, no slide animation, all four corners rounded.
- [ ] **Credit copy**: visible on `/schedule`, `/week/...`, `/settings/*`, `/accept-invite/...`, and at the bottom of the speaker chat drawer when open.
- [ ] **Credit absent**: not visible on `/print/...`, full-screen editor routes (`/plan/...`, `/week/.../prepare`), or in the shared letter PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)