### PR TITLE
Release: v0.14.0 — prayer-giver invitations + speaker-invite UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.14.0] — 2026-04-27
+
+Prayer-giver invitations land end-to-end: the bishop can now invite
+opening + closing prayer participants through the same Twilio
+Conversation + capability-token pipeline used for speakers, with
+role-appropriate copy on every surface. Plus three speaker-invite UX
+upgrades and a small personal touch on the app shell.
+
+### Added
+
+- **Prayer-giver invitations (#168, #169, #170).** New
+  `wards/{wardId}/meetings/{date}/prayers/{role}` subcollection +
+  rules block, a `kind: "speaker" | "prayer"` discriminator on
+  `sendSpeakerInvitation` + `onInvitationWrite`, and four new
+  prayer-keyed message templates (`prayerInitialInvitationSms`,
+  `prayerResponseAccepted`, `prayerResponseDeclined`,
+  `prayerBishopricResponseReceipt`). The eight-Cloud-Function rule
+  holds — we extended the existing functions instead of adding new
+  ones. UI lands inline on the meeting editor's Prayers section: each
+  row shows a status chip + Invite/Resend link once a name is typed,
+  opening a dedicated `/week/:date/prayer/:role/prepare` page with the
+  full-screen letter editor + Send / Send SMS / Mark invited / Print
+  toolbar. The speaker landing page reads `invitation.kind` and
+  flips its CTA + response banners to "Please reply to the prayer
+  invitation" when appropriate. For now both prayer slots reuse the
+  speaker letter template; a dedicated `prayerLetterTemplate` ward
+  doc + editor route lands in a follow-up.
+- **Share-as-PDF button on the speaker invite page.** Speakers tap a
+  share icon that renders the resolved letter to a paginated 8.5×11
+  PDF and hands it to `navigator.share({ files })` (Web Share API on
+  iOS / Android / Edge / Safari) with a download fallback on Firefox
+  / older desktops. Reuses the same `letterCanvasToPdf` +
+  `shareLetterPdf` strategy as the bishop-side wizard, so the
+  speaker's saved PDF is pixel-for-pixel identical. Toolbar shifts
+  from `top-4` → `top-16` with a 200ms transition when the
+  reply/unread CTA banner is visible, avoiding overlap.
+- **Personal developer credit** on the app shell + invite pages. A
+  tiny italic-serif "This app was built with love and prayer, by
+  Oriel Absin." line sourced from a single shared component, visible
+  on every authenticated bishopric route, below the `/accept-invite`
+  card, and at the bottom of the speaker chat drawer. `print:hidden`
+  keeps it out of printed programs and shared letter PDFs.
+
+### Changed
+
+- **Speaker chat drawer is now a bottom-sheet on mobile, docked panel
+  on desktop.** On phone-class viewports the drawer slides up as an
+  85dvh sheet with rounded top corners and a grab-handle pill,
+  leaving the top of the letter peeking above so the speaker keeps
+  spatial context. Desktop (`sm+`) is unchanged: bottom-right docked
+  panel at `max-w-105` / `80dvh`, all corners rounded, no entrance
+  animation. New `drawerSlideUp` keyframe scoped to mobile via
+  `sm:animate-none`.
+
+### Fixed
+
+- **AssignRow's stray dashed bottom border on `lg+`** in the meeting
+  editor's Prayers + Speakers sections. The dashed line under the
+  Invite link, the inter-row dashed border, and AssignRow's bottom
+  border are all dropped on large viewports where they were creating
+  visual noise inside the multi-column layout.
+
 ## [0.13.1] — 2026-04-27
 
 Hotfix for the v0.13.0 PDF share path: the bishop tapping "Share or
@@ -1661,7 +1723,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.13.1...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/aylabyuk/steward/releases/tag/v0.14.0
 [0.13.1]: https://github.com/aylabyuk/steward/releases/tag/v0.13.1
 [0.13.0]: https://github.com/aylabyuk/steward/releases/tag/v0.13.0
 [0.12.2]: https://github.com/aylabyuk/steward/releases/tag/v0.12.2

--- a/firestore.rules
+++ b/firestore.rules
@@ -203,6 +203,15 @@ service cloud.firestore {
           allow create, update, delete: if isActiveMember(wardId);
         }
 
+        // Prayer-giver participants. One doc per role
+        // (`opening` | `benediction`). Same trust boundary as
+        // speakers — any active bishopric/clerk member can read +
+        // mutate; non-members locked out.
+        match /prayers/{role} {
+          allow read: if isActiveMember(wardId);
+          allow create, update, delete: if isActiveMember(wardId);
+        }
+
         // Comments: any active member reads + creates (with authorUid tied
         // to the caller). Authors own their edits/soft-deletes; no one else
         // can mutate. authorUid on create MUST match request.auth.uid so a

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -8,6 +8,7 @@ import {
   trySms,
 } from "./sendSpeakerInvitation.helpers.js";
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
+import { invitationPrayerType } from "./invitationTypes.js";
 import type { FromNumberMode } from "./twilio/fromNumber.js";
 import type {
   DeliveryEntry,
@@ -45,8 +46,13 @@ export async function createFreshInvitation(
   // include the optional contact/topic fields when the caller actually
   // provided them. Missing fields read as `undefined` downstream,
   // which is what the rest of the code already expects.
+  const isPrayer = input.kind === "prayer";
   const docRef = await db.collection(`wards/${input.wardId}/speakerInvitations`).add({
     speakerRef: { meetingDate: input.meetingDate, speakerId: input.speakerId },
+    // Persist `kind` only for non-default ("prayer") rows so the doc
+    // shape stays clean for every speaker send. Readers default
+    // missing-field to "speaker" via the Zod schema.
+    ...(isPrayer ? { kind: "prayer", prayerRole: input.prayerRole } : {}),
     assignedDate: input.assignedDate,
     sentOn: input.sentOn,
     wardName: input.wardName,
@@ -80,12 +86,17 @@ export async function createFreshInvitation(
   });
 
   const inviteUrl = buildInviteUrl(origin, input.wardId, docRef.id, plaintextToken);
+  const prayerType =
+    isPrayer && input.prayerRole
+      ? invitationPrayerType({ kind: "prayer", prayerRole: input.prayerRole })
+      : undefined;
   const emailArgs = {
     speakerName: input.speakerName,
     inviterName: input.inviterName,
     assignedDate: input.assignedDate,
     wardName: input.wardName,
     inviteUrl,
+    ...(prayerType ? { prayerType } : {}),
   };
 
   const deliveryRecord: DeliveryEntry[] = [];

--- a/functions/src/invitationDelivery.ts
+++ b/functions/src/invitationDelivery.ts
@@ -24,11 +24,14 @@ export async function tryEmail(
   args: EmailArgs,
 ): Promise<DeliveryEntry> {
   try {
+    const subject = args.prayerType
+      ? `Prayer invitation — ${params.assignedDate}`
+      : `Speaking invitation — ${params.assignedDate}`;
     const messageId = await sendEmail({
       to: params.speakerEmail,
       fromDisplayName: `${params.inviterName} (via Steward)`,
       replyTo: params.replyToEmail,
-      subject: `Speaking invitation — ${params.assignedDate}`,
+      subject,
       text: buildEmailText(args),
       html: buildEmailHtml(args),
     });
@@ -43,9 +46,12 @@ export async function tryEmail(
 
 async function buildInitialInvitationSms(
   wardId: string,
-  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl">,
+  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl"> & {
+    prayerType?: string;
+  },
 ): Promise<string> {
-  const template = await readMessageTemplate(getFirestore(), wardId, "initialInvitationSms");
+  const key = vars.prayerType ? "prayerInitialInvitationSms" : "initialInvitationSms";
+  const template = await readMessageTemplate(getFirestore(), wardId, key);
   return interpolate(template, vars);
 }
 

--- a/functions/src/invitationEmailBody.ts
+++ b/functions/src/invitationEmailBody.ts
@@ -4,13 +4,28 @@ export interface BuildEmailArgs {
   assignedDate: string;
   wardName: string;
   inviteUrl: string;
+  /** Set for prayer invitations — e.g. "opening prayer" or
+   *  "benediction". When present the body wording switches from
+   *  "speak on …" to "give the {prayerType} on …". */
+  prayerType?: string;
+}
+
+function inviteAction(a: BuildEmailArgs): string {
+  return a.prayerType
+    ? `give the ${a.prayerType} on ${a.assignedDate}`
+    : `speak on ${a.assignedDate}`;
+}
+
+function inviteActionHtml(a: BuildEmailArgs): string {
+  const date = `<strong>${escapeHtml(a.assignedDate)}</strong>`;
+  return a.prayerType ? `give the ${escapeHtml(a.prayerType)} on ${date}` : `speak on ${date}`;
 }
 
 export function buildEmailText(a: BuildEmailArgs): string {
   return [
     `Dear ${a.speakerName},`,
     "",
-    `${a.inviterName} has invited you to speak on ${a.assignedDate}.`,
+    `${a.inviterName} has invited you to ${inviteAction(a)}.`,
     "",
     `Read the full invitation here:`,
     a.inviteUrl,
@@ -21,7 +36,7 @@ export function buildEmailText(a: BuildEmailArgs): string {
 
 export function buildEmailHtml(a: BuildEmailArgs): string {
   return `<p>Dear ${escapeHtml(a.speakerName)},</p>
-<p>${escapeHtml(a.inviterName)} has invited you to speak on <strong>${escapeHtml(a.assignedDate)}</strong>.</p>
+<p>${escapeHtml(a.inviterName)} has invited you to ${inviteActionHtml(a)}.</p>
 <p><a href="${a.inviteUrl}">Read the full invitation</a>.</p>
 <p style="color:#666;font-size:12px;">— ${escapeHtml(a.wardName)}</p>`;
 }

--- a/functions/src/invitationReceiptContent.ts
+++ b/functions/src/invitationReceiptContent.ts
@@ -1,5 +1,5 @@
 import { interpolate } from "./messageTemplates.js";
-import type { SpeakerInvitationShape } from "./invitationTypes.js";
+import { invitationPrayerType, type SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ReceiptBuildArgs {
   invitation: SpeakerInvitationShape;
@@ -63,12 +63,16 @@ export function buildSpeakerReceipt(args: ReceiptBuildArgs): ReceiptContent {
   const answer = invitation.response?.answer;
   if (!answer) throw new Error("speaker receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
+  const prayerType = invitationPrayerType(invitation);
 
-  const subject = `You ${verb} the speaking invitation — ${invitation.assignedDate}`;
+  const subject = prayerType
+    ? `You ${verb} the prayer invitation — ${invitation.assignedDate}`
+    : `You ${verb} the speaking invitation — ${invitation.assignedDate}`;
   const headerText = interpolate(headerTemplate, {
     speakerName: invitation.speakerName,
     assignedDate: invitation.assignedDate,
     reason: invitation.response?.reason ?? "",
+    ...(prayerType ? { prayerType } : {}),
   });
   const text = [
     headerText,
@@ -109,11 +113,15 @@ export function buildBishopricReceipt(args: ReceiptBuildArgs): ReceiptContent {
   if (!answer) throw new Error("bishopric receipt requires a recorded response");
   const verb = answer === "yes" ? "accepted" : "declined";
 
-  const subject = `${invitation.speakerName} ${verb} the speaking invitation — ${invitation.assignedDate}`;
+  const prayerType = invitationPrayerType(invitation);
+  const subject = prayerType
+    ? `${invitation.speakerName} ${verb} the prayer invitation — ${invitation.assignedDate}`
+    : `${invitation.speakerName} ${verb} the speaking invitation — ${invitation.assignedDate}`;
   const responseLine = interpolate(headerTemplate, {
     speakerName: invitation.speakerName,
     verb,
     assignedDate: invitation.assignedDate,
+    ...(prayerType ? { prayerType } : {}),
   });
   const metaLines: string[] = [];
   if (respondedAt) metaLines.push(`Responded: ${respondedAt.toLocaleString()}`);

--- a/functions/src/invitationTypes.ts
+++ b/functions/src/invitationTypes.ts
@@ -2,6 +2,14 @@
  *  Cloud Functions (Admin SDK). Keeps the webhook + callable free of
  *  importing from the web Zod schema. */
 export interface SpeakerInvitationShape {
+  /** Discriminator for which kind of participant this invitation is
+   *  for. Default "speaker" (treat absent as speaker for back-compat
+   *  with pre-prayer-flow rows). */
+  kind?: "speaker" | "prayer";
+  /** Set only when `kind === "prayer"`. Mirrors the prayer
+   *  participant doc's role at
+   *  `wards/{wardId}/meetings/{date}/prayers/{role}`. */
+  prayerRole?: "opening" | "benediction";
   speakerRef: { meetingDate: string; speakerId: string };
   assignedDate: string;
   sentOn: string;
@@ -48,4 +56,15 @@ export interface SpeakerInvitationShape {
    *  subsequent SMS for this invitation route through the same
    *  number — see `twilio/fromNumber.ts`. */
   fromNumberMode?: "production" | "testing";
+}
+
+/** User-facing label for a prayer-kind invitation, used to fill the
+ *  `{{prayerType}}` token in SMS / email / receipt templates. Returns
+ *  undefined for speaker invitations so callers can spread it
+ *  conditionally into vars bags. */
+export function invitationPrayerType(
+  invitation: Pick<SpeakerInvitationShape, "kind" | "prayerRole">,
+): string | undefined {
+  if (invitation.kind !== "prayer" || !invitation.prayerRole) return undefined;
+  return invitation.prayerRole === "opening" ? "opening prayer" : "benediction";
 }

--- a/functions/src/messageTemplateDefaults.ts
+++ b/functions/src/messageTemplateDefaults.ts
@@ -38,13 +38,30 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
   "— {{wardName}}",
 ].join("\n");
 
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
+  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
+  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+
+export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =
+  "You accepted the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you.";
+
+export const DEFAULT_PRAYER_RESPONSE_DECLINED =
+  "You declined the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you for letting us know.";
+
+export const DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT =
+  "{{speakerName}} {{verb}} the invitation to give the {{prayerType}} on {{assignedDate}}.";
+
 export type MessageTemplateKey =
   | "initialInvitationSms"
   | "speakerResponseAccepted"
   | "speakerResponseDeclined"
   | "bishopricResponseReceipt"
   | "bishopReplySms"
-  | "bishopReplyEmail";
+  | "bishopReplyEmail"
+  | "prayerInitialInvitationSms"
+  | "prayerResponseAccepted"
+  | "prayerResponseDeclined"
+  | "prayerBishopricResponseReceipt";
 
 export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
@@ -53,4 +70,8 @@ export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
   bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
   bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
+  prayerInitialInvitationSms: DEFAULT_PRAYER_INITIAL_INVITATION_SMS,
+  prayerResponseAccepted: DEFAULT_PRAYER_RESPONSE_ACCEPTED,
+  prayerResponseDeclined: DEFAULT_PRAYER_RESPONSE_DECLINED,
+  prayerBishopricResponseReceipt: DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT,
 };

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -40,10 +40,17 @@ export const onInvitationWrite = onDocumentWritten(
     const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
     try {
       const bishopric = await fetchActiveBishopricEmails(db, wardId);
+      const isPrayer = after.kind === "prayer";
       if (change.fireSpeaker) {
         const answer = after.response?.answer;
-        const key = answer === "yes" ? "speakerResponseAccepted" : "speakerResponseDeclined";
-        const headerTemplate = await readMessageTemplate(db, wardId, key);
+        const speakerKey = isPrayer
+          ? answer === "yes"
+            ? "prayerResponseAccepted"
+            : "prayerResponseDeclined"
+          : answer === "yes"
+            ? "speakerResponseAccepted"
+            : "speakerResponseDeclined";
+        const headerTemplate = await readMessageTemplate(db, wardId, speakerKey);
         // allSettled — one leg failing must NOT cancel the other.
         // Promise.all rejects on first failure; the outer try/catch
         // then catches and the function exits, which tears down the
@@ -64,7 +71,10 @@ export const onInvitationWrite = onDocumentWritten(
         }
       }
       if (change.fireBishopric) {
-        const headerTemplate = await readMessageTemplate(db, wardId, "bishopricResponseReceipt");
+        const bishopricKey = isPrayer
+          ? "prayerBishopricResponseReceipt"
+          : "bishopricResponseReceipt";
+        const headerTemplate = await readMessageTemplate(db, wardId, bishopricKey);
         await sendBishopricReceipt(after, bishopric, {
           wardId,
           invitationId,

--- a/functions/src/sendSpeakerInvitation.types.ts
+++ b/functions/src/sendSpeakerInvitation.types.ts
@@ -15,6 +15,17 @@ export interface FreshInvitationRequest {
   channels: ("email" | "sms")[];
   speakerName: string;
   speakerTopic?: string;
+  /** Discriminator for the kind of participant being invited. Default
+   *  "speaker" preserves back-compat. When "prayer", `prayerRole` is
+   *  required; the SMS body uses `prayerInitialInvitationSms` and the
+   *  receipt copy uses the `prayer*` template keys. The same Twilio
+   *  Conversation + capability-token plumbing is reused — full chat
+   *  parity with speakers per product spec. */
+  kind?: "speaker" | "prayer";
+  /** Required when `kind === "prayer"`. Persisted on the invitation
+   *  doc so the speaker landing page + receipt builders can resolve
+   *  the right copy + variables (`{{prayerType}}`). */
+  prayerRole?: "opening" | "benediction";
   inviterName: string;
   wardName: string;
   assignedDate: string;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -1,4 +1,5 @@
 import { Outlet } from "react-router";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { OnlineStatusBanner } from "./OnlineStatusBanner";
 import { Topbar } from "./Topbar";
 
@@ -15,6 +16,9 @@ export function AppShell() {
       <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
         <Outlet />
       </div>
+      <footer className="flex justify-center py-3 px-4">
+        <BuiltByCredit />
+      </footer>
     </div>
   );
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -10,6 +10,7 @@ import { Login } from "./routes/login";
 import { NotificationsPage } from "./routes/notifications";
 import { PlanSpeakersRoute } from "./routes/plan-speakers";
 import { PrepareInvitationPage } from "./routes/prepare-invitation";
+import { PreparePrayerInvitationPage } from "./routes/prepare-prayer-invitation";
 import { ProfilePage } from "./routes/profile";
 import { TemplatesPage } from "./routes/templates";
 import { ProgramTemplatesPage } from "./routes/templates-programs";
@@ -57,6 +58,10 @@ export const router = createBrowserRouter([
       {
         path: "/week/:date/speaker/:speakerId/prepare",
         element: <PrepareInvitationPage />,
+      },
+      {
+        path: "/week/:date/prayer/:role/prepare",
+        element: <PreparePrayerInvitationPage />,
       },
       { path: "/plan/:date", element: <PlanSpeakersRoute /> },
     ],

--- a/src/app/routes/PreparePrayerInvitationHeader.tsx
+++ b/src/app/routes/PreparePrayerInvitationHeader.tsx
@@ -1,0 +1,76 @@
+import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
+import type { PrayerRole } from "@/lib/types";
+import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitationActionBar";
+
+interface Props {
+  role: PrayerRole;
+  speakerName: string; // prayer-giver's name; reused naming for action-bar reuse
+  speakerEmail: string;
+  speakerPhone: string;
+  email: string;
+  hasEmail: boolean;
+  busy: boolean;
+  canSend: boolean;
+  canSendReason: string | null;
+  canSms: boolean;
+  canSmsReason: string | null;
+  hasOverride: boolean;
+  onCancel: () => void;
+  onRevert: () => void;
+  onMarkInvited: () => void;
+  onPrint: () => void;
+  onSend: (email: string) => void;
+  onSendSms: (phone: string) => void;
+}
+
+const ROLE_LABEL: Record<PrayerRole, string> = {
+  opening: "Opening prayer",
+  benediction: "Benediction",
+};
+
+export function PreparePrayerInvitationHeader(props: Props) {
+  return (
+    <header className="sticky top-0 z-20 shrink-0 flex flex-col gap-3 border-b border-border bg-chalk px-4 sm:px-8 pt-4 sm:pt-5 pb-3 sm:pb-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5 min-w-0">
+          <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+            Prepare invitation · {ROLE_LABEL[props.role]}
+          </div>
+          <h1 className="font-display text-[20px] sm:text-[22px] font-semibold text-walnut leading-tight truncate">
+            {props.speakerName}
+          </h1>
+          <p className="font-serif italic text-[12.5px] text-walnut-3 truncate">
+            {props.hasEmail ? `Will be emailed to ${props.email}.` : "No email on file."}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={props.onCancel}
+          aria-label="Cancel and close tab"
+          title="Cancel"
+          className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
+        >
+          <RemoveIcon />
+        </button>
+      </div>
+      <div className="lg:hidden flex justify-center">
+        <PrepareInvitationActionBar
+          busy={props.busy}
+          canSend={props.canSend}
+          canSendReason={props.canSendReason}
+          canSms={props.canSms}
+          canSmsReason={props.canSmsReason}
+          hasOverride={props.hasOverride}
+          speakerName={props.speakerName}
+          speakerEmail={props.speakerEmail}
+          speakerPhone={props.speakerPhone}
+          onRevert={props.onRevert}
+          onMarkInvited={props.onMarkInvited}
+          onPrint={props.onPrint}
+          onSend={props.onSend}
+          onSendSms={props.onSendSms}
+        />
+      </div>
+    </header>
+  );
+}

--- a/src/app/routes/accept-invite.tsx
+++ b/src/app/routes/accept-invite.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Navigate, useNavigate, useParams } from "react-router";
 import { doc, getDoc } from "firebase/firestore";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { AcceptInviteBody, type AcceptInviteState } from "@/features/invites/AcceptInviteBody";
 import { acceptInvite, findInvitesForEmail } from "@/features/invites/inviteActions";
 import { db } from "@/lib/firebase";
@@ -92,15 +93,18 @@ export function AcceptInvitePage() {
 
   return (
     <main className="min-h-dvh bg-parchment paper-grain grid place-items-center p-6">
-      <div className="w-full max-w-md rounded-[14px] border border-border-strong bg-chalk p-7 shadow-elev-3">
-        <div className="mb-4 font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
-          Ward invitation
+      <div className="w-full max-w-md flex flex-col items-center gap-4">
+        <div className="w-full rounded-[14px] border border-border-strong bg-chalk p-7 shadow-elev-3">
+          <div className="mb-4 font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+            Ward invitation
+          </div>
+          <AcceptInviteBody
+            state={state}
+            onAccept={() => void accept()}
+            onSignOut={() => void signOut()}
+          />
         </div>
-        <AcceptInviteBody
-          state={state}
-          onAccept={() => void accept()}
-          onSignOut={() => void signOut()}
-        />
+        <BuiltByCredit />
       </div>
     </main>
   );

--- a/src/app/routes/invite-speaker-chat-drawer.tsx
+++ b/src/app/routes/invite-speaker-chat-drawer.tsx
@@ -15,10 +15,14 @@ interface Props {
 }
 
 /** Floating chat drawer for the speaker invite page. Collapsed, it
- *  shows a pill-shaped FAB bottom-right. Opened, it fills the screen
- *  on mobile and docks as a ~420px wide panel bottom-right on sm+.
- *  Body scroll is locked while open to keep the letter behind from
- *  rubber-banding on iOS. */
+ *  shows a pill-shaped FAB bottom-right. Opened on **mobile**, it
+ *  slides up from the bottom as a sheet (with a grab handle and
+ *  rounded top corners) so the top of the letter remains visible
+ *  behind it. Opened on **desktop** (sm+), it docks as a ~420px
+ *  wide panel in the bottom-right with a small inset — the speaker
+ *  has the screen real estate to keep the letter visible alongside
+ *  it. Body scroll is locked while open to keep the letter behind
+ *  from rubber-banding on iOS. */
 export function SpeakerChatFloatingDrawer({
   open,
   onOpenChange,
@@ -71,12 +75,20 @@ export function SpeakerChatFloatingDrawer({
       role="dialog"
       aria-modal="true"
       aria-label="Conversation with the bishopric"
-      className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.42)] flex items-stretch sm:items-end justify-end sm:p-4 animate-[fade_160ms_ease-out]"
+      className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)] flex items-end justify-center sm:justify-end sm:p-4 animate-[fade_160ms_ease-out]"
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onOpenChange(false);
       }}
     >
-      <div className="bg-chalk flex flex-col w-full h-dvh sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border sm:border-border-strong sm:shadow-elev-3 overflow-hidden">
+      <div className="bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)] sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b sm:animate-none">
+        <button
+          type="button"
+          aria-label="Close conversation"
+          onClick={() => onOpenChange(false)}
+          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer sm:hidden"
+        >
+          <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
+        </button>
         {children}
       </div>
     </div>

--- a/src/app/routes/invite-speaker-cta-banner.tsx
+++ b/src/app/routes/invite-speaker-cta-banner.tsx
@@ -2,6 +2,9 @@ export type CtaVariant = "reply" | "unread";
 
 interface Props {
   variant: CtaVariant;
+  /** Discriminator from the invitation doc — adjusts the "speaking
+   *  invitation" copy to "prayer invitation" for prayer-givers. */
+  kind?: "speaker" | "prayer";
   onTap: () => void;
 }
 
@@ -9,8 +12,9 @@ interface Props {
  *  chat drawer. Shown only while the drawer is closed and something
  *  demands attention (no response yet, or an unread bishop message).
  *  Taps anywhere on the banner open the drawer. */
-export function SpeakerChatCTABanner({ variant, onTap }: Props): React.ReactElement {
-  const copy = variant === "reply" ? REPLY_COPY : UNREAD_COPY;
+export function SpeakerChatCTABanner({ variant, kind, onTap }: Props): React.ReactElement {
+  const copy =
+    variant === "reply" ? (kind === "prayer" ? REPLY_COPY_PRAYER : REPLY_COPY) : UNREAD_COPY;
   return (
     <button
       type="button"
@@ -42,6 +46,12 @@ const REPLY_COPY = {
   body: "Please reply to the speaking invitation",
   action: "Reply now",
   aria: "Please reply to the speaking invitation — tap to open the chat",
+};
+
+const REPLY_COPY_PRAYER = {
+  body: "Please reply to the prayer invitation",
+  action: "Reply now",
+  aria: "Please reply to the prayer invitation — tap to open the chat",
 };
 
 const UNREAD_COPY = {

--- a/src/app/routes/invite-speaker-share-toolbar.tsx
+++ b/src/app/routes/invite-speaker-share-toolbar.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { letterCanvasToPdf } from "@/features/page-editor/letterToPdf";
+import { shareLetterPdf } from "@/features/page-editor/shareLetterPdf";
+
+/** Renders the letter PDF and hands it to the OS share sheet (Web
+ *  Share API on iOS / Android), falling back to a download on
+ *  desktop browsers without share support. Targets the existing
+ *  `[data-print-only-letter]` portal that the invite page already
+ *  mounts at true 8.5×11. */
+export function ShareToolbar({
+  speakerName,
+  assignedDate,
+}: {
+  speakerName: string;
+  assignedDate: string;
+}): React.ReactElement {
+  const [busy, setBusy] = useState(false);
+
+  async function handleShare() {
+    if (busy) return;
+    const target = document.querySelector<HTMLElement>("[data-print-only-letter]");
+    if (!target) return;
+    setBusy(true);
+    try {
+      const filename = pdfFilename(speakerName, assignedDate);
+      const { file } = await letterCanvasToPdf(target, filename);
+      await shareLetterPdf(file, filename, `Invitation for ${speakerName}`);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="print:hidden flex justify-end">
+      <button
+        type="button"
+        onClick={handleShare}
+        disabled={busy}
+        title="Share · Save as PDF"
+        aria-label="Share · Save as PDF"
+        className="inline-flex items-center justify-center rounded-md border border-walnut bg-walnut w-9 h-9 text-chalk hover:bg-walnut-2 shadow-elev-2 disabled:opacity-60 disabled:cursor-progress"
+      >
+        {busy ? <SpinnerIcon /> : <ShareIcon />}
+      </button>
+    </div>
+  );
+}
+
+function pdfFilename(speakerName: string, date: string): string {
+  const slug = speakerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `invitation-${slug || "speaker"}-${date}.pdf`;
+}
+
+function ShareIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M12 3v13" />
+      <path d="m7 8 5-5 5 5" />
+      <path d="M5 14v5a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-5" />
+    </svg>
+  );
+}
+
+function SpinnerIcon() {
+  return (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      aria-hidden="true"
+      className="animate-spin"
+    >
+      <path d="M12 3a9 9 0 1 1-6.4 2.6" />
+    </svg>
+  );
+}

--- a/src/app/routes/invite-speaker-states.tsx
+++ b/src/app/routes/invite-speaker-states.tsx
@@ -2,6 +2,7 @@ import type { SpeakerInvitation } from "@/lib/types";
 import type { SpeakerInvitationState } from "@/features/templates/useSpeakerInvitation";
 
 export { SessionGate } from "./invite-speaker-session-gate";
+export { ShareToolbar } from "./invite-speaker-share-toolbar";
 
 /** Non-"ready" sub-states for the invite landing page. Split out so
  *  the main route stays under the 150-LOC ceiling while keeping
@@ -61,40 +62,5 @@ export function ExpiredState({
 function StateFrame({ children }: { children?: React.ReactNode }) {
   return (
     <main className="min-h-dvh bg-[#e6ddc7] flex items-center justify-center p-4">{children}</main>
-  );
-}
-
-export function PrintToolbar(): React.ReactElement {
-  return (
-    <div className="print:hidden flex justify-end">
-      <button
-        type="button"
-        onClick={() => window.print()}
-        title="Print · Save as PDF"
-        aria-label="Print · Save as PDF"
-        className="inline-flex items-center justify-center rounded-md border border-walnut bg-walnut w-9 h-9 text-chalk hover:bg-walnut-2 shadow-elev-2"
-      >
-        <PrinterIcon />
-      </button>
-    </div>
-  );
-}
-
-function PrinterIcon() {
-  return (
-    <svg
-      width="14"
-      height="14"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.75"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M6 9V2h12v7" />
-      <rect x="3" y="9" width="18" height="9" rx="2" />
-      <path d="M6 14h12v7H6z" />
-    </svg>
   );
 }

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -105,7 +105,11 @@ function InviteLandingContent({
       </div>
 
       {promptVariant && (
-        <SpeakerChatCTABanner variant={promptVariant} onTap={() => setChatOpen(true)} />
+        <SpeakerChatCTABanner
+          variant={promptVariant}
+          kind={invitation.kind}
+          onTap={() => setChatOpen(true)}
+        />
       )}
 
       <div
@@ -133,6 +137,7 @@ function InviteLandingContent({
               meetingDate={invitation.speakerRef.meetingDate}
               responseAnswer={invitation.response?.answer ?? null}
               currentStatus={invitation.currentSpeakerStatus ?? null}
+              {...(invitation.kind ? { kind: invitation.kind } : {})}
               onClose={() => setChatOpen(false)}
               fillHeight
             />

--- a/src/app/routes/invite-speaker.tsx
+++ b/src/app/routes/invite-speaker.tsx
@@ -11,7 +11,7 @@ import { useSpeakerInvitation } from "@/features/templates/useSpeakerInvitation"
 import type { SpeakerInvitation } from "@/lib/types";
 import { SpeakerChatFloatingDrawer } from "./invite-speaker-chat-drawer";
 import { SpeakerChatCTABanner, type CtaVariant } from "./invite-speaker-cta-banner";
-import { ExpiredState, NonReadyState, PrintToolbar, SessionGate } from "./invite-speaker-states";
+import { ExpiredState, NonReadyState, SessionGate, ShareToolbar } from "./invite-speaker-states";
 
 /**
  * Public landing page for an invitation link. The letter fills the
@@ -108,8 +108,12 @@ function InviteLandingContent({
         <SpeakerChatCTABanner variant={promptVariant} onTap={() => setChatOpen(true)} />
       )}
 
-      <div className="absolute top-4 right-4 z-10 pt-[env(safe-area-inset-top)]">
-        <PrintToolbar />
+      <div
+        className={`absolute right-4 z-10 pt-[env(safe-area-inset-top)] transition-[top] duration-200 ${
+          promptVariant ? "top-16" : "top-4"
+        }`}
+      >
+        <ShareToolbar speakerName={invitation.speakerName} assignedDate={invitation.assignedDate} />
       </div>
 
       <SpeakerChatFloatingDrawer

--- a/src/app/routes/prepare-prayer-invitation.tsx
+++ b/src/app/routes/prepare-prayer-invitation.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import { useParams } from "react-router";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useMeeting } from "@/hooks/useMeeting";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { useSpeakerLetterTemplate } from "@/features/templates/useSpeakerLetterTemplate";
+import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
+import { formatAssignedDate, formatToday } from "@/features/templates/letterDates";
+import { isPlausiblePhone } from "@/features/templates/smsInvitation";
+import { isValidEmail } from "@/lib/email";
+import { type PrayerRole, prayerRoleSchema } from "@/lib/types";
+import { useAuthStore } from "@/stores/authStore";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { usePrayerParticipant } from "@/features/prayers/usePrayerParticipant";
+import { usePreparePrayerInvitation } from "@/features/prayers/usePreparePrayerInvitation";
+import { usePreparePrayerActions } from "@/features/prayers/usePreparePrayerActions";
+import { PreparePrayerInvitationHeader } from "./PreparePrayerInvitationHeader";
+import { PrepareInvitationPageMessage } from "./PrepareInvitationPageMessage";
+
+export function PreparePrayerInvitationPage() {
+  const { date, role: roleParam } = useParams<{ date: string; role: string }>();
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const me = useCurrentMember();
+  const authUser = useAuthStore((s) => s.user);
+  const ward = useWardSettings();
+  const { data: letterTemplate } = useSpeakerLetterTemplate();
+  const meeting = useMeeting(date ?? null);
+  const roleParseResult = roleParam ? prayerRoleSchema.safeParse(roleParam) : null;
+  const role: PrayerRole | null = roleParseResult?.success ? roleParseResult.data : null;
+  const participant = usePrayerParticipant(date ?? null, role ?? "opening");
+  const [done, setDone] = useState(false);
+
+  const inviterName =
+    me?.data.displayName ?? authUser?.displayName ?? authUser?.email ?? "The bishopric";
+  const wardName = ward.data?.name ?? "";
+
+  // Resolve the prayer-giver's name + contact: prefer the structured
+  // participant doc (set once invited / overridden), fall back to the
+  // lightweight `meeting.{role}.person` Assignment row the bishop
+  // typed inline. Email + phone live only on the participant doc.
+  const inlineAssignment =
+    role === "opening" ? meeting.data?.openingPrayer : meeting.data?.benediction;
+  const prayerGiverName = participant.data?.name ?? inlineAssignment?.person?.name ?? "";
+  const prayerGiverEmail = participant.data?.email ?? "";
+  const prayerGiverPhone = participant.data?.phone ?? "";
+
+  const form = usePreparePrayerInvitation({
+    wardId: wardId ?? "",
+    date: date ?? "",
+    role: role ?? "opening",
+    open: Boolean(wardId && date && role),
+    letterTemplate,
+  });
+
+  const vars = useMemo(
+    () => ({
+      speakerName: prayerGiverName,
+      prayerGiverName,
+      prayerType: role === "opening" ? "opening prayer" : "benediction",
+      date: date ? formatAssignedDate(date) : "",
+      today: formatToday(),
+      wardName,
+      inviterName,
+    }),
+    [prayerGiverName, role, date, wardName, inviterName],
+  );
+
+  const actions = usePreparePrayerActions({
+    wardId: wardId ?? "",
+    date: date ?? "",
+    role: role ?? "opening",
+    prayerGiverName,
+    prayerGiverEmail,
+    prayerGiverPhone,
+    inviterName,
+    form,
+    onDone: () => setDone(true),
+  });
+
+  if (!wardId || !date || !role) {
+    return (
+      <PrepareInvitationPageMessage
+        title="Missing invitation context"
+        body="Return to the schedule."
+      />
+    );
+  }
+  if (!prayerGiverName) {
+    return (
+      <PrepareInvitationPageMessage
+        title="No name set"
+        body="Add a name in the meeting's Prayers section before sending an invitation."
+      />
+    );
+  }
+  if (done) {
+    return (
+      <PrepareInvitationPageMessage
+        title="Invitation sent"
+        body="The prayer-giver has been notified. This tab will close on its own."
+        close
+      />
+    );
+  }
+
+  const hasEmail = isValidEmail(prayerGiverEmail);
+  const hasPhone = isPlausiblePhone(prayerGiverPhone);
+  const canSend = hasEmail;
+  const canSms = hasPhone;
+  const canSendReason = hasEmail ? "" : "Add an email address.";
+  const canSmsReason = hasPhone ? "" : "Add a phone number.";
+
+  const toolbarProps = {
+    busy: form.busy,
+    canSend,
+    canSendReason,
+    canSms,
+    canSmsReason,
+    hasOverride: form.letterHasOverride,
+    speakerName: prayerGiverName,
+    speakerEmail: prayerGiverEmail,
+    speakerPhone: prayerGiverPhone,
+    onRevert: () => void form.clearLetterOverride(),
+    onMarkInvited: actions.markInvited,
+    onPrint: () => window.print(),
+    onSend: actions.send,
+    onSendSms: actions.sendSms,
+  };
+
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PreparePrayerInvitationHeader
+        role={role}
+        email={prayerGiverEmail}
+        hasEmail={hasEmail}
+        onCancel={() => window.close()}
+        {...toolbarProps}
+      />
+      <div className="flex-1 min-h-0 lg:overflow-hidden px-5 sm:px-8 pt-5 pb-4">
+        {form.hydrated ? (
+          <PrepareInvitationLetterTab
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            liveStateJson={form.letterStateJson}
+            body={form.letterBody}
+            footer={form.letterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
+            vars={vars}
+          />
+        ) : (
+          <p className="font-serif italic text-[14px] text-walnut-3">Loading letter…</p>
+        )}
+        {form.error && <p className="mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>}
+      </div>
+    </main>
+  );
+}

--- a/src/components/BuiltByCredit.tsx
+++ b/src/components/BuiltByCredit.tsx
@@ -1,0 +1,14 @@
+/** Personal-touch developer credit. Single source of truth so the
+ *  copy stays consistent on the app shell footer and on the public
+ *  invite pages. `className` lets the caller position it (footer flow
+ *  in AppShell / accept-invite, absolute bottom-left on the
+ *  full-viewport speaker invite). */
+export function BuiltByCredit({ className = "" }: { className?: string }): React.ReactElement {
+  return (
+    <span
+      className={`font-serif italic text-[10px] text-walnut-3 select-none print:hidden ${className}`}
+    >
+      This app was built with love and prayer, by Oriel Absin.
+    </span>
+  );
+}

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -53,6 +53,9 @@ interface Props {
    *  floating drawer on the invite page). Default layout stays inline
    *  for other callsites. */
   fillHeight?: boolean;
+  /** Discriminator from the invitation doc — adjusts the response
+   *  banner copy from "speaking" to "prayer" wording. */
+  kind?: "speaker" | "prayer";
 }
 
 /** Speaker-side chat pane. By the time this renders the parent
@@ -155,6 +158,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         answer={props.responseAnswer}
         meetingDate={props.meetingDate}
         {...(props.currentStatus !== undefined ? { currentStatus: props.currentStatus } : {})}
+        {...(props.kind ? { kind: props.kind } : {})}
       />
 
       <ConversationThread

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { onAuthStateChanged, type User } from "firebase/auth";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { inviteAuth } from "@/lib/firebase";
 import { ConversationComposer } from "./ConversationComposer";
 import { ConversationThread } from "./ConversationThread";
@@ -184,6 +185,10 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
         ensureReady={ensureReady}
         placeholder="Reply to the bishopric…"
       />
+
+      <div className="flex justify-center py-2 px-4 border-t border-border">
+        <BuiltByCredit />
+      </div>
     </section>
   );
 }

--- a/src/features/invitations/SpeakerResponseBanner.tsx
+++ b/src/features/invitations/SpeakerResponseBanner.tsx
@@ -14,6 +14,9 @@ interface Props {
    *  Substituted into the subtitle copy instead of the ambiguous
    *  "this Sunday" so the date is unambiguous. */
   meetingDate: string;
+  /** Discriminator from the invitation doc — adjusts "speaking" copy
+   *  to "prayer" copy when the participant is a prayer-giver. */
+  kind?: "speaker" | "prayer";
 }
 
 /** Speaker-side confirmation banner rendered under the conversation
@@ -34,8 +37,14 @@ export function SpeakerResponseBanner({
   answer,
   currentStatus,
   meetingDate,
+  kind,
 }: Props): React.ReactElement | null {
   const when = formatShortSunday(meetingDate);
+  const isPrayer = kind === "prayer";
+  const inviteLabel = isPrayer ? "prayer invitation" : "invitation to speak";
+  const declinedSubtitle = isPrayer
+    ? `You are no longer asked to give the prayer on ${when}. See the chat below for any follow-up.`
+    : `You are no longer scheduled to speak on ${when}. See the chat below for any follow-up.`;
   if (currentStatus === "confirmed") {
     return (
       <Banner
@@ -50,7 +59,7 @@ export function SpeakerResponseBanner({
       <Banner
         tone="danger"
         title="Your assignment has been updated to declined."
-        subtitle={`You are no longer scheduled to speak on ${when}. See the chat below for any follow-up.`}
+        subtitle={declinedSubtitle}
       />
     );
   }
@@ -58,7 +67,7 @@ export function SpeakerResponseBanner({
     return (
       <Banner
         tone="success"
-        title={`You accepted the invitation to speak on ${when}. Thank you!`}
+        title={`You accepted the ${inviteLabel} on ${when}. Thank you!`}
         subtitle="The bishopric will follow up with any remaining details in the chat below."
       />
     );
@@ -67,7 +76,7 @@ export function SpeakerResponseBanner({
     return (
       <Banner
         tone="danger"
-        title={`You declined the invitation to speak on ${when}.`}
+        title={`You declined the ${inviteLabel} on ${when}.`}
         subtitle="The bishopric has been notified and will respond in the chat below if needed."
       />
     );

--- a/src/features/invitations/invitationsCallable.ts
+++ b/src/features/invitations/invitationsCallable.ts
@@ -4,11 +4,19 @@ import { functions, inviteFunctions } from "@/lib/firebase";
 export interface FreshInvitationRequest {
   mode?: "fresh";
   wardId: string;
+  /** Speaker doc ID, OR the prayer role string ("opening" |
+   *  "benediction") when `kind === "prayer"`. The Cloud Function
+   *  treats this as the participant's identifier within its
+   *  collection. */
   speakerId: string;
   meetingDate: string;
   channels: ("email" | "sms")[];
   speakerName: string;
   speakerTopic?: string;
+  /** Discriminator. Default "speaker" preserves back-compat. */
+  kind?: "speaker" | "prayer";
+  /** Required when `kind === "prayer"`. */
+  prayerRole?: "opening" | "benediction";
   inviterName: string;
   wardName: string;
   assignedDate: string;

--- a/src/features/meetings/program/AssignRow.tsx
+++ b/src/features/meetings/program/AssignRow.tsx
@@ -40,7 +40,7 @@ export function AssignRow({ label, placeholder, assignment, showStatus = true, o
       : "unconfirmed";
 
   return (
-    <div className="grid grid-cols-[86px_minmax(0,1fr)_30px] items-center gap-3 py-2 border-b border-dashed border-border last:border-b-0">
+    <div className="grid grid-cols-[86px_minmax(0,1fr)_30px] items-center gap-3 py-2 border-b border-dashed border-border last:border-b-0 lg:border-b-0">
       <div className="text-[13.5px] font-sans font-medium text-walnut-2">{label}</div>
       <input
         value={local}

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -60,9 +60,11 @@ function PrayerRowGroup({ label, role, date, placeholder, assignment, onChange }
     // Suppress AssignRow's own dashed bottom border when we're
     // grouping it with the Invite link — its `last:border-b-0`
     // doesn't trigger because the link is now a sibling. The dashed
-    // separator role passes to this wrapper so consecutive prayer
-    // groups stay visually divided.
-    <div className="border-b border-dashed border-border last:border-b-0 *:first:border-b-0">
+    // separator role passes to this wrapper for the stacked
+    // (mobile / tablet) layout; on `lg:` the rows sit side by side
+    // in a 2-col grid so a horizontal separator below each row reads
+    // as noise — drop it.
+    <div className="border-b border-dashed border-border last:border-b-0 lg:border-b-0 *:first:border-b-0">
       <AssignRow
         label={label}
         placeholder={placeholder}

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -57,7 +57,12 @@ function PrayerRowGroup({ label, role, date, placeholder, assignment, onChange }
   const hasName = Boolean(assignment?.person?.name?.trim() || participant.data?.name?.trim());
 
   return (
-    <div>
+    // Suppress AssignRow's own dashed bottom border when we're
+    // grouping it with the Invite link — its `last:border-b-0`
+    // doesn't trigger because the link is now a sibling. The dashed
+    // separator role passes to this wrapper so consecutive prayer
+    // groups stay visually divided.
+    <div className="border-b border-dashed border-border last:border-b-0 *:first:border-b-0">
       <AssignRow
         label={label}
         placeholder={placeholder}

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -1,4 +1,7 @@
-import type { Assignment, NonMeetingSunday, SacramentMeeting } from "@/lib/types";
+import { Link } from "react-router";
+import type { Assignment, NonMeetingSunday, PrayerRole, SacramentMeeting } from "@/lib/types";
+import { SpeakerStatusChip } from "@/features/plan-speakers/SpeakerStatusChip";
+import { usePrayerParticipant } from "@/features/prayers/usePrayerParticipant";
 import { AssignRow } from "../program/AssignRow";
 import { ProgramSection } from "../program/ProgramSection";
 import { updateMeetingField } from "../updateMeeting";
@@ -18,19 +21,62 @@ export function PrayersSection({ wardId, date, meeting, nonMeetingSundays }: Pro
   return (
     <ProgramSection id="sec-prayers" label="Prayers">
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-7 gap-y-1">
-        <AssignRow
+        <PrayerRowGroup
           label="Opening"
+          role="opening"
+          date={date}
           placeholder="Who will give the opening prayer?"
           assignment={meeting?.openingPrayer}
           onChange={(a) => void set("openingPrayer", a)}
         />
-        <AssignRow
+        <PrayerRowGroup
           label="Benediction"
+          role="benediction"
+          date={date}
           placeholder="Who will give the benediction?"
           assignment={meeting?.benediction}
           onChange={(a) => void set("benediction", a)}
         />
       </div>
     </ProgramSection>
+  );
+}
+
+interface RowGroupProps {
+  label: string;
+  role: PrayerRole;
+  date: string;
+  placeholder: string;
+  assignment: Assignment | undefined;
+  onChange: (a: Assignment) => void;
+}
+
+function PrayerRowGroup({ label, role, date, placeholder, assignment, onChange }: RowGroupProps) {
+  const participant = usePrayerParticipant(date, role);
+  const status = participant.data?.status ?? null;
+  const hasName = Boolean(assignment?.person?.name?.trim() || participant.data?.name?.trim());
+
+  return (
+    <div>
+      <AssignRow
+        label={label}
+        placeholder={placeholder}
+        assignment={assignment}
+        onChange={onChange}
+      />
+      {hasName && (
+        <div className="flex items-center justify-end gap-2 pl-24.5 pr-10.5 -mt-1 mb-2">
+          {status && status !== "planned" && <SpeakerStatusChip status={status} />}
+          <Link
+            to={`/week/${date}/prayer/${role}/prepare`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-[10px] uppercase tracking-[0.14em] text-bordeaux hover:text-bordeaux-deep underline-offset-2 hover:underline"
+          >
+            {status === "invited" || status === "confirmed" ? "Resend" : "Invite"} →
+          </Link>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/features/prayers/prayerActions.ts
+++ b/src/features/prayers/prayerActions.ts
@@ -1,0 +1,41 @@
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { InvitationStatus, PrayerRole } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+interface PrayerUpsertPatch {
+  name?: string;
+  email?: string;
+  phone?: string;
+  status?: InvitationStatus;
+}
+
+/** Upsert the prayer participant doc at
+ *  `wards/{wardId}/meetings/{date}/prayers/{role}`. Uses
+ *  `setDoc(..., { merge: true })` so the bishop's first action on a
+ *  prayer (Send / Mark invited) creates the doc lazily — the
+ *  lightweight inline `meeting.openingPrayer` Assignment row is the
+ *  source of truth until then. */
+export async function upsertPrayerParticipant(
+  wardId: string,
+  date: string,
+  role: PrayerRole,
+  patch: PrayerUpsertPatch,
+): Promise<void> {
+  reportSaving();
+  try {
+    await setDoc(
+      doc(db, "wards", wardId, "meetings", date, "prayers", role),
+      {
+        role,
+        ...patch,
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/prayers/prayerLetterOverride.ts
+++ b/src/features/prayers/prayerLetterOverride.ts
@@ -1,0 +1,71 @@
+import { deleteField, doc, serverTimestamp, setDoc, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { PrayerRole } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
+
+function prayerRef(wardId: string, date: string, role: PrayerRole) {
+  return doc(db, "wards", wardId, "meetings", date, "prayers", role);
+}
+
+export interface PrayerOverrideInput {
+  /** Lexical EditorState JSON — the new source of truth. Required so
+   *  the writer can derive legacy markdown fields. */
+  editorStateJson: string;
+}
+
+/** Write a per-prayer override of the ward invitation letter
+ *  template. Mirrors the speaker-side override writer but targets
+ *  the prayer participant doc at
+ *  `wards/{wardId}/meetings/{date}/prayers/{role}`. Uses `setDoc(...,
+ *  { merge: true })` so the doc gets created if the bishop is
+ *  authoring an override before the participant has otherwise been
+ *  promoted out of the lightweight inline `Assignment` row. */
+export async function savePrayerLetterOverride(
+  wardId: string,
+  date: string,
+  role: PrayerRole,
+  input: PrayerOverrideInput,
+): Promise<void> {
+  reportSaving();
+  try {
+    const state = JSON.parse(input.editorStateJson);
+    const { bodyMarkdown, footerMarkdown } = legacyFieldsFromState(state);
+    await setDoc(
+      prayerRef(wardId, date, role),
+      {
+        role,
+        letterOverride: {
+          editorStateJson: input.editorStateJson,
+          bodyMarkdown,
+          footerMarkdown,
+          updatedAt: serverTimestamp(),
+        },
+        updatedAt: serverTimestamp(),
+      },
+      { merge: true },
+    );
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+export async function clearPrayerLetterOverride(
+  wardId: string,
+  date: string,
+  role: PrayerRole,
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(prayerRef(wardId, date, role), {
+      letterOverride: deleteField(),
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/prayers/sendPrayerInvitation.ts
+++ b/src/features/prayers/sendPrayerInvitation.ts
@@ -1,0 +1,99 @@
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { type PrayerRole, wardSchema } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+import { useDevModeStore } from "@/stores/devModeStore";
+import {
+  callSendSpeakerInvitation,
+  type FreshInvitationResponse,
+} from "@/features/invitations/invitationsCallable";
+import { resolveChipsInState } from "@/features/page-editor/serializeForInterpolation";
+import { interpolate } from "@/features/templates/interpolate";
+import { formatAssignedDate, formatToday } from "@/features/templates/letterDates";
+
+export interface SendPrayerInvitationInput {
+  wardId: string;
+  meetingDate: string;
+  role: PrayerRole;
+  prayerGiverName: string;
+  prayerGiverEmail: string;
+  prayerGiverPhone: string;
+  inviterName: string;
+  bishopReplyToEmail: string;
+  bodyMarkdown: string;
+  footerMarkdown: string;
+  editorStateJson?: string | undefined;
+  channels: ("email" | "sms")[];
+}
+
+/** Client wrapper that calls the unified `sendSpeakerInvitation`
+ *  Cloud Function with `kind: "prayer"`. The function name still
+ *  reads "speaker" — see the follow-up rename issue — but it routes
+ *  prayer-keyed copy + persists `prayerRole` on the invitation. */
+export async function sendPrayerInvitation(
+  input: SendPrayerInvitationInput,
+): Promise<FreshInvitationResponse> {
+  reportSaving();
+  try {
+    const wardSnap = await getDoc(doc(db, "wards", input.wardId));
+    const wardName = wardSnap.exists() ? wardSchema.parse(wardSnap.data()).name : "";
+
+    const vars = {
+      speakerName: input.prayerGiverName,
+      prayerGiverName: input.prayerGiverName,
+      prayerType: input.role === "opening" ? "opening prayer" : "benediction",
+      date: formatAssignedDate(input.meetingDate),
+      today: formatToday(),
+      wardName,
+      inviterName: input.inviterName,
+    };
+
+    const bodyMarkdown = interpolate(input.bodyMarkdown, vars);
+    const footerMarkdown = interpolate(input.footerMarkdown, vars);
+    const editorStateJson = input.editorStateJson
+      ? resolveChipsInState(interpolate(input.editorStateJson, vars), vars)
+      : undefined;
+    const expiresAtMillis = computeExpiresAt(input.meetingDate);
+
+    const useTestingNumber = useDevModeStore.getState().useTestingNumber;
+    const res = await callSendSpeakerInvitation({
+      wardId: input.wardId,
+      // For prayer invitations the participant identifier is the role.
+      // The CF persists this in `speakerRef.speakerId` so existing
+      // helpers (cleanupPriorConversations, etc.) keep working.
+      speakerId: input.role,
+      meetingDate: input.meetingDate,
+      channels: input.channels,
+      kind: "prayer",
+      prayerRole: input.role,
+      speakerName: input.prayerGiverName,
+      inviterName: input.inviterName,
+      wardName,
+      assignedDate: vars.date,
+      sentOn: vars.today,
+      bodyMarkdown,
+      footerMarkdown,
+      ...(editorStateJson ? { editorStateJson } : {}),
+      ...(input.prayerGiverEmail.trim() ? { speakerEmail: input.prayerGiverEmail.trim() } : {}),
+      ...(input.prayerGiverPhone.trim() ? { speakerPhone: input.prayerGiverPhone.trim() } : {}),
+      bishopReplyToEmail: input.bishopReplyToEmail,
+      expiresAtMillis,
+      ...(useTestingNumber ? { useTestingNumber: true } : {}),
+    });
+    reportSaved();
+    return res;
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+/** Monday 00:00 local to the sender after the meeting's Sunday. */
+function computeExpiresAt(meetingDate: string): number {
+  const [y, m, d] = meetingDate.split("-").map(Number);
+  if (!y || !m || !d) return Date.now();
+  const local = new Date(y, m - 1, d);
+  local.setDate(local.getDate() + 1);
+  local.setHours(0, 0, 0, 0);
+  return local.getTime();
+}

--- a/src/features/prayers/usePrayerParticipant.ts
+++ b/src/features/prayers/usePrayerParticipant.ts
@@ -1,0 +1,17 @@
+import { type PrayerRole, prayerParticipantSchema } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { useDocSnapshot } from "@/hooks/_sub";
+
+/** Live subscription to a single prayer-participant doc.
+ *  Path: `wards/{wardId}/meetings/{date}/prayers/{role}`. The doc
+ *  only exists once the bishop has explicitly invited (or saved an
+ *  override); the lightweight inline `meeting.openingPrayer` /
+ *  `meeting.benediction` Assignment row stays the source of truth
+ *  until then. */
+export function usePrayerParticipant(date: string | null, role: PrayerRole) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  return useDocSnapshot(
+    ["wards", wardId, "meetings", date ?? undefined, "prayers", role],
+    prayerParticipantSchema,
+  );
+}

--- a/src/features/prayers/usePreparePrayerActions.ts
+++ b/src/features/prayers/usePreparePrayerActions.ts
@@ -1,0 +1,121 @@
+import type { PrayerRole } from "@/lib/types";
+import type { DeliveryEntry } from "@/features/invitations/invitationsCallable";
+import { useAuthStore } from "@/stores/authStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { upsertPrayerParticipant } from "./prayerActions";
+import { sendPrayerInvitation } from "./sendPrayerInvitation";
+
+function assertChannelsDelivered(
+  deliveryRecord: readonly DeliveryEntry[],
+  requested: readonly ("email" | "sms")[],
+): void {
+  const failed = deliveryRecord.filter(
+    (e) => requested.includes(e.channel) && e.status === "failed",
+  );
+  if (failed.length === 0) return;
+  const messages = failed.map((e) => {
+    const label = e.channel === "email" ? "Email" : "SMS";
+    return e.error ? `${label}: ${e.error}` : `${label} delivery failed.`;
+  });
+  throw new Error(messages.join(" · "));
+}
+
+interface FormState {
+  letterBody: string;
+  letterFooter: string;
+  letterStateJson: string | null;
+  persistOverrides: () => Promise<void>;
+  setBusy: (b: boolean) => void;
+  setError: (e: string | null) => void;
+}
+
+interface Args {
+  wardId: string;
+  date: string;
+  role: PrayerRole;
+  prayerGiverName: string;
+  prayerGiverEmail: string;
+  prayerGiverPhone: string;
+  inviterName: string;
+  form: FormState;
+  onDone: () => void;
+}
+
+/** Mirror of `usePrepareInvitationActions` for prayer-givers. Wraps
+ *  Mark invited / Send (email) / Send SMS with override persistence
+ *  + busy/error bookkeeping. Send routes through
+ *  `sendPrayerInvitation` (which calls the unified CF with
+ *  `kind: "prayer"`), then upserts the prayer participant doc with
+ *  `status: "invited"`. */
+export function usePreparePrayerActions(args: Args) {
+  const { form } = args;
+  const bishopEmail = useAuthStore((s) => s.user?.email ?? "");
+
+  async function runAction(fn: () => Promise<void> | void) {
+    form.setBusy(true);
+    form.setError(null);
+    try {
+      await form.persistOverrides();
+      await fn();
+      args.onDone();
+    } catch (e) {
+      form.setError(friendlyWriteError(e));
+    } finally {
+      form.setBusy(false);
+    }
+  }
+
+  async function sendVia(
+    channels: ("email" | "sms")[],
+    contactOverride?: { email?: string; phone?: string },
+  ): Promise<void> {
+    const resolvedEmail = (contactOverride?.email ?? args.prayerGiverEmail).trim();
+    const resolvedPhone = (contactOverride?.phone ?? args.prayerGiverPhone).trim();
+    const patch: { email?: string; phone?: string } = {};
+    if (contactOverride?.email && resolvedEmail !== args.prayerGiverEmail.trim()) {
+      patch.email = resolvedEmail;
+    }
+    if (contactOverride?.phone && resolvedPhone !== args.prayerGiverPhone.trim()) {
+      patch.phone = resolvedPhone;
+    }
+    if (patch.email || patch.phone) {
+      await upsertPrayerParticipant(args.wardId, args.date, args.role, {
+        name: args.prayerGiverName,
+        ...patch,
+      });
+    }
+    const res = await sendPrayerInvitation({
+      wardId: args.wardId,
+      meetingDate: args.date,
+      role: args.role,
+      prayerGiverName: args.prayerGiverName,
+      prayerGiverEmail: resolvedEmail,
+      prayerGiverPhone: resolvedPhone,
+      inviterName: args.inviterName,
+      bishopReplyToEmail: bishopEmail,
+      bodyMarkdown: form.letterBody,
+      footerMarkdown: form.letterFooter,
+      ...(form.letterStateJson ? { editorStateJson: form.letterStateJson } : {}),
+      channels,
+    });
+    assertChannelsDelivered(res.deliveryRecord, channels);
+    await upsertPrayerParticipant(args.wardId, args.date, args.role, {
+      name: args.prayerGiverName,
+      status: "invited",
+    });
+  }
+
+  return {
+    markInvited: () =>
+      void runAction(() =>
+        upsertPrayerParticipant(args.wardId, args.date, args.role, {
+          name: args.prayerGiverName,
+          status: "invited",
+        }),
+      ),
+    send: (email?: string) =>
+      void runAction(() => sendVia(["email"], email ? { email } : undefined)),
+    sendSms: (phone?: string) =>
+      void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
+  };
+}

--- a/src/features/prayers/usePreparePrayerInvitation.ts
+++ b/src/features/prayers/usePreparePrayerInvitation.ts
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from "react";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { type PrayerRole, type SpeakerLetterTemplate, prayerParticipantSchema } from "@/lib/types";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { legacyFieldsFromState } from "@/features/page-editor/serializeForInterpolation";
+import {
+  DEFAULT_SPEAKER_LETTER_BODY,
+  DEFAULT_SPEAKER_LETTER_FOOTER,
+} from "@/features/templates/speakerLetterDefaults";
+import { clearPrayerLetterOverride, savePrayerLetterOverride } from "./prayerLetterOverride";
+
+interface Args {
+  wardId: string;
+  date: string;
+  role: PrayerRole;
+  open: boolean;
+  /** Reused from the speaker letter template for now — the dedicated
+   *  `prayerLetterTemplate` editor route lands in a follow-up PR.
+   *  Until then, the bishop's per-prayer override + the ward speaker
+   *  template feed the prayer prepare-invitation page. */
+  letterTemplate: SpeakerLetterTemplate | null;
+}
+
+interface InitialMarkdown {
+  bodyMarkdown: string;
+  footerMarkdown: string;
+}
+
+/** Hydration + persistence helpers for the per-prayer letter
+ *  override. Mirrors `usePrepareInvitation` but reads / writes the
+ *  prayer participant doc at
+ *  `wards/{wardId}/meetings/{date}/prayers/{role}`. */
+export function usePreparePrayerInvitation(args: Args) {
+  const { wardId, date, role, open, letterTemplate } = args;
+  const [initialJson, setInitialJson] = useState<string | null>(null);
+  const [initialMarkdown, setInitialMarkdown] = useState<InitialMarkdown>({
+    bodyMarkdown: DEFAULT_SPEAKER_LETTER_BODY,
+    footerMarkdown: DEFAULT_SPEAKER_LETTER_FOOTER,
+  });
+  const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
+  const [letterHasOverride, setLetterHasOverride] = useState(false);
+  const [hydrated, setHydrated] = useState(false);
+  const [resetKey, setResetKey] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setHydrated(false);
+    (async () => {
+      const snap = await getDoc(doc(db, "wards", wardId, "meetings", date, "prayers", role));
+      if (cancelled) return;
+      const parsed = snap.exists() ? prayerParticipantSchema.safeParse(snap.data()) : null;
+      const override = parsed?.success ? parsed.data.letterOverride : undefined;
+      const json = override?.editorStateJson ?? letterTemplate?.editorStateJson ?? null;
+      const md: InitialMarkdown = {
+        bodyMarkdown:
+          override?.bodyMarkdown ?? letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+        footerMarkdown:
+          override?.footerMarkdown ??
+          letterTemplate?.footerMarkdown ??
+          DEFAULT_SPEAKER_LETTER_FOOTER,
+      };
+      setInitialJson(json);
+      setInitialMarkdown(md);
+      setLetterStateJson(json);
+      setLetterHasOverride(Boolean(override));
+      setError(null);
+      setHydrated(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, wardId, date, role, letterTemplate]);
+
+  const { letterBody, letterFooter } = useMemo(() => {
+    if (!letterStateJson) {
+      return {
+        letterBody: initialMarkdown.bodyMarkdown,
+        letterFooter: initialMarkdown.footerMarkdown,
+      };
+    }
+    try {
+      const state = JSON.parse(letterStateJson);
+      const fields = legacyFieldsFromState(state);
+      return { letterBody: fields.bodyMarkdown, letterFooter: fields.footerMarkdown };
+    } catch {
+      return {
+        letterBody: initialMarkdown.bodyMarkdown,
+        letterFooter: initialMarkdown.footerMarkdown,
+      };
+    }
+  }, [letterStateJson, initialMarkdown]);
+
+  function captureInitial(json: string) {
+    setLetterStateJson(json);
+    setInitialJson((prev) => prev ?? json);
+  }
+
+  async function persistOverrides() {
+    if (!letterStateJson) return;
+    await savePrayerLetterOverride(wardId, date, role, { editorStateJson: letterStateJson });
+    setLetterHasOverride(true);
+  }
+
+  function revertLetterToWardDefault() {
+    setLetterStateJson(letterTemplate?.editorStateJson ?? null);
+    setInitialJson(letterTemplate?.editorStateJson ?? null);
+    setInitialMarkdown({
+      bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
+      footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
+    });
+    setResetKey((k) => k + 1);
+  }
+
+  async function clearLetterOverride() {
+    setBusy(true);
+    setError(null);
+    try {
+      await clearPrayerLetterOverride(wardId, date, role);
+      revertLetterToWardDefault();
+      setLetterHasOverride(false);
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return {
+    initialJson,
+    initialMarkdown,
+    letterStateJson,
+    setLetterStateJson,
+    captureInitial,
+    letterBody,
+    letterFooter,
+    letterHasOverride,
+    hydrated,
+    resetKey,
+    error,
+    busy,
+    setBusy,
+    setError,
+    persistOverrides,
+    revertLetterToWardDefault,
+    clearLetterOverride,
+  };
+}

--- a/src/features/templates/prepareInvitationVars.ts
+++ b/src/features/templates/prepareInvitationVars.ts
@@ -1,13 +1,15 @@
 /** Variable shape for PrepareInvitationDialog's letter tab. The
  *  dialog computes vars once and the letter preview interpolates them
- *  identically to what a send would produce. Defined as a `type` (not
- *  `interface`) so it's assignable to `Record<string, string>` for
- *  `interpolate()`. */
+ *  identically to what a send would produce. Required keys cover the
+ *  speaker-shaped letter chrome (date / wardName / inviterName); the
+ *  index signature lets prayer invitations layer in extra tokens
+ *  (`prayerGiverName`, `prayerType`) without a separate type. */
 export type LetterVars = {
   speakerName: string;
-  topic: string;
   date: string;
   today: string;
   wardName: string;
   inviterName: string;
+  topic?: string;
+  [key: string]: string | undefined;
 };

--- a/src/features/templates/serverTemplateDefaults.ts
+++ b/src/features/templates/serverTemplateDefaults.ts
@@ -55,6 +55,26 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
   "— {{wardName}}",
 ].join("\n");
 
+/** Twilio SMS body sent when a bishop first invites a prayer-giver.
+ *  Mirrors the speaker-side wording with prayer phrasing in place of
+ *  "speak". `{{prayerType}}` resolves to "opening prayer" or
+ *  "benediction" per the prayer participant's role. */
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
+  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
+  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+
+/** Speaker-side acceptance receipt for prayer invitations. */
+export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =
+  "You accepted the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you.";
+
+/** Speaker-side decline receipt for prayer invitations. */
+export const DEFAULT_PRAYER_RESPONSE_DECLINED =
+  "You declined the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you for letting us know.";
+
+/** Bishopric-side receipt opening line for prayer invitations. */
+export const DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT =
+  "{{speakerName}} {{verb}} the invitation to give the {{prayerType}} on {{assignedDate}}.";
+
 export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
   speakerResponseAccepted: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
@@ -62,4 +82,8 @@ export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
   bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
   bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
+  prayerInitialInvitationSms: DEFAULT_PRAYER_INITIAL_INVITATION_SMS,
+  prayerResponseAccepted: DEFAULT_PRAYER_RESPONSE_ACCEPTED,
+  prayerResponseDeclined: DEFAULT_PRAYER_RESPONSE_DECLINED,
+  prayerBishopricResponseReceipt: DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT,
 };

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -5,9 +5,18 @@ export const MEETING_TYPES = ["regular", "fast", "stake", "general"] as const;
 export const meetingTypeSchema = z.enum(MEETING_TYPES);
 export type MeetingType = z.infer<typeof meetingTypeSchema>;
 
-export const SPEAKER_STATUSES = ["planned", "invited", "confirmed", "declined"] as const;
-export const speakerStatusSchema = z.enum(SPEAKER_STATUSES);
-export type SpeakerStatus = z.infer<typeof speakerStatusSchema>;
+// Shared invitation lifecycle for both speakers and prayer-givers.
+// `SPEAKER_STATUSES` / `speakerStatusSchema` / `SpeakerStatus` are
+// retained as aliases so existing speaker call sites don't churn —
+// new invitation kinds (prayers, future) should import the
+// `INVITATION_*` names directly.
+export const INVITATION_STATUSES = ["planned", "invited", "confirmed", "declined"] as const;
+export const invitationStatusSchema = z.enum(INVITATION_STATUSES);
+export type InvitationStatus = z.infer<typeof invitationStatusSchema>;
+
+export const SPEAKER_STATUSES = INVITATION_STATUSES;
+export const speakerStatusSchema = invitationStatusSchema;
+export type SpeakerStatus = InvitationStatus;
 
 export const SPEAKER_ROLES = ["Member", "Youth", "High Council", "Visiting"] as const;
 export const speakerRoleSchema = z.enum(SPEAKER_ROLES);
@@ -156,3 +165,29 @@ export const speakerSchema = z.object({
   updatedAt: z.any().optional(),
 });
 export type Speaker = z.infer<typeof speakerSchema>;
+
+// Prayer-giver participant — promoted from the lightweight inline
+// `Assignment` row on the meeting (`openingPrayer`, `benediction`)
+// when the bishop wants to send a formal invitation. Stored at
+// `wards/{wardId}/meetings/{date}/prayers/{role}` (one doc per slot).
+// The status enum is shared with speakers (see `INVITATION_STATUSES`).
+export const PRAYER_ROLES = ["opening", "benediction"] as const;
+export const prayerRoleSchema = z.enum(PRAYER_ROLES);
+export type PrayerRole = z.infer<typeof prayerRoleSchema>;
+
+export const prayerParticipantSchema = z.object({
+  name: z.string().min(1),
+  email: z.email().optional().or(z.literal("")),
+  phone: z.string().optional().or(z.literal("")),
+  role: prayerRoleSchema,
+  status: invitationStatusSchema.catch("planned"),
+  letterOverride: speakerLetterOverrideSchema.optional(),
+  invitationId: z.string().optional(),
+  conversationSid: z.string().optional(),
+  statusSource: statusSourceSchema.optional(),
+  statusSetBy: z.string().optional(),
+  statusSetAt: z.any().optional(),
+  createdAt: z.any().optional(),
+  updatedAt: z.any().optional(),
+});
+export type PrayerParticipant = z.infer<typeof prayerParticipantSchema>;

--- a/src/lib/types/speakerInvitation.ts
+++ b/src/lib/types/speakerInvitation.ts
@@ -65,7 +65,23 @@ export const speakerInvitationResponseSchema = z.object({
 export type SpeakerInvitationResponse = z.infer<typeof speakerInvitationResponseSchema>;
 
 export const speakerInvitationSchema = z.object({
-  /** Denormalized speaker reference back to the originating doc. */
+  /** Discriminator for which kind of participant this invitation is
+   *  for. Default "speaker" preserves back-compat for invitations
+   *  written before the prayer flow shipped; "prayer" routes through
+   *  the same Cloud Function + Twilio Conversation infrastructure
+   *  but with prayer-specific copy + the prayer letter template.
+   *  When `kind === "prayer"`, `prayerRole` is required and
+   *  `speakerRef.speakerId` holds the prayer role ("opening" |
+   *  "benediction") rather than a speaker doc ID. */
+  kind: z.enum(["speaker", "prayer"]).default("speaker"),
+  /** Set only when `kind === "prayer"`. Mirrors the participant doc's
+   *  role at `wards/{wardId}/meetings/{date}/prayers/{role}`. */
+  prayerRole: z.enum(["opening", "benediction"]).optional(),
+  /** Denormalized participant reference back to the originating doc.
+   *  For speakers: `speakerId` is the speaker doc ID. For prayers:
+   *  `speakerId` holds the role string ("opening" | "benediction")
+   *  matching the prayer participant doc path. The field name is
+   *  retained for back-compat — see follow-up rename issue. */
   speakerRef: z.object({
     meetingDate: z.string(), // ISO YYYY-MM-DD
     speakerId: z.string().min(1),

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -157,6 +157,10 @@ export const MESSAGE_TEMPLATE_KEYS = [
   "bishopricResponseReceipt",
   "bishopReplySms",
   "bishopReplyEmail",
+  "prayerInitialInvitationSms",
+  "prayerResponseAccepted",
+  "prayerResponseDeclined",
+  "prayerBishopricResponseReceipt",
 ] as const;
 export type MessageTemplateKey = (typeof MESSAGE_TEMPLATE_KEYS)[number];
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -246,6 +246,15 @@
   }
 }
 
+@keyframes drawerSlideUp {
+  from {
+    transform: translateY(100%);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
 /* Soft pulse ring for attention-worthy FABs. Used on the speaker
    invite page to draw the eye to the chat drawer when the speaker
    hasn't responded yet or the bishop has replied. */


### PR DESCRIPTION
## Summary

Promotes `develop` → `main` for **v0.14.0** (minor bump from 0.13.1).

### Highlights

- **Prayer-giver invitations end-to-end** (#168, #169, #170) — bishops can now invite opening + closing prayer participants through the same Twilio Conversation + capability-token pipeline used for speakers, with role-appropriate copy on the SMS, email, landing page CTA, and response banners. New `wards/{wardId}/meetings/{date}/prayers/{role}` subcollection + rules block; `sendSpeakerInvitation` and `onInvitationWrite` were extended with a `kind: "speaker" | "prayer"` discriminator instead of adding new functions, so the eight-Cloud-Function rule still holds. UI lands inline on the meeting editor's Prayers section: each row gets a status chip + Invite/Resend link once a name is typed, opening a dedicated `/week/:date/prayer/:role/prepare` page with the full-screen letter editor.
- **Share-as-PDF on the speaker invite page** (#168) — speakers tap a share icon that renders the resolved letter to a paginated 8.5×11 PDF and hands it to `navigator.share({ files })` (Web Share API on iOS / Android / Edge / Safari) with a download fallback elsewhere. Reuses the same `letterCanvasToPdf` + `shareLetterPdf` strategy as the bishop-side wizard.
- **Mobile bottom-sheet chat drawer** (#168) — on phone-class viewports the speaker chat slides up as an 85dvh sheet with rounded top corners + grab handle, leaving the top of the letter peeking above for spatial context. Desktop is unchanged.
- **Personal developer credit** (#168) — a tiny italic-serif "This app was built with love and prayer, by Oriel Absin." line on the app shell, accept-invite card, and speaker chat drawer. `print:hidden` keeps it out of printed programs and shared PDFs.

### Fixed

- AssignRow's stray dashed bottom border on `lg+` viewports in the meeting editor's Prayers + Speakers sections.

See [`CHANGELOG.md`](CHANGELOG.md) for the full v0.14.0 entry.

## Post-merge automation

Once this merges, [`.github/workflows/release.yml`](.github/workflows/release.yml) will:
1. Tag `v0.14.0` on the merge commit
2. Publish a GitHub Release with the matching CHANGELOG section
3. Deploy Firestore rules + indexes to `steward-prod-65a36`
4. Deploy Cloud Functions to `steward-prod-65a36`

Vercel handles the frontend redeploy via its own GitHub integration.

## Test plan

- [ ] Develop CI green (already confirmed on the release-prep merge)
- [ ] After main merge: Actions → Release workflow lands clean (tag + GitHub Release + Firebase deploys)
- [ ] Production smoke: hit prod URL, sign in, confirm Schedule loads
- [ ] Production smoke: edit a meeting field — rules accept the write
- [ ] Production smoke: type a name in PrayersSection → click Invite → prepare page opens → Send → status flips to invited
- [ ] Production smoke: prayer-giver receives SMS with prayer-shaped wording, lands on the invite page, replies, sees "prayer invitation" copy on banners
- [ ] Production smoke: speaker invite page → tap Share → OS share sheet appears with the PDF (iOS Safari / Android Chrome)
- [ ] Production smoke: open speaker chat on mobile → drawer slides up 85dvh with grab handle; on desktop → docked panel

Auto-merge is handled by [`.github/workflows/auto-merge-release.yml`](.github/workflows/auto-merge-release.yml) (matches `Release:` title prefix).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTVMtj9Sb1ispK9QXiYWyg)_