### PR TITLE
feat(prayers): UI for inviting opening + closing prayer-givers

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -203,6 +203,15 @@ service cloud.firestore {
           allow create, update, delete: if isActiveMember(wardId);
         }
 
+        // Prayer-giver participants. One doc per role
+        // (`opening` | `benediction`). Same trust boundary as
+        // speakers — any active bishopric/clerk member can read +
+        // mutate; non-members locked out.
+        match /prayers/{role} {
+          allow read: if isActiveMember(wardId);
+          allow create, update, delete: if isActiveMember(wardId);
+        }
+
         // Comments: any active member reads + creates (with authorUid tied
         // to the caller). Authors own their edits/soft-deletes; no one else
         // can mutate. authorUid on create MUST match request.auth.uid so a

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -10,6 +10,7 @@ import { Login } from "./routes/login";
 import { NotificationsPage } from "./routes/notifications";
 import { PlanSpeakersRoute } from "./routes/plan-speakers";
 import { PrepareInvitationPage } from "./routes/prepare-invitation";
+import { PreparePrayerInvitationPage } from "./routes/prepare-prayer-invitation";
 import { ProfilePage } from "./routes/profile";
 import { TemplatesPage } from "./routes/templates";
 import { ProgramTemplatesPage } from "./routes/templates-programs";
