### PR TITLE
feat(invite): backend wire for prayer-kind invitations

### DIFF
--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -8,6 +8,7 @@ import {
   trySms,
 } from "./sendSpeakerInvitation.helpers.js";
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
+import { invitationPrayerType } from "./invitationTypes.js";
 import type { FromNumberMode } from "./twilio/fromNumber.js";
 import type {
   DeliveryEntry,
@@ -45,8 +46,13 @@ export async function createFreshInvitation(
   // include the optional contact/topic fields when the caller actually
   // provided them. Missing fields read as `undefined` downstream,
   // which is what the rest of the code already expects.
+  const isPrayer = input.kind === "prayer";
   const docRef = await db.collection(`wards/${input.wardId}/speakerInvitations`).add({
     speakerRef: { meetingDate: input.meetingDate, speakerId: input.speakerId },
+    // Persist `kind` only for non-default ("prayer") rows so the doc
+    // shape stays clean for every speaker send. Readers default
+    // missing-field to "speaker" via the Zod schema.
+    ...(isPrayer ? { kind: "prayer", prayerRole: input.prayerRole } : {}),
     assignedDate: input.assignedDate,
     sentOn: input.sentOn,
     wardName: input.wardName,
@@ -80,12 +86,17 @@ export async function createFreshInvitation(
   });
 
   const inviteUrl = buildInviteUrl(origin, input.wardId, docRef.id, plaintextToken);
+  const prayerType =
+    isPrayer && input.prayerRole
+      ? invitationPrayerType({ kind: "prayer", prayerRole: input.prayerRole })
+      : undefined;
   const emailArgs = {
     speakerName: input.speakerName,
     inviterName: input.inviterName,
     assignedDate: input.assignedDate,
     wardName: input.wardName,
     inviteUrl,
+    ...(prayerType ? { prayerType } : {}),
   };
 
   const deliveryRecord: DeliveryEntry[] = [];

--- a/functions/src/invitationDelivery.ts
+++ b/functions/src/invitationDelivery.ts
@@ -24,11 +24,14 @@ export async function tryEmail(
   args: EmailArgs,
 ): Promise<DeliveryEntry> {
   try {
+    const subject = args.prayerType
+      ? `Prayer invitation — ${params.assignedDate}`
+      : `Speaking invitation — ${params.assignedDate}`;
     const messageId = await sendEmail({
       to: params.speakerEmail,
       fromDisplayName: `${params.inviterName} (via Steward)`,
       replyTo: params.replyToEmail,
-      subject: `Speaking invitation — ${params.assignedDate}`,
+      subject,
       text: buildEmailText(args),
       html: buildEmailHtml(args),
     });
@@ -43,9 +46,12 @@ export async function tryEmail(
 
 async function buildInitialInvitationSms(
   wardId: string,
-  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl">,
+  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl"> & {
+    prayerType?: string;
+  },
 ): Promise<string> {
-  const template = await readMessageTemplate(getFirestore(), wardId, "initialInvitationSms");
+  const key = vars.prayerType ? "prayerInitialInvitationSms" : "initialInvitationSms";
+  const template = await readMessageTemplate(getFirestore(), wardId, key);
   return interpolate(template, vars);
 }
 

--- a/functions/src/invitationEmailBody.ts
+++ b/functions/src/invitationEmailBody.ts
@@ -4,13 +4,28 @@ export interface BuildEmailArgs {
   assignedDate: string;
   wardName: string;
   inviteUrl: string;
+  /** Set for prayer invitations — e.g. "opening prayer" or
+   *  "benediction". When present the body wording switches from
+   *  "speak on …" to "give the {prayerType} on …". */
+  prayerType?: string;
+}
+
+function inviteAction(a: BuildEmailArgs): string {
+  return a.prayerType
+    ? `give the ${a.prayerType} on ${a.assignedDate}`
+    : `speak on ${a.assignedDate}`;
+}
+
+function inviteActionHtml(a: BuildEmailArgs): string {
+  const date = `<strong>${escapeHtml(a.assignedDate)}</strong>`;
+  return a.prayerType ? `give the ${escapeHtml(a.prayerType)} on ${date}` : `speak on ${date}`;
 }
 
 export function buildEmailText(a: BuildEmailArgs): string {
   return [
     `Dear ${a.speakerName},`,
     "",
-    `${a.inviterName} has invited you to speak on ${a.assignedDate}.`,
+    `${a.inviterName} has invited you to ${inviteAction(a)}.`,
     "",
     `Read the full invitation here:`,
     a.inviteUrl,
@@ -21,7 +36,7 @@ export function buildEmailText(a: BuildEmailArgs): string {
 
 export function buildEmailHtml(a: BuildEmailArgs): string {
   return `<p>Dear ${escapeHtml(a.speakerName)},</p>
-<p>${escapeHtml(a.inviterName)} has invited you to speak on <strong>${escapeHtml(a.assignedDate)}</strong>.</p>
+<p>${escapeHtml(a.inviterName)} has invited you to ${inviteActionHtml(a)}.</p>
 <p><a href="${a.inviteUrl}">Read the full invitation</a>.</p>
 <p style="color:#666;font-size:12px;">— ${escapeHtml(a.wardName)}</p>`;
 }

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -1,5 +1,5 @@
 import { interpolate } from "./messageTemplates.js";
-import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import { invitationPrayerType, type SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ReceiptBuildArgs {
   invitation: SpeakerInvitationShape;
@@ -63,12 +63,16 @@ export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("speaker receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
+  const prayerType = invitationPrayerType(invitation);
 
-  const subject = `You ${verb} the speaking invitation — ${invitation.assignedDate}`;
+  const subject = prayerType
+    ? `You ${verb} the prayer invitation — ${invitation.assignedDate}`
+    : `You ${verb} the speaking invitation — ${invitation.assignedDate}`;
   const headerText = interpolate(headerTemplate, {
     speakerName: invitation.speakerName,
     assignedDate: invitation.assignedDate,
     reason: invitation.response?.reason ?? "",
+    ...(prayerType ? { prayerType } : {}),
   });
   const text = [
     headerText,
@@ -109,11 +113,15 @@ export function buildBishopricReceipt(args: ReceiptBuildArgs): ReceiptContent {
   if (!answer) throw new Error("bishopric receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
 
-  const subject = `${invitation.speakerName} ${verb} the speaking invitation — ${invitation.assignedDate}`;
+  const prayerType = invitationPrayerType(invitation);
+  const subject = prayerType
+    ? `${invitation.speakerName} ${verb} the prayer invitation — ${invitation.assignedDate}`
+    : `${invitation.speakerName} ${verb} the speaking invitation — ${invitation.assignedDate}`;
   const responseLine = interpolate(headerTemplate, {
     speakerName: invitation.speakerName,
     verb,
     assignedDate: invitation.assignedDate,
+    ...(prayerType ? { prayerType } : {}),
   });
   const metaLines: string[] = [];
   if (respondedAt) metaLines.push(`Responded: ${respondedAt.toLocaleString()}`);

--- a/functions/src/invitationTypes.ts
+++ b/functions/src/invitationTypes.ts
@@ -2,6 +2,14 @@
  *  Cloud Functions (Admin SDK). Keeps the webhook + callable free of
  *  importing from the web Zod schema. */
 export interface SpeakerInvitationShape {
+  /** Discriminator for which kind of participant this invitation is
+   *  for. Default "speaker" (treat absent as speaker for back-compat
+   *  with pre-prayer-flow rows). */
+  kind?: "speaker" | "prayer";
+  /** Set only when `kind === "prayer"`. Mirrors the prayer
+   *  participant doc's role at
+   *  `wards/{wardId}/meetings/{date}/prayers/{role}`. */
+  prayerRole?: "opening" | "benediction";
   speakerRef: { meetingDate: string; speakerId: string };
   assignedDate: string;
   sentOn: string;
@@ -48,4 +56,15 @@ export interface SpeakerInvitationShape {
    *  subsequent SMS for this invitation route through the same
    *  number — see `twilio/fromNumber.ts`. */
   fromNumberMode?: "production" | "testing";
+}
+
+/** User-facing label for a prayer-kind invitation, used to fill the
+ *  `{{prayerType}}` token in SMS / email / receipt templates. Returns
+ *  undefined for speaker invitations so callers can spread it
+ *  conditionally into vars bags. */
+export function invitationPrayerType(
+  invitation: Pick<SpeakerInvitationShape, "kind" | "prayerRole">,
+): string | undefined {
+  if (invitation.kind !== "prayer" || !invitation.prayerRole) return undefined;
+  return invitation.prayerRole === "opening" ? "opening prayer" : "benediction";
 }

--- a/functions/src/messageTemplateDefaults.ts
+++ b/functions/src/messageTemplateDefaults.ts
@@ -38,13 +38,30 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
   "— {{wardName}}",
 ].join("\n");
 
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
+  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
+  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+
+export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =
+  "You accepted the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you.";
+
+export const DEFAULT_PRAYER_RESPONSE_DECLINED =
+  "You declined the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you for letting us know.";
+
+export const DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT =
+  "{{speakerName}} {{verb}} the invitation to give the {{prayerType}} on {{assignedDate}}.";
+
 export type MessageTemplateKey =
   | "initialInvitationSms"
   | "speakerResponseAccepted"
   | "speakerResponseDeclined"
   | "bishopricResponseReceipt"
   | "bishopReplySms"
-  | "bishopReplyEmail";
+  | "bishopReplyEmail"
+  | "prayerInitialInvitationSms"
+  | "prayerResponseAccepted"
+  | "prayerResponseDeclined"
+  | "prayerBishopricResponseReceipt";
 
 export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
@@ -53,4 +70,8 @@ export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
   bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
   bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
+  prayerInitialInvitationSms: DEFAULT_PRAYER_INITIAL_INVITATION_SMS,
+  prayerResponseAccepted: DEFAULT_PRAYER_RESPONSE_ACCEPTED,
+  prayerResponseDeclined: DEFAULT_PRAYER_RESPONSE_DECLINED,
+  prayerBishopricResponseReceipt: DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT,
 };

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -40,10 +40,17 @@ export const onInvitationWrite = onDocumentWritten(
     const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
     try {
       const bishopric = await fetchActiveBishopricEmails(db, wardId);
+      const isPrayer = after.kind === "prayer";
       if (change.fireSpeaker) {
         const answer = after.response?.answer;
-        const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
-        const headerTemplate = await readMessageTemplate(db, wardId, key);
+        const speakerKey = isPrayer
+          ? answer === "yes"
+            ? "prayerResponseAccepted"
+            : "prayerResponseDeclined"
+          : answer === "yes"
+            ? "speakerResponseAccepted"
+            : "speakerResponseDeclined";
+        const headerTemplate = await readMessageTemplate(db, wardId, speakerKey);
         // allSettled — one leg failing must NOT cancel the other.
         // Promise.all rejects on first failure; the outer try/catch
         // then catches and the function exits, which tears down the
@@ -64,7 +71,10 @@ export const onInvitationWrite = onDocumentWritten(
         }
       }
       if (change.fireBishopric) {
-        const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");
+        const bishopricKey = isPrayer
+          ? "prayerBishopricResponseReceipt"
+          : "bishopricResponseReceipt";
+        const headerTemplate = await readMessageTemplate(db, wardId, bishopricKey);
         await sendBishopricReceipt(after, bishopric, {
           wardId,
           invitationId,

--- a/functions/src/sendSpeakerInvitation.types.ts
+++ b/functions/src/sendSpeakerInvitation.types.ts
@@ -15,6 +15,17 @@ export interface FreshInvitationRequest {
   channels: ("email" | "sms")[];
   speakerName: string;
   speakerTopic?: string;
+  /** Discriminator for the kind of participant being invited. Default
+   *  "speaker" preserves back-compat. When "prayer", `prayerRole` is
+   *  required; the SMS body uses `prayerInitialInvitationSms` and the
+   *  receipt copy uses the `prayer*` template keys. The same Twilio
+   *  Conversation + capability-token plumbing is reused — full chat
+   *  parity with speakers per product spec. */
+  kind?: "speaker" | "prayer";
+  /** Required when `kind === "prayer"`. Persisted on the invitation
+   *  doc so the speaker landing page + receipt builders can resolve
+   *  the right copy + variables (`{{prayerType}}`). */
+  prayerRole?: "opening" | "benediction";
   inviterName: string;
   wardName: string;
   assignedDate: string;

--- a/src/features/templates/serverTemplateDefaults.ts
+++ b/src/features/templates/serverTemplateDefaults.ts
@@ -55,6 +55,26 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
   "— {{wardName}}",
 ].join("\n");
 
+/** Twilio SMS body sent when a bishop first invites a prayer-giver.
+ *  Mirrors the speaker-side wording with prayer phrasing in place of
+ *  "speak". `{{prayerType}}` resolves to "opening prayer" or
+ *  "benediction" per the prayer participant's role. */
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
+  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
+  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+
+/** Speaker-side acceptance receipt for prayer invitations. */
+export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =
+  "You accepted the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you.";
+
+/** Speaker-side decline receipt for prayer invitations. */
+export const DEFAULT_PRAYER_RESPONSE_DECLINED =
+  "You declined the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you for letting us know.";
+
+/** Bishopric-side receipt opening line for prayer invitations. */
+export const DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT =
+  "{{speakerName}} {{verb}} the invitation to give the {{prayerType}} on {{assignedDate}}.";
+
 export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
   speakerResponseAccepted: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
@@ -62,4 +82,8 @@ export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
   bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
   bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
+  prayerInitialInvitationSms: DEFAULT_PRAYER_INITIAL_INVITATION_SMS,
+  prayerResponseAccepted: DEFAULT_PRAYER_RESPONSE_ACCEPTED,
+  prayerResponseDeclined: DEFAULT_PRAYER_RESPONSE_DECLINED,
+  prayerBishopricResponseReceipt: DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT,
 };

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -5,9 +5,18 @@ export const MEETING_TYPES = ["regular", "fast", "stake", "general"] as const;
 export const meetingTypeSchema = z.enum(MEETING_TYPES);
 export type MeetingType = z.infer<typeof meetingTypeSchema>;
 
-export const SPEAKER_STATUSES = ["planned", "invited", "confirmed", "declined"] as const;
-export const speakerStatusSchema = z.enum(SPEAKER_STATUSES);
-export type SpeakerStatus = z.infer<typeof speakerStatusSchema>;
+// Shared invitation lifecycle for both speakers and prayer-givers.
+// `SPEAKER_STATUSES` / `speakerStatusSchema` / `SpeakerStatus` are
+// retained as aliases so existing speaker call sites don't churn —
+// new invitation kinds (prayers, future) should import the
+// `INVITATION_*` names directly.
+export const INVITATION_STATUSES = ["planned", "invited", "confirmed", "declined"] as const;
+export const invitationStatusSchema = z.enum(INVITATION_STATUSES);
+export type InvitationStatus = z.infer<typeof invitationStatusSchema>;
+
+export const SPEAKER_STATUSES = INVITATION_STATUSES;
+export const speakerStatusSchema = invitationStatusSchema;
+export type SpeakerStatus = InvitationStatus;
 
 export const SPEAKER_ROLES = ["Member", "Youth", "High Council", "Visiting"] as const;
 export const speakerRoleSchema = z.enum(SPEAKER_ROLES);
@@ -156,3 +165,29 @@ export const speakerSchema = z.object({
   updatedAt: z.any().optional(),
 });
 export type Speaker = z.infer<typeof speakerSchema>;
+
+// Prayer-giver participant — promoted from the lightweight inline
+// `Assignment` row on the meeting (`openingPrayer`, `benediction`)
+// when the bishop wants to send a formal invitation. Stored at
+// `wards/{wardId}/meetings/{date}/prayers/{role}` (one doc per slot).
+// The status enum is shared with speakers (see `INVITATION_STATUSES`).
+export const PRAYER_ROLES = ["opening", "benediction"] as const;
+export const prayerRoleSchema = z.enum(PRAYER_ROLES);
+export type PrayerRole = z.infer<typeof prayerRoleSchema>;
+
+export const prayerParticipantSchema = z.object({
+  name: z.string().min(1),
+  email: z.email().optional().or(z.literal("")),
+  phone: z.string().optional().or(z.literal("")),
+  role: prayerRoleSchema,
+  status: invitationStatusSchema.catch("planned"),
+  letterOverride: speakerLetterOverrideSchema.optional(),
+  invitationId: z.string().optional(),
+  conversationSid: z.string().optional(),
+  statusSource: statusSourceSchema.optional(),
+  statusSetBy: z.string().optional(),
+  statusSetAt: z.any().optional(),
+  createdAt: z.any().optional(),
+  updatedAt: z.any().optional(),
+});
+export type PrayerParticipant = z.infer<typeof prayerParticipantSchema>;

--- a/src/lib/types/speakerInvitation.ts
+++ b/src/lib/types/speakerInvitation.ts
@@ -65,7 +65,23 @@ export const speakerInvitationResponseSchema = z.object({
 export type SpeakerInvitationResponse = z.infer<typeof speakerInvitationResponseSchema>;
 
 export const speakerInvitationSchema = z.object({
-  /** Denormalized speaker reference back to the originating doc. */
+  /** Discriminator for which kind of participant this invitation is
+   *  for. Default "speaker" preserves back-compat for invitations
+   *  written before the prayer flow shipped; "prayer" routes through
+   *  the same Cloud Function + Twilio Conversation infrastructure
+   *  but with prayer-specific copy + the prayer letter template.
+   *  When `kind === "prayer"`, `prayerRole` is required and
+   *  `speakerRef.speakerId` holds the prayer role ("opening" |
+   *  "benediction") rather than a speaker doc ID. */
+  kind: z.enum(["speaker", "prayer"]).default("speaker"),
+  /** Set only when `kind === "prayer"`. Mirrors the participant doc's
+   *  role at `wards/{wardId}/meetings/{date}/prayers/{role}`. */
+  prayerRole: z.enum(["opening", "benediction"]).optional(),
+  /** Denormalized participant reference back to the originating doc.
+   *  For speakers: `speakerId` is the speaker doc ID. For prayers:
+   *  `speakerId` holds the role string ("opening" | "benediction")
+   *  matching the prayer participant doc path. The field name is
+   *  retained for back-compat — see follow-up rename issue. */
   speakerRef: z.object({
     meetingDate: z.string(), // ISO YYYY-MM-DD
     speakerId: z.string().min(1),

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -157,6 +157,10 @@ export const MESSAGE_TEMPLATE_KEYS = [
   "bishopricResponseReceipt",
   "bishopReplySms",
   "bishopReplyEmail",
+  "prayerInitialInvitationSms",
+  "prayerResponseAccepted",
+  "prayerResponseDeclined",
+  "prayerBishopricResponseReceipt",
 ] as const;
 export type MessageTemplateKey = (typeof MESSAGE_TEMPLATE_KEYS)[number];
 


### PR DESCRIPTION
## Summary

First cut of prayer invitations — backend foundations only. The bishopric's executive secretary asked us to extend invitations to **opening** + **closing** prayer participants. This PR plumbs the Cloud Function + receipt builders with a \`kind: "speaker" | "prayer"\` discriminator so prayer-giver invitations route through the same pipeline (Twilio Conversation, capability token, accept/decline) but with role-appropriate copy.

**No new Cloud Function** — the CLAUDE.md eight-function rule holds; we extend \`sendSpeakerInvitation\` + \`onInvitationWrite\` instead.

### Changes

- **Types**: shared \`INVITATION_STATUSES\` / \`invitationStatusSchema\` between speakers + prayers; legacy \`SPEAKER_STATUSES\` aliased for back-compat. New \`prayerParticipantSchema\` + \`PRAYER_ROLES\` for the upcoming \`wards/{wardId}/meetings/{date}/prayers/{role}\` subcollection. \`speakerInvitationSchema\` gains \`kind\` + \`prayerRole\`.
- **Message templates**: four new keys + defaults (\`prayerInitialInvitationSms\`, \`prayerResponseAccepted\`, \`prayerResponseDeclined\`, \`prayerBishopricResponseReceipt\`). Client/server drift test still passes.
- **Cloud Function**: \`createFreshInvitation\` accepts + persists \`kind\` and \`prayerRole\`; \`tryEmail\` + \`trySms\` pick the prayer-keyed template + subject + email body when prayerType is set.
- **Receipts**: \`onInvitationWrite\` picks the prayer template keys when \`kind === "prayer"\`; \`buildSpeakerReceipt\` + \`buildBishopricReceipt\` fill \`{{prayerType}}\` from the new \`invitationPrayerType()\` helper.

### Out of scope (follow-up PRs)

- \`PrayersSection\` UI ("Invite" button per row + status chip)
- New \`/week/:date/prayer/:role/prepare\` route
- Speaker landing page kind-aware copy
- Dedicated \`prayerLetterTemplate\` ward template + editor route at \`/settings/templates/prayer-letter\` (PR 1 reuses the speaker letter template; PR 2/3 will add a dedicated prayer one)
- Two follow-up tech-debt issues for \`Speaker → Participant\` rename and \`sendSpeakerInvitation → sendInvitation\` rename

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean (181 → 184 warnings, 0 errors)
- [x] \`pnpm test\` passes (340/340)
- [x] \`functions: pnpm test\` passes (89/89) — drift test green with new prayer keys
- [x] \`pnpm build\` succeeds
- [ ] No UI consumers yet — feature lands fully in PR 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)