### PR TITLE
docs(workflow): forbid stacked PRs in CLAUDE.md + feature-branch skill

### DIFF
--- a/.claude/skills/feature-branch-workflow.md
+++ b/.claude/skills/feature-branch-workflow.md
@@ -117,6 +117,17 @@ git fetch --prune origin                   # drops the remote-tracking ref
 - **Don't commit directly to `develop`** — even for a one-line doc
   fix. GitHub isn't enforcing this on the free tier; discipline is.
 - **Don't commit directly to `main`** — ever.
+- **Don't stack PRs.** Every PR's base must be `develop` (or `main`
+  for a release PR), never another feature branch. Stacked PRs become
+  orphans the moment the parent branch is deleted post-merge — see
+  PR #173, which was based on `feat/prayer-chat-parity`, sat dirty
+  when that base was deleted, and stranded 13 commits of finished
+  work (including the merged-but-stranded #175 plan-prayers wizard)
+  outside of `develop` for a full release cycle. If a feature
+  naturally splits into multiple PRs, ship the foundational PR first,
+  wait for it to merge into `develop`, then branch the next slice off
+  the new `develop`. The cost of waiting one CI cycle is far less
+  than the cost of an orphaned stack.
 - **Don't force-push to `develop` or `main`**, even with
   `--force-with-lease`. (The `release-to-main` skill used to, for
   drift cleanup. It no longer does, because merge-commit-only is now

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ PWA for a ward bishopric to plan weekly sacrament meeting programs. Desktop + mo
 - **Eight Cloud Functions, no API server.** The list above is the full surface; expanding it requires a deliberate scope decision. Firestore rules carry the rest of the authorization logic.
 - **Multi-ward from day one.** All data scoped under `wards/{wardId}/`.
 - **No direct pushes to `develop` or `main`.** Every change flows through a PR: feature branch → PR into `develop` (see the [`feature-branch-workflow`](.claude/skills/feature-branch-workflow.md) skill); releases go via PR from `develop` → `main` (see [`release-to-main`](.claude/skills/release-to-main.md)). GitHub's free tier doesn't enforce this — discipline does. No force-pushes to either branch, ever.
+- **No stacked PRs.** Every PR's base must be `develop` (or `main` for a release PR), never another feature branch. Stacked PRs orphan the moment the parent branch is deleted post-merge — finished work strands outside `develop` and won't ship. If a feature splits into multiple PRs, merge the foundation into `develop` first, then branch the next slice off the new `develop`.
 - **Merge-commit is the only enabled merge method** at the repo level (squash + rebase disabled). Keeps `develop` and `main` SHA-aligned and prevents "N ahead / N behind" drift.
 - **Every push to `develop` runs the full CI pipeline.** Lint + format + typecheck + unit + rules + e2e. All must pass; no retries on flakes.
 


### PR DESCRIPTION
## Summary

Codifies the no-stacked-PRs rule the user just gave the agent. Lesson learned from PR [#173](https://github.com/aylabyuk/steward/pull/173): it was based on the parent feature branch `feat/prayer-chat-parity`, which was deleted post-merge. The deletion orphaned #173 (`mergeable_state: "dirty"`), which in turn stranded **13 commits of finished work** outside `develop` for a full release cycle — including the merged-but-orphaned [#175](https://github.com/aylabyuk/steward/pull/175) (`feat(plan-prayers): full wizard`, +1100 / -281). Recovered via [#178](https://github.com/aylabyuk/steward/pull/178), but the right answer is to never let it happen.

## Changes

- **`CLAUDE.md` Hard rules** — adds a one-liner: every PR's base must be `develop` (or `main` for a release PR), never another feature branch.
- **`.claude/skills/feature-branch-workflow.md`** — adds a longer "What NOT to do" entry citing the #173 / #175 case as the cautionary example, and the corrective pattern: ship the foundation first, wait for it to land on `develop`, then branch the next slice off the new `develop`.

## Test plan

- [ ] CI green
- [ ] Future agent sessions: when planning multi-slice features, the model proposes shipping each slice as a PR off `develop` (not as a stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTVMtj9Sb1ispK9QXiYWyg)_