@@ -57,6 +58,10 @@ export const router = createBrowserRouter([
       {
         path: "/week/:date/speaker/:speakerId/prepare",
         element: <PrepareInvitationPage />,
+      },
+      {
+        path: "/week/:date/prayer/:role/prepare",
+        element: <PreparePrayerInvitationPage />,
       },
       { path: "/plan/:date", element: <PlanSpeakersRoute /> },
     ],

--- a/src/app/routes/PreparePrayerInvitationHeader.tsx
+++ b/src/app/routes/PreparePrayerInvitationHeader.tsx
@@ -1,0 +1,76 @@
+import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
+import type { PrayerRole } from "@/lib/types";
+import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitationActionBar";
+
+interface Props {
+  role: PrayerRole;
+  speakerName: string; // prayer-giver's name; reused naming for action-bar reuse
+  speakerEmail: string;
+  speakerPhone: string;
+  email: string;
+  hasEmail: boolean;
+  busy: boolean;
+  canSend: boolean;
+  canSendReason: string | null;
+  canSms: boolean;
+  canSmsReason: string | null;
+  hasOverride: boolean;
+  onCancel: () => void;
+  onRevert: () => void;
+  onMarkInvited: () => void;
+  onPrint: () => void;
+  onSend: (email: string) => void;
+  onSendSms: (phone: string) => void;
+}
+
+const ROLE_LABEL: Record<PrayerRole, string> = {
+  opening: "Opening prayer",
+  benediction: "Benediction",
+};
+
+export function PreparePrayerInvitationHeader(props: Props) {
+  return (
+    <header className="sticky top-0 z-20 shrink-0 flex flex-col gap-3 border-b border-border bg-chalk px-4 sm:px-8 pt-4 sm:pt-5 pb-3 sm:pb-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+            Prepare invitation · {ROLE_LABEL[props.role]}
+          </div>
+          <h1 className="font-display text-[20px] sm:text-[22px] font-semibold text-walnut leading-tight truncate">
+            {props.speakerName}
+          </h1>
+          <p className="font-serif italic text-[12.5px] text-walnut-3 truncate">
+            {props.hasEmail ? `Will be emailed to ${props.email}.` : "No email on file."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          aria-label="Cancel and close tab"
+          title="Cancel"
+          className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
+        >
+          <RemoveIcon />
+        </button>
+      </div>
+      <div className="lg:hidden flex justify-center">
+        <PrepareInvitationActionBar
+          busy={props.busy}
+          canSend={props.canSend}
+          canSendReason={props.canSendReason}
+          canSms={props.canSms}
+          canSmsReason={props.canSmsReason}
+          hasOverride={props.hasOverride}
+          speakerName={props.speakerName}
+          speakerEmail={props.speakerEmail}
+          speakerPhone={props.speakerPhone}
+          onRevert={props.onRevert}
+          onMarkInvited={props.onMarkInvited}
+          onPrint={props.onPrint}
+          onSend={props.onSend}
+          onSendSms={props.onSendSms}
+        />
+      </div>
+    </header>
+  );
+}

--- a/src/app/routes/invite-speaker-cta-banner.tsx
+++ b/src/app/routes/invite-speaker-cta-banner.tsx
@@ -2,6 +2,9 @@ export type CtaVariant = "reply" | "unread";
 
 interface Props {
   variant: CtaVariant;
+  /** Discriminator from the invitation doc — adjusts the "speaking
+   *  invitation" copy to "prayer invitation" for prayer-givers. */
+  kind?: "speaker" | "prayer";
   onTap: () => void;
 }
 
@@ -9,8 +12,9 @@ interface Props {
  *  chat drawer. Shown only while the drawer is closed and something
  *  demands attention (no response yet, or an unread bishop message).
  *  Taps anywhere on the banner open the drawer. */
-export function SpeakerChatCTABanner({ variant, onTap }: Props): React.ReactElement {
-  const copy = variant === "reply" ? REPLY_COPY : UNREAD_COPY;
+export function SpeakerChatCTABanner({ variant, kind, onTap }: Props): React.ReactElement {
+  const copy =
+    variant === "reply" ? (kind === "prayer" ? REPLY_COPY_PRAYER : REPLY_COPY) : UNREAD_COPY;
   return (
     <button
       type="button"
@@ -42,6 +46,12 @@ const REPLY_COPY = {
   body: "Please reply to the speaking invitation",
   action: "Reply now",
   aria: "Please reply to the speaking invitation — tap to open the chat",
+};
+
+const REPLY_COPY_PRAYER = {
+  body: "Please reply to the prayer invitation",
+  action: "Reply now",
+  aria: "Please reply to the prayer invitation — tap to open the chat",
 };
 
 const UNREAD_COPY = {

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -105,7 +105,11 @@ function InviteLandingContent({
       </div>
 
       {promptVariant && (
-        <SpeakerChatCTABanner variant={promptVariant} onTap={() => setChatOpen(true)} />
+        <SpeakerChatCTABanner
+          variant={promptVariant}
+          kind={invitation.kind}
+          onTap={() => setChatOpen(true)}
+        />
       )}
 
       <div
@@ -133,6 +137,7 @@ function InviteLandingContent({
               meetingDate={invitation.speakerRef.meetingDate}
               responseAnswer={invitation.response?.answer ?? null}
               currentStatus={invitation.currentSpeakerStatus ?? null}
+              {...(invitation.kind ? { kind: invitation.kind } : {})}
               onClose={() => setChatOpen(false)}
               fillHeight
             />

--- a/src/app/routes/prepare-prayer-invitation.tsx
+++ b/src/app/routes/prepare-prayer-invitation.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { useParams } from "react-router";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useMeeting } from "@/hooks/useMeeting";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { useSpeakerLetterTemplate } from "@/features/templates/useSpeakerLetterTemplate";
+import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
+import { formatAssignedDate, formatToday } from "@/features/templates/letterDates";
+import { isPlausiblePhone } from "@/features/templates/smsInvitation";
+import { isValidEmail } from "@/lib/email";
+import { type PrayerRole, prayerRoleSchema } from "@/lib/types";
+import { useAuthStore } from "@/stores/authStore";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { usePrayerParticipant } from "@/features/prayers/usePrayerParticipant";
+import { usePreparePrayerInvitation } from "@/features/prayers/usePreparePrayerInvitation";
+import { usePreparePrayerActions } from "@/features/prayers/usePreparePrayerActions";
+import { PreparePrayerInvitationHeader } from "./PreparePrayerInvitationHeader";
+import { PrepareInvitationPageMessage } from "./PrepareInvitationPageMessage";
+
+export function PreparePrayerInvitationPage() {
+  const { date, role: roleParam } = useParams<{ date: string; role: string }>();
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const me = useCurrentMember();
+  const authUser = useAuthStore((s) => s.user);
+  const ward = useWardSettings();
+  const { data: letterTemplate } = useSpeakerLetterTemplate();
+  const meeting = useMeeting(date ?? null);
+  const roleParseResult = roleParam ? prayerRoleSchema.safeParse(roleParam) : null;
+  const role: PrayerRole | null = roleParseResult?.success ? roleParseResult.data : null;
+  const participant = usePrayerParticipant(date ?? null, role ?? "opening");
+  const [done, setDone] = useState(false);
+
+  const inviterName =
+    me?.data.displayName ?? authUser?.displayName ?? authUser?.email ?? "The bishopric";
+  const wardName = ward.data?.name ?? "";
+
+  // Resolve the prayer-giver's name + contact: prefer the structured
+  // participant doc (set once invited / overridden), fall back to the
+  // lightweight `meeting.{role}.person` Assignment row the bishop
+  // typed inline. Email + phone live only on the participant doc.
+  const inlineAssignment =
+    role === "opening" ? meeting.data?.openingPrayer : meeting.data?.benediction;
+  const prayerGiverName = participant.data?.name ?? inlineAssignment?.person?.name ?? "";
+  const prayerGiverEmail = participant.data?.email ?? "";
+  const prayerGiverPhone = participant.data?.phone ?? "";
+
+  const form = usePreparePrayerInvitation({
+    wardId: wardId ?? "",
+    date: date ?? "",
+    role: role ?? "opening",
+    open: Boolean(wardId && date && role),
+    letterTemplate,
+  });
+
+  const vars = useMemo(
+    () => ({
+      speakerName: prayerGiverName,
+      prayerGiverName,
+      prayerType: role === "opening" ? "opening prayer" : "benediction",
+      date: date ? formatAssignedDate(date) : "",
+      today: formatToday(),
+      wardName,
+      inviterName,
+    }),
+    [prayerGiverName, role, date, wardName, inviterName],
+  );
+
+  const actions = usePreparePrayerActions({
+    wardId: wardId ?? "",
+    date: date ?? "",
+    role: role ?? "opening",
+    prayerGiverName,
+    prayerGiverEmail,
+    prayerGiverPhone,
+    inviterName,
+    form,
+    onDone: () => setDone(true),
+  });
+
+  if (!wardId || !date || !role) {
+    return (
+      <PrepareInvitationPageMessage
+        title="Missing invitation context"
+        body="Return to the schedule."
+      />
+    );
+  }
+  if (!prayerGiverName) {
+    return (
+      <PrepareInvitationPageMessage
+        title="No name set"
+        body="Add a name in the meeting's Prayers section before sending an invitation."
+      />
+    );
+  }
+  if (done) {
+    return (
+      <PrepareInvitationPageMessage
+        title="Invitation sent"
+        body="The prayer-giver has been notified. This tab will close on its own."
+        close
+      />
+    );
+  }
+
+  const hasEmail = isValidEmail(prayerGiverEmail);
+  const hasPhone = isPlausiblePhone(prayerGiverPhone);
+  const canSend = hasEmail;
+  const canSms = hasPhone;
+  const canSendReason = hasEmail ? "" : "Add an email address.";
+  const canSmsReason = hasPhone ? "" : "Add a phone number.";
+
+  const toolbarProps = {
+    busy: form.busy,
+    canSend,
+    canSendReason,
+    canSms,
+    canSmsReason,
+    hasOverride: form.letterHasOverride,
+    speakerName: prayerGiverName,
+    speakerEmail: prayerGiverEmail,
+    speakerPhone: prayerGiverPhone,
+    onRevert: () => void form.clearLetterOverride(),
+    onMarkInvited: actions.markInvited,
+    onPrint: () => window.print(),
+    onSend: actions.send,
+    onSendSms: actions.sendSms,
+  };
+
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PreparePrayerInvitationHeader
+        role={role}
+        email={prayerGiverEmail}
+        hasEmail={hasEmail}
+        onCancel={() => window.close()}
+        {...toolbarProps}
+      />
+      <div className="flex-1 min-h-0 lg:overflow-hidden px-5 sm:px-8 pt-5 pb-4">
+        {form.hydrated ? (
+          <PrepareInvitationLetterTab
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            liveStateJson={form.letterStateJson}
+            body={form.letterBody}
+            footer={form.letterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
+            vars={vars}
+          />
+        ) : (
+          <p className="font-serif italic text-[14px] text-walnut-3">Loading letter…</p>
+        )}
+        {form.error && <p className="mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>}
+      </div>
+    </main>
+  );
+}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -53,6 +53,9 @@ interface Props {
    *  floating drawer on the invite page). Default layout stays inline
    *  for other callsites. */
   fillHeight?: boolean;
+  /** Discriminator from the invitation doc — adjusts the response
+   *  banner copy from "speaking" to "prayer" wording. */
+  kind?: "speaker" | "prayer";
 }
 
 /** Speaker-side chat pane. By the time this renders the parent
@@ -155,6 +158,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         answer={props.responseAnswer}
         meetingDate={props.meetingDate}
         {...(props.currentStatus !== undefined ? { currentStatus: props.currentStatus } : {})}
+        {...(props.kind ? { kind: props.kind } : {})}
       />
 
       <ConversationThread

--- a/src/features/invitations/SpeakerResponseBanner.tsx
+++ b/src/features/invitations/SpeakerResponseBanner.tsx
@@ -14,6 +14,9 @@ interface Props {
    *  Substituted into the subtitle copy instead of the ambiguous
    *  "this Sunday" so the date is unambiguous. */
   meetingDate: string;
+  /** Discriminator from the invitation doc — adjusts "speaking" copy
+   *  to "prayer" copy when the participant is a prayer-giver. */
+  kind?: "speaker" | "prayer";
 }
 
 /** Speaker-side confirmation banner rendered under the conversation
@@ -34,8 +37,14 @@ export function SpeakerResponseBanner({
   answer,
   currentStatus,
   meetingDate,
+  kind,
 }: Props): React.ReactElement | null {
   const when = formatShortSunday(meetingDate);
+  const isPrayer = kind === "prayer";
+  const inviteLabel = isPrayer ? "prayer invitation" : "invitation to speak";
+  const declinedSubtitle = isPrayer
+    ? `You are no longer asked to give the prayer on ${when}. See the chat below for any follow-up.`
+    : `You are no longer scheduled to speak on ${when}. See the chat below for any follow-up.`;
   if (currentStatus === "confirmed") {
     return (
       <Banner
@@ -50,7 +59,7 @@ export function SpeakerResponseBanner({
       <Banner
         tone="danger"
         title="Your assignment has been updated to declined."
-        subtitle={`You are no longer scheduled to speak on ${when}. See the chat below for any follow-up.`}
+        subtitle={declinedSubtitle}
       />
     );
   }
@@ -58,7 +67,7 @@ export function SpeakerResponseBanner({
     return (
       <Banner
         tone="success"
-        title={`You accepted the invitation to speak on ${when}. Thank you!`}
+        title={`You accepted the ${inviteLabel} on ${when}. Thank you!`}
         subtitle="The bishopric will follow up with any remaining details in the chat below."
       />
     );
@@ -67,7 +76,7 @@ export function SpeakerResponseBanner({
     return (
       <Banner
         tone="danger"
-        title={`You declined the invitation to speak on ${when}.`}
+        title={`You declined the ${inviteLabel} on ${when}.`}
         subtitle="The bishopric has been notified and will respond in the chat below if needed."
       />
     );

--- a/src/features/invitations/invitationsCallable.ts
+++ b/src/features/invitations/invitationsCallable.ts
@@ -4,11 +4,19 @@ import { functions, inviteFunctions } from "@/lib/firebase";
 export interface FreshInvitationRequest {
   mode?: "fresh";
   wardId: string;
+  /** Speaker doc ID, OR the prayer role string ("opening" |
+   *  "benediction") when `kind === "prayer"`. The Cloud Function
+   *  treats this as the participant's identifier within its
+   *  collection. */
   speakerId: string;
   meetingDate: string;
   channels: ("email" | "sms")[];
   speakerName: string;
   speakerTopic?: string;
+  /** Discriminator. Default "speaker" preserves back-compat. */
+  kind?: "speaker" | "prayer";
+  /** Required when `kind === "prayer"`. */
+  prayerRole?: "opening" | "benediction";
   inviterName: string;
   wardName: string;
   assignedDate: string;

--- a/src/features/meetings/program/AssignRow.tsx
+++ b/src/features/meetings/program/AssignRow.tsx
@@ -40,7 +40,7 @@ export function AssignRow({ label, placeholder, assignment, showStatus = true, o
       : "unconfirmed";
 
   return (
-    <div className="grid grid-cols-[86px_minmax(0,1fr)_30px] items-center gap-3 py-2 border-b border-dashed border-border last:border-b-0">
+    <div className="grid grid-cols-[86px_minmax(0,1fr)_30px] items-center gap-3 py-2 border-b border-dashed border-border last:border-b-0 lg:border-b-0">
       <div className="text-[13.5px] font-sans font-medium text-walnut-2">{label}</div>
       <input
         value={local}

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -60,9 +60,11 @@ function PrayerRowGroup({ label, role, date, placeholder, assignment, onChange }
     // Suppress AssignRow's own dashed bottom border when we're
     // grouping it with the Invite link — its `last:border-b-0`
     // doesn't trigger because the link is now a sibling. The dashed
-    // separator role passes to this wrapper so consecutive prayer
-    // groups stay visually divided.
-    <div className="border-b border-dashed border-border last:border-b-0 *:first:border-b-0">
+    // separator role passes to this wrapper for the stacked
+    // (mobile / tablet) layout; on `lg:` the rows sit side by side
+    // in a 2-col grid so a horizontal separator below each row reads
+    // as noise — drop it.
+    <div className="border-b border-dashed border-border last:border-b-0 lg:border-b-0 *:first:border-b-0">
       <AssignRow
         label={label}
         placeholder={placeholder}

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -57,7 +57,12 @@ function PrayerRowGroup({ label, role, date, placeholder, assignment, onChange }
   const hasName = Boolean(assignment?.person?.name?.trim() || participant.data?.name?.trim());
 
   return (
-    <div>
+    // Suppress AssignRow's own dashed bottom border when we're
+    // grouping it with the Invite link — its `last:border-b-0`
+    // doesn't trigger because the link is now a sibling. The dashed
+    // separator role passes to this wrapper so consecutive prayer
+    // groups stay visually divided.
+    <div className="border-b border-dashed border-border last:border-b-0 *:first:border-b-0">
       <AssignRow
         label={label}
         placeholder={placeholder}

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -1,4 +1,7 @@
-import type { Assignment, NonMeetingSunday, SacramentMeeting } from "@/lib/types";
+import { Link } from "react-router";
+import type { Assignment, NonMeetingSunday, PrayerRole, SacramentMeeting } from "@/lib/types";
+import { SpeakerStatusChip } from "@/features/plan-speakers/SpeakerStatusChip";
+import { usePrayerParticipant } from "@/features/prayers/usePrayerParticipant";
 import { AssignRow } from "../program/AssignRow";
 import { ProgramSection } from "../program/ProgramSection";
 import { updateMeetingField } from "../updateMeeting";
@@ -18,19 +21,62 @@ export function PrayersSection({ wardId, date, meeting, nonMeetingSundays }: Pro
   return (
     <ProgramSection id="sec-prayers" label="Prayers">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-7 gap-y-1">
-        <AssignRow
+        <PrayerRowGroup
           label="Opening"
+          role="opening"
+          date={date}
           placeholder="Who will give the opening prayer?"
           assignment={meeting?.openingPrayer}
           onChange={(a) => void set("openingPrayer", a)}
         />
-        <AssignRow
+        <PrayerRowGroup
           label="Benediction"
+          role="benediction"
+          date={date}
           placeholder="Who will give the benediction?"
           assignment={meeting?.benediction}
           onChange={(a) => void set("benediction", a)}
         />
       </div>
     </ProgramSection>
+  );
+}
+
+interface RowGroupProps {
+  label: string;
+  role: PrayerRole;
+  date: string;
+  placeholder: string;
+  assignment: Assignment | undefined;
+  onChange: (a: Assignment) => void;
+}
+
+function PrayerRowGroup({ label, role, date, placeholder, assignment, onChange }: RowGroupProps) {
+  const participant = usePrayerParticipant(date, role);
+  const status = participant.data?.status ?? null;
+  const hasName = Boolean(assignment?.person?.name?.trim() || participant.data?.name?.trim());
+
+  return (
+    <div>
+      <AssignRow
+        label={label}
+        placeholder={placeholder}
+        assignment={assignment}
+        onChange={onChange}
+      />
+      {hasName && (
+        <div className="flex items-center justify-end gap-2 pl-24.5 pr-10.5 -mt-1 mb-2">
+          {status && status !== "planned" && <SpeakerStatusChip status={status} />}
+          <Link
+            to={`/week/${date}/prayer/${role}/prepare`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-bordeaux hover:text-bordeaux-deep underline-offset-2 hover:underline"
+          >
+            {status === "invited" || status === "confirmed" ? "Resend" : "Invite"} →
+          </Link>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/features/prayers/prayerActions.ts
+++ b/src/features/prayers/prayerActions.ts
@@ -1,0 +1,41 @@
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { InvitationStatus, PrayerRole } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+interface PrayerUpsertPatch {
+  name?: string;
+  email?: string;
+  phone?: string;
+  status?: InvitationStatus;
+}
+
+/** Upsert the prayer participant doc at
+ *  `wards/{wardId}/meetings/{date}/prayers/{role}`. Uses
+ *  `setDoc(..., { merge: true })` so the bishop's first action on a
+ *  prayer (Send / Mark invited) creates the doc lazily — the
+ *  lightweight inline `meeting.openingPrayer` Assignment row is the
+ *  source of truth until then. */
+export async function upsertPrayerParticipant(
+  wardId: string,
+  date: string,
+  role: PrayerRole,
+  patch: PrayerUpsertPatch,
+): Promise<void> {
+  reportSaving();
+  try {
+    await setDoc(
+      doc(db, "wards", wardId, "meetings", date, "prayers", role),
+      {
+        role,
+        ...patch,
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/prayers/prayerLetterOverride.ts
+++ b/src/features/prayers/prayerLetterOverride.ts
@@ -1,0 +1,71 @@
+import { deleteField, doc, serverTimestamp, setDoc, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { PrayerRole } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
+
+function prayerRef(wardId: string, date: string, role: PrayerRole) {
+  return doc(db, "wards", wardId, "meetings", date, "prayers", role);
+}
+
+export interface PrayerOverrideInput {
+  /** Lexical EditorState JSON — the new source of truth. Required so
+   *  the writer can derive legacy markdown fields. */
+  editorStateJson: string;
+}
+
+/** Write a per-prayer override of the ward invitation letter
+ *  template. Mirrors the speaker-side override writer but targets
+ *  the prayer participant doc at
+ *  `wards/{wardId}/meetings/{date}/prayers/{role}`. Uses `setDoc(...,
+ *  { merge: true })` so the doc gets created if the bishop is
+ *  authoring an override before the participant has otherwise been
+ *  promoted out of the lightweight inline `Assignment` row. */
+export async function savePrayerLetterOverride(
+  wardId: string,
+  date: string,
+  role: PrayerRole,
+  input: PrayerOverrideInput,
+): Promise<void> {
+  reportSaving();
+  try {
+    const state = JSON.parse(input.editorStateJson);
+    const { bodyMarkdown, footerMarkdown } = legacyFieldsFromState(state);
+    await setDoc(
+      prayerRef(wardId, date, role),
+      {
+        role,
+        letterOverride: {
+          editorStateJson: input.editorStateJson,
+          bodyMarkdown,
+          footerMarkdown,
+          updatedAt: serverTimestamp(),
+        },
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+export async function clearPrayerLetterOverride(
+  wardId: string,
+  date: string,
+  role: PrayerRole,
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(prayerRef(wardId, date, role), {
+      letterOverride: deleteField(),
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/prayers/sendPrayerInvitation.ts
+++ b/src/features/prayers/sendPrayerInvitation.ts
@@ -1,0 +1,99 @@
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { type PrayerRole, wardSchema } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import { useDevModeStore } from "@/stores/devModeStore";
+import {
+  callSendSpeakerInvitation,
+  type FreshInvitationResponse,
+} from "@/features/invitations/invitationsCallable";
+import { resolveChipsInState } from "@/features/page-editor/serializeForInterpolation";
+import { interpolate } from "@/features/templates/interpolate";
+import { formatAssignedDate, formatToday } from "@/features/templates/letterDates";
+
+export interface SendPrayerInvitationInput {
+  wardId: string;
+  meetingDate: string;
+  role: PrayerRole;
+  prayerGiverName: string;
+  prayerGiverEmail: string;
+  prayerGiverPhone: string;
+  inviterName: string;
+  bishopReplyToEmail: string;
+  bodyMarkdown: string;
+  footerMarkdown: string;
+  editorStateJson?: string | undefined;
+  channels: ("email" | "sms")[];
+}
+
+/** Client wrapper that calls the unified `sendSpeakerInvitation`
+ *  Cloud Function with `kind: "prayer"`. The function name still
+ *  reads "speaker" — see the follow-up rename issue — but it routes
+ *  prayer-keyed copy + persists `prayerRole` on the invitation. */
+export async function sendPrayerInvitation(
+  input: SendPrayerInvitationInput,
+): Promise<FreshInvitationResponse> {
+  reportSaving();
+  try {
+    const wardSnap = await getDoc(doc(db, "wards", input.wardId));
+    const wardName = wardSnap.exists() ? wardSchema.parse(wardSnap.data()).name : "";
+
+    const vars = {
+      speakerName: input.prayerGiverName,
+      prayerGiverName: input.prayerGiverName,
+      prayerType: input.role === "opening" ? "opening prayer" : "benediction",
+      date: formatAssignedDate(input.meetingDate),
+      today: formatToday(),
+      wardName,
+      inviterName: input.inviterName,
+    };
+
+    const bodyMarkdown = interpolate(input.bodyMarkdown, vars);
+    const footerMarkdown = interpolate(input.footerMarkdown, vars);
+    const editorStateJson = input.editorStateJson
+      ? resolveChipsInState(interpolate(input.editorStateJson, vars), vars)
+      : undefined;
+    const expiresAtMillis = computeExpiresAt(input.meetingDate);
+
+    const useTestingNumber = useDevModeStore.getState().useTestingNumber;
+    const res = await callSendSpeakerInvitation({
+      wardId: input.wardId,
+      // For prayer invitations the participant identifier is the role.
+      // The CF persists this in `speakerRef.speakerId` so existing
+      // helpers (cleanupPriorConversations, etc.) keep working.
+      speakerId: input.role,
+      meetingDate: input.meetingDate,
+      channels: input.channels,
+      kind: "prayer",
+      prayerRole: input.role,
+      speakerName: input.prayerGiverName,
+      inviterName: input.inviterName,
+      wardName,
+      assignedDate: vars.date,
+      sentOn: vars.today,
+      bodyMarkdown,
+      footerMarkdown,
+      ...(editorStateJson ? { editorStateJson } : {}),
+      ...(input.prayerGiverEmail.trim() ? { speakerEmail: input.prayerGiverEmail.trim() } : {}),
+      ...(input.prayerGiverPhone.trim() ? { speakerPhone: input.prayerGiverPhone.trim() } : {}),
+      bishopReplyToEmail: input.bishopReplyToEmail,
+      expiresAtMillis,
+      ...(useTestingNumber ? { useTestingNumber: true } : {}),
+    });
+    reportSaved();
+    return res;
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+/** Monday 00:00 local to the sender after the meeting's Sunday. */
+function computeExpiresAt(meetingDate: string): number {
+  const [y, m, d] = meetingDate.split("-").map(Number);
+  if (!y || !m || !d) return Date.now();
+  const local = new Date(y, m - 1, d);
+  local.setDate(local.getDate() + 1);
+  local.setHours(0, 0, 0, 0);
+  return local.getTime();
+}

--- a/src/features/prayers/usePrayerParticipant.ts
+++ b/src/features/prayers/usePrayerParticipant.ts
@@ -1,0 +1,17 @@
+import { type PrayerRole, prayerParticipantSchema } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { useDocSnapshot } from "@/hooks/_sub";
+
+/** Live subscription to a single prayer-participant doc.
+ *  Path: `wards/{wardId}/meetings/{date}/prayers/{role}`. The doc
+ *  only exists once the bishop has explicitly invited (or saved an
+ *  override); the lightweight inline `meeting.openingPrayer` /
+ *  `meeting.benediction` Assignment row stays the source of truth
+ *  until then. */
+export function usePrayerParticipant(date: string | null, role: PrayerRole) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  return useDocSnapshot(
+    ["wards", wardId, "meetings", date ?? undefined, "prayers", role],
+    prayerParticipantSchema,
+  );
+}

--- a/src/features/prayers/usePreparePrayerActions.ts
+++ b/src/features/prayers/usePreparePrayerActions.ts
@@ -1,0 +1,121 @@
+import type { PrayerRole } from "@/lib/types";
+import type { DeliveryEntry } from "@/features/invitations/invitationsCallable";
+import { useAuthStore } from "@/stores/authStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { upsertPrayerParticipant } from "./prayerActions";
+import { sendPrayerInvitation } from "./sendPrayerInvitation";
+
+function assertChannelsDelivered(
+  deliveryRecord: readonly DeliveryEntry[],
+  requested: readonly ("email" | "sms")[],
+): void {
+  const failed = deliveryRecord.filter(
+    (e) => requested.includes(e.channel) && e.status === "failed",
+  );
+  if (failed.length === 0) return;
+  const messages = failed.map((e) => {
+    const label = e.channel === "email" ? "Email" : "SMS";
+    return e.error ? `${label}: ${e.error}` : `${label} delivery failed.`;
+  });
+  throw new Error(messages.join(" · "));
+}
+
+interface FormState {
+  letterBody: string;
+  letterFooter: string;
+  letterStateJson: string | null;
+  persistOverrides: () => Promise<void>;
+  setBusy: (b: boolean) => void;
+  setError: (e: string | null) => void;
+}
+
+interface Args {
+  wardId: string;
+  date: string;
+  role: PrayerRole;
+  prayerGiverName: string;
+  prayerGiverEmail: string;
+  prayerGiverPhone: string;
+  inviterName: string;
+  form: FormState;
+  onDone: () => void;
+}
+
+/** Mirror of `usePrepareInvitationActions` for prayer-givers. Wraps
+ *  Mark invited / Send (email) / Send SMS with override persistence
+ *  + busy/error bookkeeping. Send routes through
+ *  `sendPrayerInvitation` (which calls the unified CF with
+ *  `kind: "prayer"`), then upserts the prayer participant doc with
+ *  `status: "invited"`. */
+export function usePreparePrayerActions(args: Args) {
+  const { form } = args;
+  const bishopEmail = useAuthStore((s) => s.user?.email ?? "");
+
+  async function runAction(fn: () => Promise<void> | void) {
+    form.setBusy(true);
+    form.setError(null);
+    try {
+      await form.persistOverrides();
+      await fn();
+      args.onDone();
+    } catch (e) {
+      form.setError(friendlyWriteError(e));
+    } finally {
+      form.setBusy(false);
+    }
+  }
+
+  async function sendVia(
+    channels: ("email" | "sms")[],
+    contactOverride?: { email?: string; phone?: string },
+  ): Promise<void> {
+    const resolvedEmail = (contactOverride?.email ?? args.prayerGiverEmail).trim();
+    const resolvedPhone = (contactOverride?.phone ?? args.prayerGiverPhone).trim();
+    const patch: { email?: string; phone?: string } = {};
+    if (contactOverride?.email && resolvedEmail !== args.prayerGiverEmail.trim()) {
+      patch.email = resolvedEmail;
+    }
+    if (contactOverride?.phone && resolvedPhone !== args.prayerGiverPhone.trim()) {
+      patch.phone = resolvedPhone;
+    }
+    if (patch.email || patch.phone) {
+      await upsertPrayerParticipant(args.wardId, args.date, args.role, {
+        name: args.prayerGiverName,
+        ...patch,
+      });
+    }
+    const res = await sendPrayerInvitation({
+      wardId: args.wardId,
+      meetingDate: args.date,
+      role: args.role,
+      prayerGiverName: args.prayerGiverName,
+      prayerGiverEmail: resolvedEmail,
+      prayerGiverPhone: resolvedPhone,
+      inviterName: args.inviterName,
+      bishopReplyToEmail: bishopEmail,
+      bodyMarkdown: form.letterBody,
+      footerMarkdown: form.letterFooter,
+      ...(form.letterStateJson ? { editorStateJson: form.letterStateJson } : {}),
+      channels,
+    });
+    assertChannelsDelivered(res.deliveryRecord, channels);
+    await upsertPrayerParticipant(args.wardId, args.date, args.role, {
+      name: args.prayerGiverName,
+      status: "invited",
+    });
+  }
+
+  return {
+    markInvited: () =>
+      void runAction(() =>
+        upsertPrayerParticipant(args.wardId, args.date, args.role, {
+          name: args.prayerGiverName,
+          status: "invited",
+        }),
+      ),
+    send: (email?: string) =>
+      void runAction(() => sendVia(["email"], email ? { email } : undefined)),
+    sendSms: (phone?: string) =>
+      void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
+  };
+}

--- a/src/features/prayers/usePreparePrayerInvitation.ts
+++ b/src/features/prayers/usePreparePrayerInvitation.ts
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { type PrayerRole, type SpeakerLetterTemplate, prayerParticipantSchema } from "@/lib/types";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
+import {
+  DEFAULT_SPEAKER_LETTER_BODY,
+  DEFAULT_SPEAKER_LETTER_FOOTER,
+} from "@/features/templates/speakerLetterDefaults";
+import { clearPrayerLetterOverride, savePrayerLetterOverride } from "./prayerLetterOverride";
+
+interface Args {
+  wardId: string;
+  date: string;
+  role: PrayerRole;
+  open: boolean;
+  /** Reused from the speaker letter template for now — the dedicated
+   *  `prayerLetterTemplate` editor route lands in a follow-up PR.
+   *  Until then, the bishop's per-prayer override + the ward speaker
+   *  template feed the prayer prepare-invitation page. */
+  letterTemplate: SpeakerLetterTemplate | null;
+}
+
+interface InitialMarkdown {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+}
+
+/** Hydration + persistence helpers for the per-prayer letter
+ *  override. Mirrors `usePrepareInvitation` but reads / writes the
+ *  prayer participant doc at
+ *  `wards/{wardId}/meetings/{date}/prayers/{role}`. */
+export function usePreparePrayerInvitation(args: Args) {
+  const { wardId, date, role, open, letterTemplate } = args;
+  const [initialJson, setInitialJson] = useState<string | null>(null);
+  const [initialMarkdown, setInitialMarkdown] = useState<InitialMarkdown>({
+    bodyMarkdown: DEFAULT_SPEAKER_LETTER_BODY,
+    footerMarkdown: DEFAULT_SPEAKER_LETTER_FOOTER,
+  });
+  const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
+  const [letterHasOverride, setLetterHasOverride] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setHydrated(false);
+    (async () => {
+      const snap = await getDoc(doc(db, "wards", wardId, "meetings", date, "prayers", role));
+      if (cancelled) return;
+      const parsed = snap.exists() ? prayerParticipantSchema.safeParse(snap.data()) : null;
+      const override = parsed?.success ? parsed.data.letterOverride : undefined;
+      const json = override?.editorStateJson ?? letterTemplate?.editorStateJson ?? null;
+      const md: InitialMarkdown = {
+        bodyMarkdown:
+          override?.bodyMarkdown ?? letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+        footerMarkdown:
+          override?.footerMarkdown ??
+          letterTemplate?.footerMarkdown ??
+          DEFAULT_SPEAKER_LETTER_FOOTER,
+      };
+      setInitialJson(json);
+      setInitialMarkdown(md);
+      setLetterStateJson(json);
+      setLetterHasOverride(Boolean(override));
+      setError(null);
+      setHydrated(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, wardId, date, role, letterTemplate]);
+
+  const { letterBody, letterFooter } = useMemo(() => {
+    if (!letterStateJson) {
+      return {
+        letterBody: initialMarkdown.bodyMarkdown,
+        letterFooter: initialMarkdown.footerMarkdown,
+      };
+    }
+    try {
+      const state = JSON.parse(letterStateJson);
+      const fields = legacyFieldsFromState(state);
+      return { letterBody: fields.bodyMarkdown, letterFooter: fields.footerMarkdown };
+    } catch {
+      return {
+        letterBody: initialMarkdown.bodyMarkdown,
+        letterFooter: initialMarkdown.footerMarkdown,
+      };
+    }
+  }, [letterStateJson, initialMarkdown]);
+
+  function captureInitial(json: string) {
+    setLetterStateJson(json);
+    setInitialJson((prev) => prev ?? json);
+  }
+
+  async function persistOverrides() {
+    if (!letterStateJson) return;
+    await savePrayerLetterOverride(wardId, date, role, { editorStateJson: letterStateJson });
+    setLetterHasOverride(true);
+  }
+
+  function revertLetterToWardDefault() {
+    setLetterStateJson(letterTemplate?.editorStateJson ?? null);
+    setInitialJson(letterTemplate?.editorStateJson ?? null);
+    setInitialMarkdown({
+      bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+      footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+    });
+    setResetKey((k) => k + 1);
+  }
+
+  async function clearLetterOverride() {
+    setBusy(true);
+    setError(null);
+    try {
+      await clearPrayerLetterOverride(wardId, date, role);
+      revertLetterToWardDefault();
+      setLetterHasOverride(false);
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return {
+    initialJson,
+    initialMarkdown,
+    letterStateJson,
+    setLetterStateJson,
+    captureInitial,
+    letterBody,
+    letterFooter,
+    letterHasOverride,
+    hydrated,
+    resetKey,
+    error,
+    busy,
+    setBusy,
+    setError,
+    persistOverrides,
+    revertLetterToWardDefault,
+    clearLetterOverride,
+  };
+}

--- a/src/features/templates/prepareInvitationVars.ts
+++ b/src/features/templates/prepareInvitationVars.ts
@@ -1,13 +1,15 @@
 /** Variable shape for PrepareInvitationDialog's letter tab. The
  *  dialog computes vars once and the letter preview interpolates them
- *  identically to what a send would produce. Defined as a `type` (not
- *  `interface`) so it's assignable to `Record<string, string>` for
- *  `interpolate()`. */
+ *  identically to what a send would produce. Required keys cover the
+ *  speaker-shaped letter chrome (date / wardName / inviterName); the
+ *  index signature lets prayer invitations layer in extra tokens
+ *  (`prayerGiverName`, `prayerType`) without a separate type. */
 export type LetterVars = {
   speakerName: string;
-  topic: string;
   date: string;
   today: string;
   wardName: string;
   inviterName: string;
+  topic?: string;
+  [key: string]: string | undefined;
 };


### PR DESCRIPTION
## Summary

End-to-end UI built on the v0.13.x backend wire (PR #169). Bishops can now invite opening + closing prayer-givers through the same flow as speakers — Twilio Conversation, capability token, accept/decline — but launched inline from the meeting editor's Prayers section instead of the plan-speakers wizard.

### Changes

- **PrayersSection** ([src/features/meetings/sections/PrayersSection.tsx](src/features/meetings/sections/PrayersSection.tsx)) — each prayer row now shows a status chip + Invite/Resend link once a name is typed. Link navigates to \`/week/:date/prayer/:role/prepare\` in a new tab.
- **Prepare-prayer-invitation page** ([src/app/routes/prepare-prayer-invitation.tsx](src/app/routes/prepare-prayer-invitation.tsx)) — full-screen letter editor with action toolbar (Send / Send SMS / Mark invited / Print). Hydrates from the prayer participant doc + speaker letter template (dedicated prayer template lands in a follow-up).
- **New prayers feature module** ([src/features/prayers/](src/features/prayers/)) — \`usePrayerParticipant\`, \`upsertPrayerParticipant\`, \`save/clearPrayerLetterOverride\`, \`sendPrayerInvitation\` client wrapper (calls the unified CF with \`kind: "prayer"\`), \`usePreparePrayerInvitation\` + \`usePreparePrayerActions\`.
- **Landing page** ([src/app/routes/invite-speaker.tsx](src/app/routes/invite-speaker.tsx)) — reads \`invitation.kind\` and threads it to the CTA + response banners. "Please reply to the speaking invitation" → "Please reply to the prayer invitation" when set.
- **Firestore rules** — new \`meetings/{date}/prayers/{role}\` subcollection block; same trust as \`speakers\`.

### Out of scope (follow-up)

- Dedicated \`prayerLetterTemplate\` ward doc + \`/settings/templates/prayer-letter\` editor route — for now both prayer slots reuse the speaker letter template
- Rules tests for the new prayers/{role} block (CI rules suite still runs the existing speakers tests, which exercise the same code path)
- Two follow-up tech-debt issues filed after this PR ships:
  - \`Speaker → Participant\` type/folder rename
  - \`sendSpeakerInvitation → sendInvitation\` Cloud Function rename

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` 0 errors (181 → 187 warnings)
- [x] \`pnpm test\` 340/340 passes
- [x] \`functions: pnpm test\` 89/89 passes
- [x] \`pnpm build\` clean
- [ ] Manual: type a name in PrayersSection → click Invite → prepare page opens → Send → status flips to invited
- [ ] Manual: prayer-giver receives SMS with prayer-shaped wording, lands on the invite page, replies, sees "prayer invitation" copy on banners

🤖 Generated with [Claude Code](https://claude.com/claude-code)