### PR TITLE
fix(plan-prayers): expose role so roster Continue works

### DIFF
--- a/src/features/plan-prayers/PrayerRosterStep.tsx
+++ b/src/features/plan-prayers/PrayerRosterStep.tsx
@@ -21,16 +21,20 @@ export function PrayerRosterStep({ wardId, date, onContinue }: Props) {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const validCount = [opening, benediction].filter((r) => r.name.trim()).length;
+  const rows = [
+    { role: "opening" as const, row: opening },
+    { role: "benediction" as const, row: benediction },
+  ];
+  const validCount = rows.filter(({ row }) => row.name.trim()).length;
   const canContinue = validCount > 0 && !saving;
 
   async function handleContinue() {
     setError(null);
     setSaving(true);
     try {
-      for (const row of [opening, benediction]) {
+      for (const { role, row } of rows) {
         if (!row.name.trim()) continue;
-        await upsertPrayerParticipant(wardId, date, row.role, {
+        await upsertPrayerParticipant(wardId, date, role, {
           name: row.name.trim(),
           email: row.email.trim(),
           phone: row.phone.trim(),

--- a/src/features/plan-prayers/usePrayerPlanRow.ts
+++ b/src/features/plan-prayers/usePrayerPlanRow.ts
@@ -4,9 +4,6 @@ import { useMeeting } from "@/hooks/useMeeting";
 import { usePrayerParticipant } from "@/features/prayers/usePrayerParticipant";
 
 interface Result {
-  /** Mirrors the `role` argument so the consumer can pass the row
-   *  straight into writers without re-threading it. */
-  role: PrayerRole;
   /** Effective name — participant doc takes precedence over the
    *  inline `meeting.{role}.person.name` Assignment row. */
   name: string;
@@ -73,7 +70,6 @@ export function usePrayerPlanRow(date: string, role: PrayerRole): Result {
   ]);
 
   return {
-    role,
     name,
     email,
     phone,

--- a/src/features/plan-prayers/usePrayerPlanRow.ts
+++ b/src/features/plan-prayers/usePrayerPlanRow.ts
@@ -4,6 +4,9 @@ import { useMeeting } from "@/hooks/useMeeting";
 import { usePrayerParticipant } from "@/features/prayers/usePrayerParticipant";
 
 interface Result {
+  /** Mirrors the `role` argument so the consumer can pass the row
+   *  straight into writers without re-threading it. */
+  role: PrayerRole;
   /** Effective name — participant doc takes precedence over the
    *  inline `meeting.{role}.person.name` Assignment row. */
   name: string;
@@ -70,6 +73,7 @@ export function usePrayerPlanRow(date: string, role: PrayerRole): Result {
   ]);
 
   return {
+    role,
     name,
     email,
     phone,


### PR DESCRIPTION
## Summary

- `PrayerRosterStep` iterates `[opening, benediction]` and calls `upsertPrayerParticipant(wardId, date, row.role, ...)`, but `usePrayerPlanRow`'s `Result` never returned `role` — so the third argument was `undefined`.
- Firestore's `doc(..., "prayers", undefined)` then crashes in path validation with `"Cannot read properties of undefined (reading 'indexOf')"` — the error the bishop saw under the Continue button after filling both prayer-giver names.
- Mirror the hook's `role` argument back through the returned object so the consumer pattern `(row.role)` resolves.

## Test plan

- [ ] On `/plan/:date/prayers`, fill Opening + Benediction names, tap Continue → advances to invitation step (no error banner).
- [ ] Inspect Firestore — `meetings/{date}/prayers/opening` and `…/benediction` docs both written with the typed names.
- [ ] Mirror still lands on `meeting.openingPrayer.person.name` / `meeting.benediction.person.name` (covered by the prior fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)