### PR TITLE
feat(mobile): schedule list view, native bottom sheets, side drawer

### DIFF
--- a/functions/src/messageTemplates.test.ts
+++ b/functions/src/messageTemplates.test.ts
@@ -8,7 +8,7 @@ import { interpolate, readMessageTemplate } from "./messageTemplates.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLIENT_DEFAULTS_PATH = resolve(
   __dirname,
-  "../../src/features/templates/serverTemplateDefaults.ts",
+  "../../src/features/templates/utils/serverTemplateDefaults.ts",
 );
 
 describe("interpolate", () => {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-markdown": "^10.1.0",
     "react-router": "^7.14.1",
     "react-zoom-pan-pinch": "^4.0.3",
+    "vaul": "^1.1.2",
     "zod": "^4.3.6",
     "zustand": "^5.0.12"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,12 +71,15 @@ importers:
       react-zoom-pan-pinch:
         specifier: ^4.0.3
         version: 4.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
       zustand:
         specifier: ^5.0.12
-        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)
+        version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.12
@@ -1364,6 +1367,177 @@ packages:
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1972,6 +2146,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -2519,6 +2697,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
@@ -2897,6 +3078,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -4251,6 +4436,26 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router@7.14.1:
     resolution: {integrity: sha512-5BCvFskyAAVumqhEKh/iPhLOIkfxcEUz8WqFIARCkMg8hZZzDYX9CtwxXA0e+qT8zAxmMC0x3Ckb9iMONwc5jg==}
     engines: {node: '>=20.0.0'}
@@ -4259,6 +4464,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react-zoom-pan-pinch@4.0.3:
@@ -4826,6 +5041,31 @@ packages:
   url-template@2.0.8:
     resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4861,6 +5101,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
@@ -6463,6 +6709,149 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.5)
+      aria-hidden: 1.2.6
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.5)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
@@ -7073,6 +7462,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -7608,6 +8001,8 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   devlop@1.1.0:
     dependencies:
@@ -8235,6 +8630,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.3
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-proto@1.0.1:
     dependencies:
@@ -9789,6 +10186,25 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.5)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.5)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.5)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-router@7.14.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       cookie: 1.1.1
@@ -9796,6 +10212,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react-zoom-pan-pinch@4.0.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -10541,6 +10965,26 @@ snapshots:
 
   url-template@2.0.8: {}
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.5
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optional: true
+
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
@@ -10562,6 +11006,15 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   vary@1.1.2: {}
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vfile-message@4.0.3:
     dependencies:
@@ -10799,9 +11252,10 @@ snapshots:
 
   zod@4.3.6: {}
 
-  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5):
+  zustand@5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:
       '@types/react': 19.2.14
       react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
 
   zwitch@2.0.4: {}

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import { Outlet } from "react-router";
 import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { useHideOnScroll } from "./hooks/useHideOnScroll";
@@ -13,22 +12,8 @@ export function AppShell() {
   const isMobile = useIsMobile();
   const hidden = useHideOnScroll(isMobile);
   const drawerOpen = useUserMenuStore((s) => s.open);
-  // The mobile drawer "pushes" the page off-screen left so a small
-  // peek of the page stays visible. Lock both axes of body overflow
-  // while open so the off-screen content can't be panned into view
-  // and the underlying page can't scroll vertically behind the drawer.
-  useEffect(() => {
-    if (!drawerOpen || !isMobile) return;
-    const prevX = document.body.style.overflowX;
-    const prevY = document.body.style.overflowY;
-    document.body.style.overflowX = "hidden";
-    document.body.style.overflowY = "hidden";
-    return () => {
-      document.body.style.overflowX = prevX;
-      document.body.style.overflowY = prevY;
-    };
-  }, [drawerOpen, isMobile]);
-
+  // Vaul handles body-scroll lock on its own when the side drawer
+  // opens; we only need to push the page transform here.
   const pushed = drawerOpen && isMobile;
 
   return (

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -1,36 +1,62 @@
+import { useEffect } from "react";
 import { Outlet } from "react-router";
 import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { useHideOnScroll } from "./hooks/useHideOnScroll";
 import { useIsMobile } from "@/hooks/useMediaQuery";
+import { useUserMenuStore } from "@/stores/userMenuStore";
 import { cn } from "@/lib/cn";
 import { OnlineStatusBanner } from "./OnlineStatusBanner";
 import { Topbar } from "./Topbar";
+import { UserSideDrawer } from "./UserSideDrawer";
 
 export function AppShell() {
   const isMobile = useIsMobile();
   const hidden = useHideOnScroll(isMobile);
+  const drawerOpen = useUserMenuStore((s) => s.open);
+  // The mobile drawer "pushes" the page off-screen left so a small
+  // peek of the page stays visible on the right of the drawer. Lock
+  // body horizontal overflow while open so the off-screen content
+  // can't be panned into view.
+  useEffect(() => {
+    if (!drawerOpen || !isMobile) return;
+    const prev = document.body.style.overflowX;
+    document.body.style.overflowX = "hidden";
+    return () => {
+      document.body.style.overflowX = prev;
+    };
+  }, [drawerOpen, isMobile]);
+
+  const pushed = drawerOpen && isMobile;
+
   return (
-    <div className="flex min-h-dvh flex-col bg-parchment paper-grain">
-      {/* Topbar + connection banner travel together — wrapping them in a
-          single sticky container keeps the banner pinned right below the
-          topbar without depending on a hardcoded topbar height. On mobile
-          the wrapper slides off-screen on scroll-down and returns on
-          scroll-up, mirroring native auto-hiding navigation bars. */}
+    <div className="min-h-dvh bg-parchment paper-grain overflow-x-hidden">
       <div
         className={cn(
-          "sticky top-0 z-20 transition-transform duration-200 ease-out will-change-transform",
-          hidden && "-translate-y-full",
+          "min-h-dvh flex flex-col transition-transform duration-300 ease-out will-change-transform",
+          pushed && "-translate-x-[85vw]",
         )}
+        // While pushed, taps on the visible peek shouldn't activate
+        // the page underneath — the side drawer's own backdrop button
+        // handles dismissal.
+        aria-hidden={pushed}
       >
-        <Topbar />
-        <OnlineStatusBanner />
+        <div
+          className={cn(
+            "sticky top-0 z-20 transition-transform duration-200 ease-out will-change-transform",
+            hidden && "-translate-y-full",
+          )}
+        >
+          <Topbar />
+          <OnlineStatusBanner />
+        </div>
+        <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
+          <Outlet />
+        </div>
+        <footer className="flex justify-center py-3 px-4">
+          <BuiltByCredit />
+        </footer>
       </div>
-      <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
-        <Outlet />
-      </div>
-      <footer className="flex justify-center py-3 px-4">
-        <BuiltByCredit />
-      </footer>
+      <UserSideDrawer />
     </div>
   );
 }

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -2,7 +2,6 @@ import { Outlet } from "react-router";
 import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { useHideOnScroll } from "./hooks/useHideOnScroll";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useUserMenuStore } from "@/stores/userMenuStore";
 import { cn } from "@/lib/cn";
 import { OnlineStatusBanner } from "./OnlineStatusBanner";
 import { Topbar } from "./Topbar";
@@ -11,45 +10,24 @@ import { UserSideDrawer } from "./UserSideDrawer";
 export function AppShell() {
   const isMobile = useIsMobile();
   const hidden = useHideOnScroll(isMobile);
-  const drawerOpen = useUserMenuStore((s) => s.open);
-  // Vaul handles body-scroll lock on its own when the side drawer
-  // opens; we only need to push the page transform here.
-  const pushed = drawerOpen && isMobile;
 
   return (
-    <div className="min-h-dvh bg-parchment paper-grain overflow-x-clip">
+    <div className="flex min-h-dvh flex-col bg-parchment paper-grain">
       <div
         className={cn(
-          // Note: no `will-change-transform` here. Setting it would
-          // promote this wrapper into a containing block for the
-          // sticky-positioned descendants inside (the schedule's
-          // sticky week header, etc.), breaking their stick-to-
-          // viewport behavior. The 300ms translate animates fine
-          // without the hint on modern browsers.
-          "min-h-dvh flex flex-col transition-transform duration-300 ease-out",
-          pushed && "-translate-x-[85vw]",
+          "sticky top-0 z-20 transition-transform duration-200 ease-out will-change-transform",
+          hidden && "-translate-y-full",
         )}
-        // While pushed, taps on the visible peek shouldn't activate
-        // the page underneath — the side drawer's own backdrop button
-        // handles dismissal.
-        aria-hidden={pushed}
       >
-        <div
-          className={cn(
-            "sticky top-0 z-20 transition-transform duration-200 ease-out will-change-transform",
-            hidden && "-translate-y-full",
-          )}
-        >
-          <Topbar />
-          <OnlineStatusBanner />
-        </div>
-        <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
-          <Outlet />
-        </div>
-        <footer className="flex justify-center py-3 px-4">
-          <BuiltByCredit />
-        </footer>
+        <Topbar />
+        <OnlineStatusBanner />
       </div>
+      <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
+        <Outlet />
+      </div>
+      <footer className="flex justify-center py-3 px-4">
+        <BuiltByCredit />
+      </footer>
       {isMobile && <UserSideDrawer />}
     </div>
   );

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -14,15 +14,18 @@ export function AppShell() {
   const hidden = useHideOnScroll(isMobile);
   const drawerOpen = useUserMenuStore((s) => s.open);
   // The mobile drawer "pushes" the page off-screen left so a small
-  // peek of the page stays visible on the right of the drawer. Lock
-  // body horizontal overflow while open so the off-screen content
-  // can't be panned into view.
+  // peek of the page stays visible. Lock both axes of body overflow
+  // while open so the off-screen content can't be panned into view
+  // and the underlying page can't scroll vertically behind the drawer.
   useEffect(() => {
     if (!drawerOpen || !isMobile) return;
-    const prev = document.body.style.overflowX;
+    const prevX = document.body.style.overflowX;
+    const prevY = document.body.style.overflowY;
     document.body.style.overflowX = "hidden";
+    document.body.style.overflowY = "hidden";
     return () => {
-      document.body.style.overflowX = prev;
+      document.body.style.overflowX = prevX;
+      document.body.style.overflowY = prevY;
     };
   }, [drawerOpen, isMobile]);
 

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -65,7 +65,7 @@ export function AppShell() {
           <BuiltByCredit />
         </footer>
       </div>
-      <UserSideDrawer />
+      {isMobile && <UserSideDrawer />}
     </div>
   );
 }

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -32,7 +32,7 @@ export function AppShell() {
   const pushed = drawerOpen && isMobile;
 
   return (
-    <div className="min-h-dvh bg-parchment paper-grain overflow-x-hidden">
+    <div className="min-h-dvh bg-parchment paper-grain overflow-x-clip">
       <div
         className={cn(
           // Note: no `will-change-transform` here. Setting it would

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -35,7 +35,13 @@ export function AppShell() {
     <div className="min-h-dvh bg-parchment paper-grain overflow-x-hidden">
       <div
         className={cn(
-          "min-h-dvh flex flex-col transition-transform duration-300 ease-out will-change-transform",
+          // Note: no `will-change-transform` here. Setting it would
+          // promote this wrapper into a containing block for the
+          // sticky-positioned descendants inside (the schedule's
+          // sticky week header, etc.), breaking their stick-to-
+          // viewport behavior. The 300ms translate animates fine
+          // without the hint on modern browsers.
+          "min-h-dvh flex flex-col transition-transform duration-300 ease-out",
           pushed && "-translate-x-[85vw]",
         )}
         // While pushed, taps on the visible peek shouldn't activate

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -6,12 +6,12 @@ export function Topbar() {
   const ward = useWardSettings();
   const wardName = ward.data?.name;
   return (
-    <div className="border-b border-border bg-parchment-2 sm:bg-parchment/82 sm:backdrop-blur-sm">
+    <div className="bg-walnut border-b border-walnut sm:border-border sm:bg-parchment/82 sm:backdrop-blur-sm">
       <div className="flex items-center gap-3 px-4 py-2.5 sm:gap-4 sm:px-8 sm:py-3.5">
         <Link
           to="/"
           aria-label="Steward — back to schedule"
-          className="flex items-center gap-2.5 shrink-0 -m-1 p-1 rounded-md hover:bg-parchment-2/60 transition-colors"
+          className="flex items-center gap-2.5 shrink-0 -m-1 p-1 rounded-md hover:bg-walnut-2/40 sm:hover:bg-parchment-2/60 transition-colors"
         >
           <img src="/icons/logo-monogram.svg" alt="" className="h-6 w-6" />
           <div className="hidden sm:flex flex-col items-center leading-none">
@@ -26,7 +26,7 @@ export function Topbar() {
             <span aria-hidden className="hidden sm:inline text-walnut-3">
               ·
             </span>
-            <span className="font-serif text-[15px] sm:text-[14px] text-walnut sm:text-walnut-2 truncate min-w-0 flex-1 sm:flex-initial sm:max-w-[40vw]">
+            <span className="font-serif text-[15px] sm:text-[14px] text-parchment-2 sm:text-walnut-2 truncate min-w-0 flex-1 sm:flex-initial sm:max-w-[40vw]">
               {wardName}
             </span>
           </>

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -6,7 +6,7 @@ export function Topbar() {
   const ward = useWardSettings();
   const wardName = ward.data?.name;
   return (
-    <div className="border-b border-border bg-parchment/82 backdrop-blur-sm">
+    <div className="border-b border-border bg-parchment-2 sm:bg-parchment/82 sm:backdrop-blur-sm">
       <div className="flex items-center gap-3 px-4 py-2.5 sm:gap-4 sm:px-8 sm:py-3.5">
         <Link
           to="/"

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -6,7 +6,7 @@ export function Topbar() {
   const ward = useWardSettings();
   const wardName = ward.data?.name;
   return (
-    <div className="bg-walnut border-b border-walnut sm:border-border sm:bg-parchment/82 sm:backdrop-blur-sm">
+    <div className="bg-walnut border-b border-walnut shadow-elev-1 sm:border-border sm:bg-parchment/82 sm:backdrop-blur-sm">
       <div className="flex items-center gap-3 px-4 py-2.5 sm:gap-4 sm:px-8 sm:py-3.5">
         <Link
           to="/"

--- a/src/app/components/UserMenu.tsx
+++ b/src/app/components/UserMenu.tsx
@@ -67,11 +67,16 @@ export function UserMenu() {
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-haspopup="menu"
-        className="inline-flex items-center gap-2.5 rounded-full border border-transparent bg-transparent px-2.5 py-1 text-walnut transition-all hover:border-border hover:bg-chalk"
+        className="inline-flex items-center gap-2.5 rounded-full border border-transparent bg-transparent px-2.5 py-1 text-parchment-2 sm:text-walnut transition-all hover:border-border hover:bg-chalk"
       >
         <Avatar user={avatarUser} size="sm" />
         <span className="hidden text-sm font-medium sm:inline">{name}</span>
-        <span className={cn("text-walnut-3 transition-transform", open && "rotate-180")}>
+        <span
+          className={cn(
+            "text-parchment-3 sm:text-walnut-3 transition-transform",
+            open && "rotate-180",
+          )}
+        >
           <ChevronDown size={13} />
         </span>
       </button>

--- a/src/app/components/UserMenu.tsx
+++ b/src/app/components/UserMenu.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { Avatar } from "@/components/ui/Avatar";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useAuthStore } from "@/stores/authStore";
+import { useUserMenuStore } from "@/stores/userMenuStore";
 import { cn } from "@/lib/cn";
-import { MenuItemDisabled, MenuLink, MenuLinkWithToggle } from "./UserMenuItems";
-import { useDevicePushToggle } from "./hooks/useDevicePushToggle";
+import { UserMenuContent } from "./UserMenuContent";
 
 function ChevronDown({ size = 14 }: { size?: number }) {
   return (
@@ -23,19 +24,22 @@ function ChevronDown({ size = 14 }: { size?: number }) {
 
 export function UserMenu() {
   const user = useAuthStore((s) => s.user);
-  const signOut = useAuthStore((s) => s.signOut);
   const me = useCurrentMember();
-  const push = useDevicePushToggle();
-  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const open = useUserMenuStore((s) => s.open);
+  const toggle = useUserMenuStore((s) => s.toggle);
+  const close = useUserMenuStore((s) => s.close);
   const ref = useRef<HTMLDivElement>(null);
 
+  // Outside-click + Escape only close the desktop popover. The mobile
+  // side drawer handles its own dismissal (backdrop tap, drawer ESC).
   useEffect(() => {
-    if (!open) return;
+    if (!open || isMobile) return;
     const onDoc = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) close();
     };
     const onEsc = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") close();
     };
     document.addEventListener("mousedown", onDoc);
     document.addEventListener("keydown", onEsc);
@@ -43,11 +47,8 @@ export function UserMenu() {
       document.removeEventListener("mousedown", onDoc);
       document.removeEventListener("keydown", onEsc);
     };
-  }, [open]);
+  }, [open, isMobile, close]);
 
-  // Prefer the member doc (always written with the full name by the
-  // add-member script) over the Auth-level displayName, which may only
-  // be a first name depending on how the user originally signed in.
   const name = me?.data.displayName || user?.displayName || "User";
   const avatarUser = {
     uid: user?.uid ?? null,
@@ -55,16 +56,10 @@ export function UserMenu() {
     photoURL: user?.photoURL ?? me?.data.photoURL ?? null,
   };
 
-  const handleSignOut = async () => {
-    await signOut();
-    setOpen(false);
-  };
-  const close = () => setOpen(false);
-
   return (
     <div ref={ref} className="relative">
       <button
-        onClick={() => setOpen((v) => !v)}
+        onClick={toggle}
         aria-expanded={open}
         aria-haspopup="menu"
         className="inline-flex items-center gap-2.5 rounded-full border border-transparent bg-transparent px-2.5 py-1 text-parchment-2 sm:text-walnut transition-all hover:border-border hover:bg-chalk"
@@ -81,65 +76,12 @@ export function UserMenu() {
         </span>
       </button>
 
-      {open && (
+      {open && !isMobile && (
         <div
           className="absolute right-0 top-full mt-2 w-60 rounded-lg border border-border bg-chalk shadow-elev-3 z-50 animate-[menuIn_120ms_var(--ease-out)]"
           role="menu"
         >
-          <div className="flex items-center gap-3 border-b border-border px-2.5 py-2.5">
-            <Avatar user={avatarUser} size="lg" />
-            <div className="min-w-0">
-              <div className="truncate text-sm font-medium text-walnut">{name}</div>
-              <div className="truncate text-[11px] text-walnut-3">{user?.email}</div>
-            </div>
-          </div>
-
-          <MenuLink to="/settings/profile" onClick={close}>
-            Profile
-          </MenuLink>
-          <MenuLinkWithToggle
-            to="/settings/notifications"
-            onClickLink={close}
-            label="Notifications"
-            toggleChecked={push.checked}
-            toggleDisabled={!push.ready || push.busy}
-            toggleAriaLabel="Push notifications on this device"
-            onToggleChange={(next) => void push.toggle(next)}
-          />
-          <MenuLink to="/settings/ward" onClick={close}>
-            Ward settings
-          </MenuLink>
-
-          <div className="border-t border-border" />
-
-          <MenuLink to="/settings/templates" onClick={close}>
-            Templates
-          </MenuLink>
-          <MenuItemDisabled label="About" hint="Coming soon" />
-
-          <div className="border-t border-border" />
-
-          <button
-            onClick={handleSignOut}
-            role="menuitem"
-            className="w-full px-2.5 py-2 text-left text-sm text-bordeaux transition-colors hover:rounded hover:bg-danger-soft"
-          >
-            Sign out
-          </button>
-
-          <div className="border-t border-border" />
-
-          <a
-            href={`https://github.com/aylabyuk/steward/releases/tag/v${__APP_VERSION__}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            onClick={close}
-            role="menuitem"
-            aria-label={`Version ${__APP_VERSION__} — open release notes`}
-            className="block px-2.5 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut hover:bg-parchment-2 hover:rounded transition-colors"
-          >
-            v{__APP_VERSION__} ↗
-          </a>
+          <UserMenuContent onClose={close} />
         </div>
       )}
     </div>

--- a/src/app/components/UserMenuContent.tsx
+++ b/src/app/components/UserMenuContent.tsx
@@ -40,9 +40,9 @@ export function UserMenuContent({ onClose }: Props) {
 
   return (
     <>
-      <div className="flex items-center gap-3 border-b border-border px-2.5 py-2.5">
+      <div className="flex flex-col items-center gap-2 sm:flex-row sm:items-center sm:gap-3 border-b border-border px-2.5 py-3 sm:py-2.5">
         <Avatar user={avatarUser} size="lg" />
-        <div className="min-w-0">
+        <div className="min-w-0 text-center sm:text-left">
           <div className="truncate text-sm font-medium text-walnut">{name}</div>
           <div className="truncate text-[11px] text-walnut-3">{user?.email}</div>
         </div>

--- a/src/app/components/UserMenuContent.tsx
+++ b/src/app/components/UserMenuContent.tsx
@@ -1,4 +1,5 @@
 import { Avatar } from "@/components/ui/Avatar";
+import { BuiltByCredit } from "@/components/BuiltByCredit";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useAuthStore } from "@/stores/authStore";
 import { MenuItemDisabled, MenuLink, MenuLinkWithToggle } from "./UserMenuItems";
@@ -81,19 +82,23 @@ export function UserMenuContent({ onClose }: Props) {
         Sign out
       </button>
 
-      <div className="border-t border-border" />
-
-      <a
-        href={`https://github.com/aylabyuk/steward/releases/tag/v${__APP_VERSION__}`}
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={onClose}
-        role="menuitem"
-        aria-label={`Version ${__APP_VERSION__} — open release notes`}
-        className="block px-2.5 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut hover:bg-parchment-2 hover:rounded transition-colors"
-      >
-        v{__APP_VERSION__} ↗
-      </a>
+      {/* Credit + version pinned to the bottom. `mt-auto` only takes
+       *  effect when the host is a flex column (the mobile drawer);
+       *  in the desktop popover the block sits naturally at the end. */}
+      <div className="mt-auto flex flex-col items-center gap-1.5 pt-4 pb-1 px-2.5 border-t border-border">
+        <BuiltByCredit className="text-center" />
+        <a
+          href={`https://github.com/aylabyuk/steward/releases/tag/v${__APP_VERSION__}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={onClose}
+          role="menuitem"
+          aria-label={`Version ${__APP_VERSION__} — open release notes`}
+          className="font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut transition-colors"
+        >
+          v{__APP_VERSION__} ↗
+        </a>
+      </div>
     </>
   );
 }

--- a/src/app/components/UserMenuContent.tsx
+++ b/src/app/components/UserMenuContent.tsx
@@ -1,0 +1,99 @@
+import { Avatar } from "@/components/ui/Avatar";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useAuthStore } from "@/stores/authStore";
+import { MenuItemDisabled, MenuLink, MenuLinkWithToggle } from "./UserMenuItems";
+import { useDevicePushToggle } from "./hooks/useDevicePushToggle";
+
+interface Props {
+  /** Closes the surface that's hosting the content (popover on
+   *  desktop, side drawer on mobile). Called after each link nav so
+   *  the surface dismisses on selection. */
+  onClose: () => void;
+}
+
+/** The body of the user menu — header with avatar/name/email, the
+ *  navigation items, sign-out, and the version link. Shared between
+ *  the desktop popover (rendered inline next to the trigger) and the
+ *  mobile side drawer (rendered at AppShell level so it can push the
+ *  page content). */
+export function UserMenuContent({ onClose }: Props) {
+  const user = useAuthStore((s) => s.user);
+  const signOut = useAuthStore((s) => s.signOut);
+  const me = useCurrentMember();
+  const push = useDevicePushToggle();
+
+  // Prefer the member doc (always written with the full name by the
+  // add-member script) over the Auth-level displayName, which may only
+  // be a first name depending on how the user originally signed in.
+  const name = me?.data.displayName || user?.displayName || "User";
+  const avatarUser = {
+    uid: user?.uid ?? null,
+    displayName: name,
+    photoURL: user?.photoURL ?? me?.data.photoURL ?? null,
+  };
+
+  const handleSignOut = async () => {
+    await signOut();
+    onClose();
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-3 border-b border-border px-2.5 py-2.5">
+        <Avatar user={avatarUser} size="lg" />
+        <div className="min-w-0">
+          <div className="truncate text-sm font-medium text-walnut">{name}</div>
+          <div className="truncate text-[11px] text-walnut-3">{user?.email}</div>
+        </div>
+      </div>
+
+      <MenuLink to="/settings/profile" onClick={onClose}>
+        Profile
+      </MenuLink>
+      <MenuLinkWithToggle
+        to="/settings/notifications"
+        onClickLink={onClose}
+        label="Notifications"
+        toggleChecked={push.checked}
+        toggleDisabled={!push.ready || push.busy}
+        toggleAriaLabel="Push notifications on this device"
+        onToggleChange={(next) => void push.toggle(next)}
+      />
+      <MenuLink to="/settings/ward" onClick={onClose}>
+        Ward settings
+      </MenuLink>
+
+      <div className="border-t border-border" />
+
+      <MenuLink to="/settings/templates" onClick={onClose}>
+        Templates
+      </MenuLink>
+      <MenuItemDisabled label="About" hint="Coming soon" />
+
+      <div className="border-t border-border" />
+
+      <button
+        onClick={handleSignOut}
+        type="button"
+        role="menuitem"
+        className="w-full px-2.5 py-2 text-left text-sm text-bordeaux transition-colors hover:rounded hover:bg-danger-soft"
+      >
+        Sign out
+      </button>
+
+      <div className="border-t border-border" />
+
+      <a
+        href={`https://github.com/aylabyuk/steward/releases/tag/v${__APP_VERSION__}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={onClose}
+        role="menuitem"
+        aria-label={`Version ${__APP_VERSION__} — open release notes`}
+        className="block px-2.5 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut hover:bg-parchment-2 hover:rounded transition-colors"
+      >
+        v{__APP_VERSION__} ↗
+      </a>
+    </>
+  );
+}

--- a/src/app/components/UserMenuContent.tsx
+++ b/src/app/components/UserMenuContent.tsx
@@ -40,8 +40,12 @@ export function UserMenuContent({ onClose }: Props) {
 
   return (
     <>
-      <div className="flex flex-col items-center gap-2 sm:flex-row sm:items-center sm:gap-3 border-b border-border px-2.5 py-3 sm:py-2.5">
-        <Avatar user={avatarUser} size="lg" />
+      <div className="flex flex-col items-center gap-2 sm:flex-row sm:items-center sm:gap-3 border-b border-border px-2.5 py-4 sm:py-2.5">
+        <Avatar
+          user={avatarUser}
+          size="lg"
+          className="w-16 h-16 text-xl sm:w-10 sm:h-10 sm:text-[13px]"
+        />
         <div className="min-w-0 text-center sm:text-left">
           <div className="truncate text-sm font-medium text-walnut">{name}</div>
           <div className="truncate text-[11px] text-walnut-3">{user?.email}</div>

--- a/src/app/components/UserSideDrawer.tsx
+++ b/src/app/components/UserSideDrawer.tsx
@@ -74,6 +74,28 @@ export function UserSideDrawer() {
             : "animate-[drawerSlideInRight_280ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
         )}
       >
+        <div className="flex items-center justify-end px-3 pt-2 pb-1">
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close menu"
+            className="w-9 h-9 inline-flex items-center justify-center rounded-md text-walnut-3 hover:text-walnut hover:bg-parchment-2 transition-colors"
+          >
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
         <UserMenuContent onClose={close} />
       </aside>
     </>,

--- a/src/app/components/UserSideDrawer.tsx
+++ b/src/app/components/UserSideDrawer.tsx
@@ -1,105 +1,59 @@
-import { useEffect, useState } from "react";
-import { createPortal } from "react-dom";
+import { Drawer } from "vaul";
 import { useUserMenuStore } from "@/stores/userMenuStore";
-import { cn } from "@/lib/cn";
 import { UserMenuContent } from "./UserMenuContent";
 
-const EXIT_MS = 250;
-
-/** Mobile-only side drawer that hosts the user menu content. Renders
- *  as a sibling to the AppShell content (portaled to body) so it can
- *  float above the page-push transform without being clipped by it.
- *  Slides in from the right; on dismissal, slides back out and stays
- *  mounted through the exit animation. The actual page-push effect
- *  (translating the content area left to reveal the drawer + leave a
- *  small page peek) lives in AppShell so the transform applies to the
- *  outer wrapper. */
+/** Mobile-only right-side drawer that hosts the user menu content.
+ *  Backed by `vaul`'s Drawer with `direction="right"` so we get
+ *  drag-to-dismiss, ESC, and spring animations as built-ins.
+ *
+ *  AppShell does its own page-push transform when the drawer is open
+ *  (translates the content -85vw to leave a 15vw peek). Vaul's overlay
+ *  is rendered transparent so the peek stays visible and receives the
+ *  tap-to-dismiss directly via `onOpenChange`. */
 export function UserSideDrawer() {
   const open = useUserMenuStore((s) => s.open);
   const close = useUserMenuStore((s) => s.close);
 
-  const [mounted, setMounted] = useState(open);
-  const [exiting, setExiting] = useState(false);
-
-  useEffect(() => {
-    if (open) {
-      setMounted(true);
-      setExiting(false);
-      return;
-    }
-    if (!mounted) return;
-    setExiting(true);
-    const t = setTimeout(() => {
-      setMounted(false);
-      setExiting(false);
-    }, EXIT_MS);
-    return () => clearTimeout(t);
-  }, [open, mounted]);
-
-  useEffect(() => {
-    if (!open) return;
-    const onEsc = (e: KeyboardEvent) => {
-      if (e.key !== "Escape") return;
-      e.stopImmediatePropagation();
-      close();
-    };
-    document.addEventListener("keydown", onEsc, true);
-    return () => document.removeEventListener("keydown", onEsc, true);
-  }, [open, close]);
-
-  if (!mounted) return null;
-  if (typeof document === "undefined") return null;
-
-  return createPortal(
-    <>
-      <button
-        type="button"
-        aria-label="Close menu"
-        onClick={close}
-        className={cn(
-          "fixed inset-y-0 left-0 w-[15vw] z-50 bg-transparent",
-          exiting
-            ? "animate-[fadeOut_200ms_ease-in_forwards]"
-            : "animate-[fade_200ms_ease-out_backwards]",
-        )}
-      />
-      <aside
-        role="dialog"
-        aria-modal="true"
-        aria-label="User menu"
-        className={cn(
-          "fixed inset-y-0 right-0 w-[85vw] z-50 bg-chalk shadow-elev-3 flex flex-col overflow-y-auto pt-[env(safe-area-inset-top)] pb-[max(0.75rem,env(safe-area-inset-bottom))]",
-          exiting
-            ? "animate-[drawerSlideOutRight_250ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideInRight_280ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
-        )}
-      >
-        <button
-          type="button"
-          onClick={close}
-          aria-label="Close menu"
-          // Absolute so it doesn't push the avatar header down — sits in
-          // the top-right corner against the safe-area-inset that the
-          // aside's padding already accounts for.
-          className="absolute right-2 top-[max(0.5rem,env(safe-area-inset-top))] w-9 h-9 inline-flex items-center justify-center rounded-md text-walnut-3 hover:text-walnut hover:bg-parchment-2 transition-colors z-10"
+  return (
+    <Drawer.Root
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) close();
+      }}
+      direction="right"
+    >
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-40 bg-transparent" />
+        <Drawer.Content
+          aria-describedby={undefined}
+          className="fixed inset-y-0 right-0 z-50 flex w-[85vw] flex-col bg-chalk shadow-elev-3 outline-none pt-[env(safe-area-inset-top)] pb-[max(0.75rem,env(safe-area-inset-bottom))]"
         >
-          <svg
-            width="18"
-            height="18"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden
+          <Drawer.Title className="sr-only">User menu</Drawer.Title>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close menu"
+            className="absolute right-2 top-[max(0.5rem,env(safe-area-inset-top))] w-9 h-9 inline-flex items-center justify-center rounded-md text-walnut-3 hover:text-walnut hover:bg-parchment-2 transition-colors z-10"
           >
-            <path d="M18 6L6 18M6 6l12 12" />
-          </svg>
-        </button>
-        <UserMenuContent onClose={close} />
-      </aside>
-    </>,
-    document.body,
+            <svg
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+          <div className="flex-1 overflow-y-auto flex flex-col">
+            <UserMenuContent onClose={close} />
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   );
 }

--- a/src/app/components/UserSideDrawer.tsx
+++ b/src/app/components/UserSideDrawer.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useUserMenuStore } from "@/stores/userMenuStore";
+import { cn } from "@/lib/cn";
+import { UserMenuContent } from "./UserMenuContent";
+
+const EXIT_MS = 250;
+
+/** Mobile-only side drawer that hosts the user menu content. Renders
+ *  as a sibling to the AppShell content (portaled to body) so it can
+ *  float above the page-push transform without being clipped by it.
+ *  Slides in from the right; on dismissal, slides back out and stays
+ *  mounted through the exit animation. The actual page-push effect
+ *  (translating the content area left to reveal the drawer + leave a
+ *  small page peek) lives in AppShell so the transform applies to the
+ *  outer wrapper. */
+export function UserSideDrawer() {
+  const open = useUserMenuStore((s) => s.open);
+  const close = useUserMenuStore((s) => s.close);
+
+  const [mounted, setMounted] = useState(open);
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (!mounted) return;
+    setExiting(true);
+    const t = setTimeout(() => {
+      setMounted(false);
+      setExiting(false);
+    }, EXIT_MS);
+    return () => clearTimeout(t);
+  }, [open, mounted]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      close();
+    };
+    document.addEventListener("keydown", onEsc, true);
+    return () => document.removeEventListener("keydown", onEsc, true);
+  }, [open, close]);
+
+  if (!mounted) return null;
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <>
+      <button
+        type="button"
+        aria-label="Close menu"
+        onClick={close}
+        className={cn(
+          "fixed inset-y-0 left-0 w-[15vw] z-50 bg-transparent",
+          exiting
+            ? "animate-[fadeOut_200ms_ease-in_forwards]"
+            : "animate-[fade_200ms_ease-out_backwards]",
+        )}
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-label="User menu"
+        className={cn(
+          "fixed inset-y-0 right-0 w-[85vw] z-50 bg-chalk shadow-elev-3 flex flex-col overflow-y-auto pt-[env(safe-area-inset-top)] pb-[max(0.75rem,env(safe-area-inset-bottom))]",
+          exiting
+            ? "animate-[drawerSlideOutRight_250ms_cubic-bezier(0.4,0,1,1)_forwards]"
+            : "animate-[drawerSlideInRight_280ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
+        )}
+      >
+        <UserMenuContent onClose={close} />
+      </aside>
+    </>,
+    document.body,
+  );
+}

--- a/src/app/components/UserSideDrawer.tsx
+++ b/src/app/components/UserSideDrawer.tsx
@@ -74,28 +74,29 @@ export function UserSideDrawer() {
             : "animate-[drawerSlideInRight_280ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
         )}
       >
-        <div className="flex items-center justify-end px-3 pt-2 pb-1">
-          <button
-            type="button"
-            onClick={close}
-            aria-label="Close menu"
-            className="w-9 h-9 inline-flex items-center justify-center rounded-md text-walnut-3 hover:text-walnut hover:bg-parchment-2 transition-colors"
+        <button
+          type="button"
+          onClick={close}
+          aria-label="Close menu"
+          // Absolute so it doesn't push the avatar header down — sits in
+          // the top-right corner against the safe-area-inset that the
+          // aside's padding already accounts for.
+          className="absolute right-2 top-[max(0.5rem,env(safe-area-inset-top))] w-9 h-9 inline-flex items-center justify-center rounded-md text-walnut-3 hover:text-walnut hover:bg-parchment-2 transition-colors z-10"
+        >
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
           >
-            <svg
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden
-            >
-              <path d="M18 6L6 18M6 6l12 12" />
-            </svg>
-          </button>
-        </div>
+            <path d="M18 6L6 18M6 6l12 12" />
+          </svg>
+        </button>
         <UserMenuContent onClose={close} />
       </aside>
     </>,

--- a/src/app/components/UserSideDrawer.tsx
+++ b/src/app/components/UserSideDrawer.tsx
@@ -4,12 +4,9 @@ import { UserMenuContent } from "./UserMenuContent";
 
 /** Mobile-only right-side drawer that hosts the user menu content.
  *  Backed by `vaul`'s Drawer with `direction="right"` so we get
- *  drag-to-dismiss, ESC, and spring animations as built-ins.
- *
- *  AppShell does its own page-push transform when the drawer is open
- *  (translates the content -85vw to leave a 15vw peek). Vaul's overlay
- *  is rendered transparent so the peek stays visible and receives the
- *  tap-to-dismiss directly via `onOpenChange`. */
+ *  drag-to-dismiss, ESC, backdrop tap, and spring animations as
+ *  built-ins. Overlays the page (no push transform) — tap the dimmed
+ *  backdrop to close. */
 export function UserSideDrawer() {
   const open = useUserMenuStore((s) => s.open);
   const close = useUserMenuStore((s) => s.close);
@@ -23,7 +20,7 @@ export function UserSideDrawer() {
       direction="right"
     >
       <Drawer.Portal>
-        <Drawer.Overlay className="fixed inset-0 z-40 bg-transparent" />
+        <Drawer.Overlay className="fixed inset-0 z-40 bg-[rgba(35,24,21,0.42)]" />
         <Drawer.Content
           aria-describedby={undefined}
           className="fixed inset-y-0 right-0 z-50 flex w-[85vw] flex-col bg-chalk shadow-elev-3 outline-none pt-[env(safe-area-inset-top)] pb-[max(0.75rem,env(safe-area-inset-bottom))]"

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -1,6 +1,9 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+import { cn } from "@/lib/cn";
 import type { CtaVariant } from "./SpeakerChatCTABanner";
+
+const EXIT_MS = 200;
 
 interface Props {
   /** Controlled open state so the parent can auto-open when chat
@@ -29,7 +32,27 @@ export function SpeakerChatFloatingDrawer({
   attention,
   children,
 }: Props): React.ReactElement {
-  useLockBodyScroll(open);
+  // Keep the drawer mounted through its slide-down so dismissal mirrors
+  // the slide-up entrance instead of vanishing instantly.
+  const [mounted, setMounted] = useState(open);
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (!mounted) return;
+    setExiting(true);
+    const t = setTimeout(() => {
+      setMounted(false);
+      setExiting(false);
+    }, EXIT_MS);
+    return () => clearTimeout(t);
+  }, [open, mounted]);
+
+  useLockBodyScroll(mounted && !exiting);
 
   useEffect(() => {
     if (!open) return;
@@ -42,7 +65,7 @@ export function SpeakerChatFloatingDrawer({
     return () => document.removeEventListener("keydown", handleEsc, true);
   }, [open, onOpenChange]);
 
-  if (!open) {
+  if (!mounted) {
     const label =
       attention === "reply"
         ? "Reply to the bishopric"
@@ -75,12 +98,22 @@ export function SpeakerChatFloatingDrawer({
       role="dialog"
       aria-modal="true"
       aria-label="Conversation with the bishopric"
-      className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)] flex items-end justify-center sm:justify-end sm:p-4 animate-[fade_160ms_ease-out]"
+      className={cn(
+        "fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)] flex items-end justify-center sm:justify-end sm:p-4",
+        exiting ? "animate-[fadeOut_180ms_ease-in]" : "animate-[fade_160ms_ease-out]",
+      )}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onOpenChange(false);
       }}
     >
-      <div className="bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)] sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b sm:animate-none">
+      <div
+        className={cn(
+          "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b sm:animate-none",
+          exiting
+            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",
+        )}
+      >
         <button
           type="button"
           aria-label="Close conversation"

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -108,7 +108,7 @@ export function SpeakerChatFloatingDrawer({
     >
       <div
         className={cn(
-          "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b sm:animate-none",
+          "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b",
           exiting
             ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
             : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -100,7 +100,9 @@ export function SpeakerChatFloatingDrawer({
       aria-label="Conversation with the bishopric"
       className={cn(
         "fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)] flex items-end justify-center sm:justify-end sm:p-4",
-        exiting ? "animate-[fadeOut_180ms_ease-in]" : "animate-[fade_160ms_ease-out]",
+        exiting
+          ? "animate-[fadeOut_180ms_ease-in_forwards]"
+          : "animate-[fade_160ms_ease-out_backwards]",
       )}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onOpenChange(false);
@@ -111,7 +113,7 @@ export function SpeakerChatFloatingDrawer({
           "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b",
           exiting
             ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
         )}
       >
         <button

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -1,9 +1,6 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
-import { cn } from "@/lib/cn";
+import type { ReactNode } from "react";
+import { Drawer } from "vaul";
 import type { CtaVariant } from "./SpeakerChatCTABanner";
-
-const EXIT_MS = 200;
 
 interface Props {
   /** Controlled open state so the parent can auto-open when chat
@@ -18,115 +15,66 @@ interface Props {
 }
 
 /** Floating chat drawer for the speaker invite page. Collapsed, it
- *  shows a pill-shaped FAB bottom-right. Opened on **mobile**, it
- *  slides up from the bottom as a sheet (with a grab handle and
- *  rounded top corners) so the top of the letter remains visible
- *  behind it. Opened on **desktop** (sm+), it docks as a ~420px
- *  wide panel in the bottom-right with a small inset — the speaker
- *  has the screen real estate to keep the letter visible alongside
- *  it. Body scroll is locked while open to keep the letter behind
- *  from rubber-banding on iOS. */
+ *  shows a pill-shaped FAB bottom-right. Opened, it slides up as a
+ *  `vaul` Drawer — full-width on mobile, max-width centered-bottom
+ *  on desktop. Vaul handles drag-to-dismiss, ESC, backdrop tap, and
+ *  scroll lock; we just render the chrome. */
 export function SpeakerChatFloatingDrawer({
   open,
   onOpenChange,
   attention,
   children,
 }: Props): React.ReactElement {
-  // Keep the drawer mounted through its slide-down so dismissal mirrors
-  // the slide-up entrance instead of vanishing instantly.
-  const [mounted, setMounted] = useState(open);
-  const [exiting, setExiting] = useState(false);
-
-  useEffect(() => {
-    if (open) {
-      setMounted(true);
-      setExiting(false);
-      return;
-    }
-    if (!mounted) return;
-    setExiting(true);
-    const t = setTimeout(() => {
-      setMounted(false);
-      setExiting(false);
-    }, EXIT_MS);
-    return () => clearTimeout(t);
-  }, [open, mounted]);
-
-  useLockBodyScroll(mounted && !exiting);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleEsc(e: KeyboardEvent) {
-      if (e.key !== "Escape") return;
-      e.stopImmediatePropagation();
-      onOpenChange(false);
-    }
-    document.addEventListener("keydown", handleEsc, true);
-    return () => document.removeEventListener("keydown", handleEsc, true);
-  }, [open, onOpenChange]);
-
-  if (!mounted) {
-    const label =
-      attention === "reply"
-        ? "Reply to the bishopric"
-        : attention === "unread"
-          ? "New message"
-          : "Conversation";
-    const pulseStyle: React.CSSProperties | undefined = attention
-      ? { animation: "fabPulse 1.8s ease-out infinite" }
-      : undefined;
-    return (
-      <button
-        type="button"
-        onClick={() => onOpenChange(true)}
-        style={pulseStyle}
-        className={
-          attention
-            ? "fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-5 py-3.5 rounded-full bg-bordeaux text-parchment font-sans text-[14px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.875rem,env(safe-area-inset-bottom))]"
-            : "fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-4 py-3 rounded-full bg-bordeaux text-parchment font-sans text-[13.5px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.75rem,env(safe-area-inset-bottom))]"
-        }
-        aria-label={`${label} — open the conversation with the bishopric`}
-      >
-        <ChatIcon />
-        <span>{label}</span>
-      </button>
-    );
-  }
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-label="Conversation with the bishopric"
-      className={cn(
-        "fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)] flex items-end justify-center sm:justify-end sm:p-4",
-        exiting
-          ? "animate-[fadeOut_180ms_ease-in_forwards]"
-          : "animate-[fade_160ms_ease-out_backwards]",
-      )}
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onOpenChange(false);
-      }}
+    <>
+      {!open && <Fab attention={attention ?? null} onClick={() => onOpenChange(true)} />}
+      <Drawer.Root open={open} onOpenChange={onOpenChange}>
+        <Drawer.Portal>
+          <Drawer.Overlay className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)]" />
+          <Drawer.Content
+            aria-describedby={undefined}
+            className="fixed bottom-0 left-0 right-0 z-20 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none sm:left-auto sm:right-4 sm:bottom-4 sm:h-[80dvh] sm:w-[min(26.25rem,calc(100dvw-2rem))] sm:rounded-[14px] sm:border-b"
+          >
+            <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40 sm:hidden" />
+            <Drawer.Title className="sr-only">Conversation with the bishopric</Drawer.Title>
+            {children}
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    </>
+  );
+}
+
+interface FabProps {
+  attention?: CtaVariant | null;
+  onClick: () => void;
+}
+
+function Fab({ attention, onClick }: FabProps) {
+  const label =
+    attention === "reply"
+      ? "Reply to the bishopric"
+      : attention === "unread"
+        ? "New message"
+        : "Conversation";
+  const pulseStyle: React.CSSProperties | undefined = attention
+    ? { animation: "fabPulse 1.8s ease-out infinite" }
+    : undefined;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={pulseStyle}
+      className={
+        attention
+          ? "fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-5 py-3.5 rounded-full bg-bordeaux text-parchment font-sans text-[14px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.875rem,env(safe-area-inset-bottom))]"
+          : "fixed bottom-4 right-4 z-20 inline-flex items-center gap-2 px-4 py-3 rounded-full bg-bordeaux text-parchment font-sans text-[13.5px] font-semibold shadow-elev-3 hover:bg-bordeaux-deep pb-[max(0.75rem,env(safe-area-inset-bottom))]"
+      }
+      aria-label={`${label} — open the conversation with the bishopric`}
     >
-      <div
-        className={cn(
-          "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:h-[80dvh] sm:max-w-105 sm:rounded-[14px] sm:border-b",
-          exiting
-            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
-        )}
-      >
-        <button
-          type="button"
-          aria-label="Close conversation"
-          onClick={() => onOpenChange(false)}
-          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer sm:hidden"
-        >
-          <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
-        </button>
-        {children}
-      </div>
-    </div>
+      <ChatIcon />
+      <span>{label}</span>
+    </button>
   );
 }
 

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -1,0 +1,63 @@
+import { useEffect, type ReactNode } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Optional small-caps eyebrow shown above the children. Mirrors the
+   *  inline label that desktop popovers carry (e.g. "Sunday type"). */
+  title?: string;
+  children: ReactNode;
+}
+
+/** Phone-only bottom sheet. Mirrors the SpeakerChatFloatingDrawer
+ *  pattern (full-width, slides up, grab handle, body-scroll lock,
+ *  backdrop dismiss, ESC to close) but at content-height instead of
+ *  85dvh — appropriate for short option lists like "horizon select"
+ *  or "Sunday actions". Desktop callers should keep their existing
+ *  absolute-positioned popover; this primitive doesn't render a
+ *  responsive variant. */
+export function MobileBottomSheet({ open, onClose, title, children }: Props) {
+  useLockBodyScroll(open);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      onClose();
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-40 bg-[rgba(35,24,21,0.32)] flex items-end justify-center animate-[fade_160ms_ease-out]"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)] pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <button
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer"
+        >
+          <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
+        </button>
+        {title && (
+          <div className="px-4 pt-1 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-walnut-3">
+            {title}
+          </div>
+        )}
+        <div className="overflow-y-auto px-2 pb-2">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -1,6 +1,9 @@
-import { useEffect, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+import { cn } from "@/lib/cn";
+
+const EXIT_MS = 200;
 
 interface Props {
   open: boolean;
@@ -24,7 +27,29 @@ interface Props {
  *  Without the portal, a sheet opened from inside a sticky row that
  *  uses `backdrop-blur-sm` ends up trapped inside the row. */
 export function MobileBottomSheet({ open, onClose, title, children }: Props) {
-  useLockBodyScroll(open);
+  // `open` flips immediately when the caller dismisses, but we keep the
+  // sheet mounted through the exit animation. `mounted` outlives `open`
+  // by EXIT_MS; `exiting` flags the exit-animation classes during that
+  // window so the slide-down + fade-out play before unmount.
+  const [mounted, setMounted] = useState(open);
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (!mounted) return;
+    setExiting(true);
+    const t = setTimeout(() => {
+      setMounted(false);
+      setExiting(false);
+    }, EXIT_MS);
+    return () => clearTimeout(t);
+  }, [open, mounted]);
+
+  useLockBodyScroll(mounted && !exiting);
 
   useEffect(() => {
     if (!open) return;
@@ -37,19 +62,29 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
     return () => document.removeEventListener("keydown", handleEsc, true);
   }, [open, onClose]);
 
-  if (!open) return null;
+  if (!mounted) return null;
   if (typeof document === "undefined") return null;
 
   return createPortal(
     <div
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 z-40 bg-[rgba(35,24,21,0.32)] flex items-end justify-center animate-[fade_160ms_ease-out]"
+      className={cn(
+        "fixed inset-0 z-40 bg-[rgba(35,24,21,0.32)] flex items-end justify-center",
+        exiting ? "animate-[fadeOut_180ms_ease-in]" : "animate-[fade_160ms_ease-out]",
+      )}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)] pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+      <div
+        className={cn(
+          "bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden pb-[max(0.75rem,env(safe-area-inset-bottom))]",
+          exiting
+            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",
+        )}
+      >
         <button
           type="button"
           aria-label="Close"

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -1,12 +1,9 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import { cn } from "@/lib/cn";
 
 const EXIT_MS = 200;
-const ENTER_MS = 250;
-const DRAG_DISMISS_THRESHOLD = 100;
-const TAP_THRESHOLD = 5;
 
 interface Props {
   open: boolean;
@@ -17,20 +14,25 @@ interface Props {
   children: ReactNode;
 }
 
-/** Phone-only bottom sheet. Slides up with a grab handle, locks body
- *  scroll, dismisses on backdrop tap / ESC / handle drag. The handle
- *  supports a native-feeling drag gesture: drag down to follow the
- *  finger, release past ~100px to dismiss, release earlier to snap
- *  back. Portaled to `document.body` so `position: fixed` always
- *  anchors to the viewport regardless of ancestor effects. */
+/** Phone-only bottom sheet. Mirrors the SpeakerChatFloatingDrawer
+ *  pattern (full-width, slides up, grab handle, body-scroll lock,
+ *  backdrop dismiss, ESC to close) but at content-height instead of
+ *  85dvh — appropriate for short option lists like "horizon select"
+ *  or "Sunday actions".
+ *
+ *  Portals to `document.body` so `position: fixed` always anchors to
+ *  the viewport, regardless of whether an ancestor has `transform`,
+ *  `filter`, `backdrop-filter`, etc. (any of which would re-root a
+ *  fixed descendant against that ancestor instead of the viewport).
+ *  Without the portal, a sheet opened from inside a sticky row that
+ *  uses `backdrop-blur-sm` ends up trapped inside the row. */
 export function MobileBottomSheet({ open, onClose, title, children }: Props) {
+  // `open` flips immediately when the caller dismisses, but we keep the
+  // sheet mounted through the exit animation. `mounted` outlives `open`
+  // by EXIT_MS; `exiting` flags the exit-animation classes during that
+  // window so the slide-down + fade-out play before unmount.
   const [mounted, setMounted] = useState(open);
   const [exiting, setExiting] = useState(false);
-  const [entered, setEntered] = useState(false);
-  const [dragY, setDragY] = useState(0);
-  const [dragging, setDragging] = useState(false);
-  const [snapping, setSnapping] = useState(false);
-  const startYRef = useRef(0);
 
   useEffect(() => {
     if (open) {
@@ -47,18 +49,6 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
     return () => clearTimeout(t);
   }, [open, mounted]);
 
-  // Once the entrance animation is done, swap to "no animation class"
-  // so the entrance doesn't replay when state changes (e.g. after a
-  // snap-back) re-render the sheet.
-  useEffect(() => {
-    if (!mounted) {
-      setEntered(false);
-      return;
-    }
-    const t = setTimeout(() => setEntered(true), ENTER_MS);
-    return () => clearTimeout(t);
-  }, [mounted]);
-
   useLockBodyScroll(mounted && !exiting);
 
   useEffect(() => {
@@ -72,60 +62,8 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
     return () => document.removeEventListener("keydown", handleEsc, true);
   }, [open, onClose]);
 
-  function onPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
-    if (!entered || exiting) return;
-    e.currentTarget.setPointerCapture(e.pointerId);
-    startYRef.current = e.clientY;
-    setDragging(true);
-    setSnapping(false);
-    setDragY(0);
-  }
-
-  function onPointerMove(e: React.PointerEvent<HTMLButtonElement>) {
-    if (!dragging) return;
-    setDragY(Math.max(0, e.clientY - startYRef.current));
-  }
-
-  function onPointerEnd(e: React.PointerEvent<HTMLButtonElement>) {
-    if (!dragging) return;
-    e.currentTarget.releasePointerCapture(e.pointerId);
-    setDragging(false);
-    if (dragY < TAP_THRESHOLD) {
-      onClose();
-      return;
-    }
-    if (dragY > DRAG_DISMISS_THRESHOLD) {
-      // Continue the slide off-screen via CSS transition, then unmount
-      // through the parent's open=false flow. Snapping stays `true`
-      // through unmount so the inline transform keeps the sheet
-      // off-screen — no late jump back to 0% from the CSS exit class.
-      setSnapping(true);
-      setDragY(window.innerHeight);
-      setTimeout(() => onClose(), EXIT_MS);
-      return;
-    }
-    setSnapping(true);
-    setDragY(0);
-    setTimeout(() => setSnapping(false), 220);
-  }
-
   if (!mounted) return null;
   if (typeof document === "undefined") return null;
-
-  const dragControlled = dragging || snapping;
-  const inlineStyle: CSSProperties = dragControlled
-    ? {
-        transform: `translateY(${dragY}px)`,
-        transition: snapping ? "transform 200ms cubic-bezier(0.22,1,0.36,1)" : "none",
-      }
-    : {};
-
-  let sheetAnim = "";
-  if (!dragControlled) {
-    if (exiting) sheetAnim = "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]";
-    else if (!entered)
-      sheetAnim = "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]";
-  }
 
   return createPortal(
     <div
@@ -144,18 +82,16 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
       <div
         className={cn(
           "bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden pb-[max(0.75rem,env(safe-area-inset-bottom))]",
-          sheetAnim,
+          exiting
+            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
         )}
-        style={inlineStyle}
       >
         <button
           type="button"
           aria-label="Close"
-          onPointerDown={onPointerDown}
-          onPointerMove={onPointerMove}
-          onPointerUp={onPointerEnd}
-          onPointerCancel={onPointerEnd}
-          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-grab active:cursor-grabbing touch-none"
+          onClick={onClose}
+          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer"
         >
           <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
         </button>

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -1,9 +1,12 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 import { cn } from "@/lib/cn";
 
 const EXIT_MS = 200;
+const ENTER_MS = 250;
+const DRAG_DISMISS_THRESHOLD = 100;
+const TAP_THRESHOLD = 5;
 
 interface Props {
   open: boolean;
@@ -14,25 +17,20 @@ interface Props {
   children: ReactNode;
 }
 
-/** Phone-only bottom sheet. Mirrors the SpeakerChatFloatingDrawer
- *  pattern (full-width, slides up, grab handle, body-scroll lock,
- *  backdrop dismiss, ESC to close) but at content-height instead of
- *  85dvh — appropriate for short option lists like "horizon select"
- *  or "Sunday actions".
- *
- *  Portals to `document.body` so `position: fixed` always anchors to
- *  the viewport, regardless of whether an ancestor has `transform`,
- *  `filter`, `backdrop-filter`, etc. (any of which would re-root a
- *  fixed descendant against that ancestor instead of the viewport).
- *  Without the portal, a sheet opened from inside a sticky row that
- *  uses `backdrop-blur-sm` ends up trapped inside the row. */
+/** Phone-only bottom sheet. Slides up with a grab handle, locks body
+ *  scroll, dismisses on backdrop tap / ESC / handle drag. The handle
+ *  supports a native-feeling drag gesture: drag down to follow the
+ *  finger, release past ~100px to dismiss, release earlier to snap
+ *  back. Portaled to `document.body` so `position: fixed` always
+ *  anchors to the viewport regardless of ancestor effects. */
 export function MobileBottomSheet({ open, onClose, title, children }: Props) {
-  // `open` flips immediately when the caller dismisses, but we keep the
-  // sheet mounted through the exit animation. `mounted` outlives `open`
-  // by EXIT_MS; `exiting` flags the exit-animation classes during that
-  // window so the slide-down + fade-out play before unmount.
   const [mounted, setMounted] = useState(open);
   const [exiting, setExiting] = useState(false);
+  const [entered, setEntered] = useState(false);
+  const [dragY, setDragY] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const [snapping, setSnapping] = useState(false);
+  const startYRef = useRef(0);
 
   useEffect(() => {
     if (open) {
@@ -49,6 +47,18 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
     return () => clearTimeout(t);
   }, [open, mounted]);
 
+  // Once the entrance animation is done, swap to "no animation class"
+  // so the entrance doesn't replay when state changes (e.g. after a
+  // snap-back) re-render the sheet.
+  useEffect(() => {
+    if (!mounted) {
+      setEntered(false);
+      return;
+    }
+    const t = setTimeout(() => setEntered(true), ENTER_MS);
+    return () => clearTimeout(t);
+  }, [mounted]);
+
   useLockBodyScroll(mounted && !exiting);
 
   useEffect(() => {
@@ -62,8 +72,60 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
     return () => document.removeEventListener("keydown", handleEsc, true);
   }, [open, onClose]);
 
+  function onPointerDown(e: React.PointerEvent<HTMLButtonElement>) {
+    if (!entered || exiting) return;
+    e.currentTarget.setPointerCapture(e.pointerId);
+    startYRef.current = e.clientY;
+    setDragging(true);
+    setSnapping(false);
+    setDragY(0);
+  }
+
+  function onPointerMove(e: React.PointerEvent<HTMLButtonElement>) {
+    if (!dragging) return;
+    setDragY(Math.max(0, e.clientY - startYRef.current));
+  }
+
+  function onPointerEnd(e: React.PointerEvent<HTMLButtonElement>) {
+    if (!dragging) return;
+    e.currentTarget.releasePointerCapture(e.pointerId);
+    setDragging(false);
+    if (dragY < TAP_THRESHOLD) {
+      onClose();
+      return;
+    }
+    if (dragY > DRAG_DISMISS_THRESHOLD) {
+      // Continue the slide off-screen via CSS transition, then unmount
+      // through the parent's open=false flow. Snapping stays `true`
+      // through unmount so the inline transform keeps the sheet
+      // off-screen — no late jump back to 0% from the CSS exit class.
+      setSnapping(true);
+      setDragY(window.innerHeight);
+      setTimeout(() => onClose(), EXIT_MS);
+      return;
+    }
+    setSnapping(true);
+    setDragY(0);
+    setTimeout(() => setSnapping(false), 220);
+  }
+
   if (!mounted) return null;
   if (typeof document === "undefined") return null;
+
+  const dragControlled = dragging || snapping;
+  const inlineStyle: CSSProperties = dragControlled
+    ? {
+        transform: `translateY(${dragY}px)`,
+        transition: snapping ? "transform 200ms cubic-bezier(0.22,1,0.36,1)" : "none",
+      }
+    : {};
+
+  let sheetAnim = "";
+  if (!dragControlled) {
+    if (exiting) sheetAnim = "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]";
+    else if (!entered)
+      sheetAnim = "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]";
+  }
 
   return createPortal(
     <div
@@ -82,16 +144,18 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
       <div
         className={cn(
           "bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden pb-[max(0.75rem,env(safe-area-inset-bottom))]",
-          exiting
-            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
+          sheetAnim,
         )}
+        style={inlineStyle}
       >
         <button
           type="button"
           aria-label="Close"
-          onClick={onClose}
-          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer"
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerEnd}
+          onPointerCancel={onPointerEnd}
+          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-grab active:cursor-grabbing touch-none"
         >
           <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
         </button>

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -1,9 +1,5 @@
-import { useEffect, useState, type ReactNode } from "react";
-import { createPortal } from "react-dom";
-import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
-import { cn } from "@/lib/cn";
-
-const EXIT_MS = 200;
+import type { ReactNode } from "react";
+import { Drawer } from "vaul";
 
 interface Props {
   open: boolean;
@@ -14,95 +10,37 @@ interface Props {
   children: ReactNode;
 }
 
-/** Phone-only bottom sheet. Mirrors the SpeakerChatFloatingDrawer
- *  pattern (full-width, slides up, grab handle, body-scroll lock,
- *  backdrop dismiss, ESC to close) but at content-height instead of
- *  85dvh — appropriate for short option lists like "horizon select"
- *  or "Sunday actions".
- *
- *  Portals to `document.body` so `position: fixed` always anchors to
- *  the viewport, regardless of whether an ancestor has `transform`,
- *  `filter`, `backdrop-filter`, etc. (any of which would re-root a
- *  fixed descendant against that ancestor instead of the viewport).
- *  Without the portal, a sheet opened from inside a sticky row that
- *  uses `backdrop-blur-sm` ends up trapped inside the row. */
+/** Phone-only bottom sheet wrapping `vaul`'s Drawer primitive — gives
+ *  us native-feeling drag-to-dismiss, swipe-down on the handle, and
+ *  smooth spring animations without hand-rolling pointer events. The
+ *  visual treatment (parchment chrome, walnut grab handle, mono
+ *  small-caps title) matches the rest of the app. */
 export function MobileBottomSheet({ open, onClose, title, children }: Props) {
-  // `open` flips immediately when the caller dismisses, but we keep the
-  // sheet mounted through the exit animation. `mounted` outlives `open`
-  // by EXIT_MS; `exiting` flags the exit-animation classes during that
-  // window so the slide-down + fade-out play before unmount.
-  const [mounted, setMounted] = useState(open);
-  const [exiting, setExiting] = useState(false);
-
-  useEffect(() => {
-    if (open) {
-      setMounted(true);
-      setExiting(false);
-      return;
-    }
-    if (!mounted) return;
-    setExiting(true);
-    const t = setTimeout(() => {
-      setMounted(false);
-      setExiting(false);
-    }, EXIT_MS);
-    return () => clearTimeout(t);
-  }, [open, mounted]);
-
-  useLockBodyScroll(mounted && !exiting);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleEsc(e: KeyboardEvent) {
-      if (e.key !== "Escape") return;
-      e.stopImmediatePropagation();
-      onClose();
-    }
-    document.addEventListener("keydown", handleEsc, true);
-    return () => document.removeEventListener("keydown", handleEsc, true);
-  }, [open, onClose]);
-
-  if (!mounted) return null;
-  if (typeof document === "undefined") return null;
-
-  return createPortal(
-    <div
-      role="dialog"
-      aria-modal="true"
-      className={cn(
-        "fixed inset-0 z-40 bg-[rgba(35,24,21,0.32)] flex items-end justify-center",
-        exiting
-          ? "animate-[fadeOut_180ms_ease-in_forwards]"
-          : "animate-[fade_160ms_ease-out_backwards]",
-      )}
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
+  return (
+    <Drawer.Root
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
       }}
     >
-      <div
-        className={cn(
-          "bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden pb-[max(0.75rem,env(safe-area-inset-bottom))]",
-          exiting
-            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
-        )}
-      >
-        <button
-          type="button"
-          aria-label="Close"
-          onClick={onClose}
-          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer"
-        >
-          <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
-        </button>
-        {title && (
-          <div className="px-4 pt-1 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-walnut-3">
-            {title}
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-40 bg-[rgba(35,24,21,0.32)]" />
+        <Drawer.Content className="fixed bottom-0 left-0 right-0 z-40 mt-24 flex max-h-[75dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+          <div aria-hidden className="flex-none flex items-center justify-center pt-2.5 pb-1.5">
+            <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
           </div>
-        )}
-        <div className="overflow-y-auto px-2 pb-2">{children}</div>
-      </div>
-    </div>,
-    document.body,
+          {title && (
+            <Drawer.Title className="px-4 pt-1 pb-2 font-mono text-[10px] uppercase tracking-[0.18em] text-walnut-3">
+              {title}
+            </Drawer.Title>
+          )}
+          {/* `vaul` reads the title for screen readers; a description is
+           *  required for a11y but our content is a list of options that
+           *  carries its own labelling. Use a visually-hidden span. */}
+          <Drawer.Description className="sr-only">{title ?? "Options"}</Drawer.Description>
+          <div className="overflow-y-auto px-2 pb-2">{children}</div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   );
 }

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -71,7 +71,9 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
       aria-modal="true"
       className={cn(
         "fixed inset-0 z-40 bg-[rgba(35,24,21,0.32)] flex items-end justify-center",
-        exiting ? "animate-[fadeOut_180ms_ease-in]" : "animate-[fade_160ms_ease-out]",
+        exiting
+          ? "animate-[fadeOut_180ms_ease-in_forwards]"
+          : "animate-[fade_160ms_ease-out_backwards]",
       )}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
@@ -82,7 +84,7 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
           "bg-chalk flex flex-col w-full max-h-[75dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden pb-[max(0.75rem,env(safe-area-inset-bottom))]",
           exiting
             ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
         )}
       >
         <button

--- a/src/components/ui/MobileBottomSheet.tsx
+++ b/src/components/ui/MobileBottomSheet.tsx
@@ -1,4 +1,5 @@
 import { useEffect, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
 
 interface Props {
@@ -14,9 +15,14 @@ interface Props {
  *  pattern (full-width, slides up, grab handle, body-scroll lock,
  *  backdrop dismiss, ESC to close) but at content-height instead of
  *  85dvh — appropriate for short option lists like "horizon select"
- *  or "Sunday actions". Desktop callers should keep their existing
- *  absolute-positioned popover; this primitive doesn't render a
- *  responsive variant. */
+ *  or "Sunday actions".
+ *
+ *  Portals to `document.body` so `position: fixed` always anchors to
+ *  the viewport, regardless of whether an ancestor has `transform`,
+ *  `filter`, `backdrop-filter`, etc. (any of which would re-root a
+ *  fixed descendant against that ancestor instead of the viewport).
+ *  Without the portal, a sheet opened from inside a sticky row that
+ *  uses `backdrop-blur-sm` ends up trapped inside the row. */
 export function MobileBottomSheet({ open, onClose, title, children }: Props) {
   useLockBodyScroll(open);
 
@@ -32,8 +38,9 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
   }, [open, onClose]);
 
   if (!open) return null;
+  if (typeof document === "undefined") return null;
 
-  return (
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -58,6 +65,7 @@ export function MobileBottomSheet({ open, onClose, title, children }: Props) {
         )}
         <div className="overflow-y-auto px-2 pb-2">{children}</div>
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 }

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,9 +1,12 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+import { cn } from "@/lib/cn";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
 import { InvitationLinkActions } from "./InvitationLinkActions";
 import { NoInvitationPlaceholder } from "./NoInvitationPlaceholder";
+
+const EXIT_MS = 200;
 
 interface Props {
   open: boolean;
@@ -46,7 +49,27 @@ export function BishopInvitationDialog({
   speakerId,
   kind = "speaker",
 }: Props): React.ReactElement | null {
-  useLockBodyScroll(open);
+  // Stay mounted through the slide-down so dismissal mirrors the
+  // slide-up entrance instead of cutting off mid-animation.
+  const [mounted, setMounted] = useState(open);
+  const [exiting, setExiting] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true);
+      setExiting(false);
+      return;
+    }
+    if (!mounted) return;
+    setExiting(true);
+    const t = setTimeout(() => {
+      setMounted(false);
+      setExiting(false);
+    }, EXIT_MS);
+    return () => clearTimeout(t);
+  }, [open, mounted]);
+
+  useLockBodyScroll(mounted && !exiting);
 
   useEffect(() => {
     if (!open) return;
@@ -59,18 +82,28 @@ export function BishopInvitationDialog({
     return () => document.removeEventListener("keydown", handleEsc, true);
   }, [open, onClose]);
 
-  if (!open) return null;
+  if (!mounted) return null;
 
   return (
     <div
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 z-[60] bg-[rgba(35,24,21,0.42)] flex items-end sm:items-center justify-center sm:p-5 animate-[fade_160ms_ease-out]"
+      className={cn(
+        "fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)] flex items-end sm:items-center justify-center sm:p-5",
+        exiting ? "animate-[fadeOut_180ms_ease-in]" : "animate-[fade_160ms_ease-out]",
+      )}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
-      <div className="bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)] sm:max-w-xl sm:h-auto sm:min-h-140 sm:max-h-[94vh] sm:rounded-[14px] sm:border-b sm:animate-none">
+      <div
+        className={cn(
+          "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:max-w-xl sm:h-auto sm:min-h-140 sm:max-h-[94vh] sm:rounded-[14px] sm:border-b sm:animate-none",
+          exiting
+            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",
+        )}
+      >
         <button
           type="button"
           aria-label="Close conversation"

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,12 +1,8 @@
-import { useEffect, useState } from "react";
-import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
-import { cn } from "@/lib/cn";
+import { Drawer } from "vaul";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
 import { InvitationLinkActions } from "./InvitationLinkActions";
 import { NoInvitationPlaceholder } from "./NoInvitationPlaceholder";
-
-const EXIT_MS = 200;
 
 interface Props {
   open: boolean;
@@ -31,13 +27,12 @@ interface Props {
   kind?: "speaker" | "prayer";
 }
 
-/** Nested modal that hosts the bishop-side chat pane from inside the
- *  Assign Speakers modal. Renders at `z-[60]` (above the Assign
- *  modal's `z-50`), and closes on Escape or backdrop click. Uses the
- *  TwilioChatProvider established higher up the tree. Slides up from
- *  the bottom as a sheet on mobile (85dvh, rounded top corners, grab
- *  handle), centered modal on sm+. Background scroll is locked while
- *  open so mobile rubber-banding doesn't drag the page behind it. */
+/** Bishop-side conversation panel. Hosts BishopInvitationChat (or the
+ *  no-invitation placeholder when the speaker hasn't been invited
+ *  yet) inside a `vaul` Drawer — gives us native drag-to-dismiss,
+ *  ESC, backdrop tap, and spring animations on both mobile and
+ *  desktop. Z-index pinned to 60 so the panel sits above the Assign
+ *  Speakers modal (z-50) it's launched from. */
 export function BishopInvitationDialog({
   open,
   onClose,
@@ -49,115 +44,67 @@ export function BishopInvitationDialog({
   speakerId,
   kind = "speaker",
 }: Props): React.ReactElement | null {
-  // Stay mounted through the slide-down so dismissal mirrors the
-  // slide-up entrance instead of cutting off mid-animation.
-  const [mounted, setMounted] = useState(open);
-  const [exiting, setExiting] = useState(false);
-
-  useEffect(() => {
-    if (open) {
-      setMounted(true);
-      setExiting(false);
-      return;
-    }
-    if (!mounted) return;
-    setExiting(true);
-    const t = setTimeout(() => {
-      setMounted(false);
-      setExiting(false);
-    }, EXIT_MS);
-    return () => clearTimeout(t);
-  }, [open, mounted]);
-
-  useLockBodyScroll(mounted && !exiting);
-
-  useEffect(() => {
-    if (!open) return;
-    function handleEsc(e: KeyboardEvent) {
-      if (e.key !== "Escape") return;
-      e.stopImmediatePropagation();
-      onClose();
-    }
-    document.addEventListener("keydown", handleEsc, true);
-    return () => document.removeEventListener("keydown", handleEsc, true);
-  }, [open, onClose]);
-
-  if (!mounted) return null;
-
   return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      className={cn(
-        "fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)] flex items-end sm:items-center justify-center sm:p-5",
-        exiting
-          ? "animate-[fadeOut_180ms_ease-in_forwards]"
-          : "animate-[fade_160ms_ease-out_backwards]",
-      )}
-      onMouseDown={(e) => {
-        if (e.target === e.currentTarget) onClose();
+    <Drawer.Root
+      open={open}
+      onOpenChange={(o) => {
+        if (!o) onClose();
       }}
     >
-      <div
-        className={cn(
-          "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:max-w-xl sm:h-auto sm:min-h-140 sm:max-h-[94vh] sm:rounded-[14px] sm:border-b sm:animate-none",
-          exiting
-            ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
-        )}
-      >
-        <button
-          type="button"
-          aria-label="Close conversation"
-          onClick={onClose}
-          className="flex-none flex items-center justify-center pt-2.5 pb-1.5 hover:bg-[rgba(35,24,21,0.04)] cursor-pointer sm:hidden"
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)]" />
+        <Drawer.Content
+          aria-describedby={undefined}
+          className="fixed bottom-0 left-0 right-0 z-60 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none sm:left-1/2 sm:right-auto sm:bottom-4 sm:h-auto sm:min-h-140 sm:max-h-[94dvh] sm:w-[min(40rem,calc(100dvw-2rem))] sm:-translate-x-1/2 sm:rounded-[14px] sm:border-b"
         >
-          <span className="block w-10 h-1 rounded-full bg-walnut-2/40" />
-        </button>
-        <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
-          <div className="flex-1 min-w-0">
-            <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
-              Conversation
+          <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40 sm:hidden" />
+          <Drawer.Title className="sr-only">Conversation with {speaker.name}</Drawer.Title>
+          <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
+            <div className="flex-1 min-w-0">
+              <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
+                Conversation
+              </div>
+              <div className="font-display text-xl font-semibold text-walnut tracking-[-0.01em] leading-tight mt-0.5">
+                {speaker.name}
+              </div>
             </div>
-            <div className="font-display text-xl font-semibold text-walnut tracking-[-0.01em] leading-tight mt-0.5">
-              {speaker.name}
-            </div>
+            {invitation && invitationId && (
+              <InvitationLinkActions
+                wardId={wardId}
+                invitationId={invitationId}
+                invitation={invitation}
+              />
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
+              aria-label="Close"
+            >
+              Close
+            </button>
           </div>
-          {invitation && invitationId && (
-            <InvitationLinkActions
+          {invitation && invitationId ? (
+            <BishopInvitationChat
               wardId={wardId}
               invitationId={invitationId}
               invitation={invitation}
+              speaker={speaker}
+              date={date}
+              speakerId={speakerId}
+            />
+          ) : (
+            <NoInvitationPlaceholder
+              wardId={wardId}
+              speaker={speaker}
+              speakerId={speakerId}
+              date={date}
+              kind={kind}
+              onNavigate={onClose}
             />
           )}
-          <button
-            onClick={onClose}
-            className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
-            aria-label="Close"
-          >
-            Close
-          </button>
-        </div>
-        {invitation && invitationId ? (
-          <BishopInvitationChat
-            wardId={wardId}
-            invitationId={invitationId}
-            invitation={invitation}
-            speaker={speaker}
-            date={date}
-            speakerId={speakerId}
-          />
-        ) : (
-          <NoInvitationPlaceholder
-            wardId={wardId}
-            speaker={speaker}
-            speakerId={speakerId}
-            date={date}
-            kind={kind}
-            onNavigate={onClose}
-          />
-        )}
-      </div>
-    </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   );
 }

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -90,7 +90,9 @@ export function BishopInvitationDialog({
       aria-modal="true"
       className={cn(
         "fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)] flex items-end sm:items-center justify-center sm:p-5",
-        exiting ? "animate-[fadeOut_180ms_ease-in]" : "animate-[fade_160ms_ease-out]",
+        exiting
+          ? "animate-[fadeOut_180ms_ease-in_forwards]"
+          : "animate-[fade_160ms_ease-out_backwards]",
       )}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
@@ -101,7 +103,7 @@ export function BishopInvitationDialog({
           "bg-chalk flex flex-col w-full h-[85dvh] rounded-t-[18px] border-t border-x border-border-strong shadow-elev-3 overflow-hidden sm:max-w-xl sm:h-auto sm:min-h-140 sm:max-h-[94vh] sm:rounded-[14px] sm:border-b sm:animate-none",
           exiting
             ? "animate-[drawerSlideDown_200ms_cubic-bezier(0.4,0,1,1)_forwards]"
-            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)]",
+            : "animate-[drawerSlideUp_220ms_cubic-bezier(0.22,1,0.36,1)_backwards]",
         )}
       >
         <button

--- a/src/features/schedule/HorizonSelect/HorizonSelect.tsx
+++ b/src/features/schedule/HorizonSelect/HorizonSelect.tsx
@@ -82,7 +82,7 @@ export function HorizonSelect({ value, onChange }: Props) {
       {open && (
         <div
           ref={menuRef}
-          className="absolute right-0 top-full mt-1.5 min-w-50 bg-chalk border border-border rounded-lg shadow-[0_10px_28px_rgba(58,37,25,0.12),0_2px_6px_rgba(58,37,25,0.06)] p-1.5 z-10 animate-[menuIn_120ms_ease-out]"
+          className="absolute right-0 top-full mt-1.5 min-w-50 bg-chalk border border-border rounded-lg shadow-[0_10px_28px_rgba(58,37,25,0.12),0_2px_6px_rgba(58,37,25,0.06)] p-1.5 z-30 animate-[menuIn_120ms_ease-out]"
         >
           {HORIZON_OPTIONS.map((option) => (
             <button

--- a/src/features/schedule/HorizonSelect/HorizonSelect.tsx
+++ b/src/features/schedule/HorizonSelect/HorizonSelect.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from "react";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { MobileBottomSheet } from "@/components/ui/MobileBottomSheet";
 import { cn } from "@/lib/cn";
 
 const HORIZON_OPTIONS = [
@@ -18,12 +20,13 @@ export function HorizonSelect({ value, onChange }: Props) {
   const [open, setOpen] = useState(false);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
   const selectedOption = HORIZON_OPTIONS.find((o) => o.weeks === value);
   const display = selectedOption?.display ?? "Schedule";
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || isMobile) return;
 
     function handleClickOutside(e: MouseEvent) {
       if (
@@ -47,7 +50,7 @@ export function HorizonSelect({ value, onChange }: Props) {
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEsc);
     };
-  }, [open]);
+  }, [open, isMobile]);
 
   function handleSelect(weeks: number) {
     onChange(weeks);
@@ -79,32 +82,47 @@ export function HorizonSelect({ value, onChange }: Props) {
         </span>
       </button>
 
-      {open && (
+      {open && !isMobile && (
         <div
           ref={menuRef}
           className="absolute right-0 top-full mt-1.5 min-w-50 bg-chalk border border-border rounded-lg shadow-[0_10px_28px_rgba(58,37,25,0.12),0_2px_6px_rgba(58,37,25,0.06)] p-1.5 z-30 animate-[menuIn_120ms_ease-out]"
         >
-          {HORIZON_OPTIONS.map((option) => (
-            <button
-              key={option.weeks}
-              onClick={() => handleSelect(option.weeks)}
-              className={cn(
-                "w-full grid gap-1.5 items-center px-2.5 py-2 text-left text-xs font-display rounded-sm cursor-pointer transition-colors duration-100",
-                "grid-cols-[16px_1fr]",
-                value === option.weeks
-                  ? "text-bordeaux font-medium"
-                  : "text-walnut hover:bg-parchment",
-              )}
-              style={{ gridTemplateColumns: "16px 1fr" }}
-            >
-              <span className="text-[8px] text-center text-bordeaux leading-none">
-                {value === option.weeks ? "•" : ""}
-              </span>
-              <span>{option.display}</span>
-            </button>
-          ))}
+          <Options value={value} onSelect={handleSelect} />
         </div>
       )}
+      {isMobile && (
+        <MobileBottomSheet open={open} onClose={() => setOpen(false)} title="Showing">
+          <Options value={value} onSelect={handleSelect} />
+        </MobileBottomSheet>
+      )}
     </div>
+  );
+}
+
+interface OptionsProps {
+  value: number;
+  onSelect: (weeks: number) => void;
+}
+
+function Options({ value, onSelect }: OptionsProps) {
+  return (
+    <>
+      {HORIZON_OPTIONS.map((option) => (
+        <button
+          key={option.weeks}
+          onClick={() => onSelect(option.weeks)}
+          className={cn(
+            "w-full grid gap-1.5 items-center px-2.5 py-2.5 text-left text-sm font-display rounded-sm cursor-pointer transition-colors duration-100",
+            "grid-cols-[16px_1fr]",
+            value === option.weeks ? "text-bordeaux font-medium" : "text-walnut hover:bg-parchment",
+          )}
+        >
+          <span className="text-[8px] text-center text-bordeaux leading-none">
+            {value === option.weeks ? "•" : ""}
+          </span>
+          <span>{option.display}</span>
+        </button>
+      ))}
+    </>
   );
 }

--- a/src/features/schedule/HorizonSelect/HorizonSelect.tsx
+++ b/src/features/schedule/HorizonSelect/HorizonSelect.tsx
@@ -7,8 +7,7 @@ const HORIZON_OPTIONS = [
   { label: "1 month", display: "Next 1 month", weeks: 4 },
   { label: "2 months", display: "Next 2 months", weeks: 9 },
   { label: "3 months", display: "Next 3 months", weeks: 13 },
-  { label: "6 months", display: "Next 6 months", weeks: 26 },
-  { label: "12 months", display: "Next 12 months", weeks: 52 },
+  { label: "4 months", display: "Next 4 months", weeks: 17 },
 ];
 
 interface Props {

--- a/src/features/schedule/HorizonSelect/__tests__/HorizonSelect.test.tsx
+++ b/src/features/schedule/HorizonSelect/__tests__/HorizonSelect.test.tsx
@@ -37,7 +37,7 @@ describe("HorizonSelect", () => {
     await userEvent.click(button);
 
     expect(screen.getByText("Next 1 month")).toBeInTheDocument();
-    expect(screen.getByText("Next 6 months")).toBeInTheDocument();
+    expect(screen.getByText("Next 4 months")).toBeInTheDocument();
   });
 
   it("closes dropdown on selection", async () => {

--- a/src/features/schedule/MobileScheduleList.tsx
+++ b/src/features/schedule/MobileScheduleList.tsx
@@ -12,28 +12,18 @@ interface Props {
 export function MobileScheduleList({ monthGroups, leadTimeDays, nonMeetingSundays }: Props) {
   return (
     <div className="-mx-4 sm:mx-0">
-      {monthGroups.map((group) => (
-        <section key={`${group.year}-${group.month}`} className="mb-6">
-          <header className="sticky top-0 z-20 flex items-baseline justify-between px-4 h-12 bg-parchment border-b border-border">
-            <h2 className="font-display font-semibold text-walnut text-lg tracking-[-0.01em]">
-              {group.label}
-            </h2>
-            <span className="font-mono uppercase text-[10px] tracking-[0.12em] text-walnut-3">
-              {group.sundays.length} Sundays
-            </span>
-          </header>
-          {group.sundays.map((sunday) => (
-            <MobileSundayBlock
-              key={sunday.date}
-              date={sunday.date}
-              meeting={sunday.meeting}
-              fallbackType={defaultMeetingType(sunday.date, nonMeetingSundays)}
-              leadTimeDays={leadTimeDays}
-              nonMeetingSundays={nonMeetingSundays}
-            />
-          ))}
-        </section>
-      ))}
+      {monthGroups.flatMap((group) =>
+        group.sundays.map((sunday) => (
+          <MobileSundayBlock
+            key={sunday.date}
+            date={sunday.date}
+            meeting={sunday.meeting}
+            fallbackType={defaultMeetingType(sunday.date, nonMeetingSundays)}
+            leadTimeDays={leadTimeDays}
+            nonMeetingSundays={nonMeetingSundays}
+          />
+        )),
+      )}
     </div>
   );
 }

--- a/src/features/schedule/MobileScheduleList.tsx
+++ b/src/features/schedule/MobileScheduleList.tsx
@@ -1,0 +1,39 @@
+import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import type { NonMeetingSunday } from "@/lib/types";
+import type { MonthGroup } from "./utils/groupByMonth";
+import { MobileSundayBlock } from "./MobileSundayBlock";
+
+interface Props {
+  monthGroups: readonly MonthGroup[];
+  leadTimeDays: number;
+  nonMeetingSundays: readonly NonMeetingSunday[];
+}
+
+export function MobileScheduleList({ monthGroups, leadTimeDays, nonMeetingSundays }: Props) {
+  return (
+    <div className="-mx-4 sm:mx-0">
+      {monthGroups.map((group) => (
+        <section key={`${group.year}-${group.month}`} className="mb-6">
+          <header className="sticky top-0 z-20 flex items-baseline justify-between px-4 h-12 bg-parchment border-b border-border">
+            <h2 className="font-display font-semibold text-walnut text-lg tracking-[-0.01em]">
+              {group.label}
+            </h2>
+            <span className="font-mono uppercase text-[10px] tracking-[0.12em] text-walnut-3">
+              {group.sundays.length} Sundays
+            </span>
+          </header>
+          {group.sundays.map((sunday) => (
+            <MobileSundayBlock
+              key={sunday.date}
+              date={sunday.date}
+              meeting={sunday.meeting}
+              fallbackType={defaultMeetingType(sunday.date, nonMeetingSundays)}
+              leadTimeDays={leadTimeDays}
+              nonMeetingSundays={nonMeetingSundays}
+            />
+          ))}
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/src/features/schedule/MobileSundayBlock.tsx
+++ b/src/features/schedule/MobileSundayBlock.tsx
@@ -94,6 +94,7 @@ export function MobileSundayBlock({
             currentType={type}
             locked={hasConfirmedSpeaker}
             nonMeetingSundays={nonMeetingSundays}
+            showPlanActions
           />
         </div>
       </div>
@@ -136,6 +137,7 @@ function Body({ cancelled, cancelReason, kind, date, meeting, speakers }: BodyPr
         description={kind.description}
         date={date}
         meeting={meeting}
+        hidePlanLink
       />
     );
   }

--- a/src/features/schedule/MobileSundayBlock.tsx
+++ b/src/features/schedule/MobileSundayBlock.tsx
@@ -1,0 +1,143 @@
+import { Link } from "react-router";
+import { useSpeakers } from "@/hooks/useMeeting";
+import { useSundayInvitationsSummary } from "@/features/invitations/hooks/useSundayInvitationsSummary";
+import { leadTimeSeverity } from "@/features/speakers/utils/leadTime";
+import type { MeetingType, NonMeetingSunday, SacramentMeeting } from "@/lib/types";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { cn } from "@/lib/cn";
+import { kindLabel, type KindVariant } from "./utils/kindLabel";
+import { formatShortDate, formatCountdown } from "./utils/dateFormat";
+import { SundayTypeMenu } from "./SundayTypeMenu";
+import { SundayCardSpecial } from "./SundayCardSpecial";
+import { MobileSundayBody } from "./MobileSundayBody";
+
+const ROW_BG: Record<KindVariant, string> = {
+  regular: "bg-chalk",
+  fast: "bg-chalk bg-[linear-gradient(180deg,rgba(224,190,135,0.14),rgba(224,190,135,0.04))]",
+  stake: "bg-chalk bg-[linear-gradient(180deg,rgba(139,46,42,0.05),rgba(139,46,42,0.01))]",
+  general: "bg-chalk bg-[linear-gradient(180deg,rgba(139,46,42,0.05),rgba(139,46,42,0.01))]",
+};
+
+const BADGE_CLS: Record<KindVariant, string> = {
+  regular: "",
+  fast: "text-brass-deep border-brass-soft bg-[rgba(224,190,135,0.22)]",
+  stake: "text-bordeaux border-danger-soft bg-danger-soft",
+  general: "text-bordeaux border-danger-soft bg-danger-soft",
+};
+
+interface Props {
+  date: string;
+  meeting: SacramentMeeting | null;
+  fallbackType: MeetingType;
+  leadTimeDays: number;
+  nonMeetingSundays: readonly NonMeetingSunday[];
+}
+
+export function MobileSundayBlock({
+  date,
+  meeting,
+  fallbackType,
+  leadTimeDays,
+  nonMeetingSundays,
+}: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId) ?? "";
+  const type = meeting?.meetingType ?? fallbackType;
+  const kind = kindLabel(type);
+  const cancelled = Boolean(meeting?.cancellation?.cancelled);
+  const { data: speakers } = useSpeakers(date);
+  const { needsApply } = useSundayInvitationsSummary(wardId || null, date);
+  const urgent = leadTimeSeverity(new Date(), date, leadTimeDays) === "urgent";
+  const hasConfirmedSpeaker = speakers.some((s) => s.data.status === "confirmed");
+
+  return (
+    <article className={cn("border-b border-border", ROW_BG[kind.variant])}>
+      <div className="sticky top-12 z-10 flex items-center justify-between gap-3 px-4 py-2.5 bg-parchment/95 backdrop-blur-sm border-b border-border">
+        <div className="flex items-baseline gap-2 flex-1 min-w-0">
+          <Link
+            to={`/week/${date}`}
+            className={cn(
+              "font-display font-semibold text-walnut leading-none text-xl shrink-0",
+              cancelled && "line-through text-walnut-3",
+            )}
+          >
+            {formatShortDate(date)}
+          </Link>
+          <span
+            className={cn(
+              "font-mono text-[10px] tracking-[0.08em] uppercase truncate",
+              urgent ? "text-bordeaux font-semibold" : "text-walnut-3",
+            )}
+          >
+            {cancelled ? "Cancelled" : formatCountdown(date)}
+          </span>
+          {needsApply && !cancelled && (
+            <span
+              aria-label="Speaker response awaiting your review"
+              className="inline-block w-2 h-2 rounded-full bg-bordeaux shrink-0"
+            />
+          )}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          {kind.badge && (
+            <span
+              className={cn(
+                "font-mono text-[9.5px] uppercase tracking-[0.16em] px-2 py-0.75 border rounded-full whitespace-nowrap",
+                BADGE_CLS[kind.variant],
+              )}
+            >
+              {kind.badge}
+            </span>
+          )}
+          <SundayTypeMenu
+            wardId={wardId}
+            date={date}
+            currentType={type}
+            locked={hasConfirmedSpeaker}
+            nonMeetingSundays={nonMeetingSundays}
+          />
+        </div>
+      </div>
+
+      <Body
+        cancelled={cancelled}
+        cancelReason={meeting?.cancellation?.reason}
+        kind={kind}
+        date={date}
+        meeting={meeting ?? null}
+        speakers={speakers}
+      />
+    </article>
+  );
+}
+
+interface BodyProps {
+  cancelled: boolean;
+  cancelReason?: string;
+  kind: ReturnType<typeof kindLabel>;
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: ReturnType<typeof useSpeakers>["data"];
+}
+
+function Body({ cancelled, cancelReason, kind, date, meeting, speakers }: BodyProps) {
+  if (cancelled) {
+    if (!cancelReason) return null;
+    return (
+      <p className="px-4 py-3 font-serif italic text-[13.5px] text-walnut-2 leading-normal">
+        {cancelReason}
+      </p>
+    );
+  }
+  if (kind.isSpecial) {
+    return (
+      <SundayCardSpecial
+        variant={kind.variant}
+        stampLabel={kind.stampLabel}
+        description={kind.description}
+        date={date}
+        meeting={meeting}
+      />
+    );
+  }
+  return <MobileSundayBody date={date} meeting={meeting} speakers={speakers} />;
+}

--- a/src/features/schedule/MobileSundayBlock.tsx
+++ b/src/features/schedule/MobileSundayBlock.tsx
@@ -51,7 +51,7 @@ export function MobileSundayBlock({
 
   return (
     <article className={cn("border-b border-border", ROW_BG[kind.variant])}>
-      <div className="sticky top-12 z-10 flex items-center justify-between gap-3 px-4 py-2.5 bg-parchment/95 backdrop-blur-sm border-b border-border">
+      <div className="sticky top-0 z-10 flex items-center justify-between gap-3 px-4 py-2.5 bg-parchment/95 backdrop-blur-sm border-b border-border">
         <div className="flex items-baseline gap-2 flex-1 min-w-0">
           <Link
             to={`/week/${date}`}

--- a/src/features/schedule/MobileSundayBody.tsx
+++ b/src/features/schedule/MobileSundayBody.tsx
@@ -1,0 +1,64 @@
+import { Link } from "react-router";
+import type { SacramentMeeting, Speaker } from "@/lib/types";
+import type { WithId } from "@/hooks/_sub";
+import { SpeakerRow } from "./SpeakerRow";
+import { PrayerRow } from "./PrayerRow";
+
+interface Props {
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: WithId<Speaker>[];
+}
+
+export function MobileSundayBody({ date, meeting, speakers }: Props) {
+  const openingName = meeting?.openingPrayer?.person?.name ?? "";
+  const benedictionName = meeting?.benediction?.person?.name ?? "";
+  const hasPrayers = Boolean(openingName.trim() || benedictionName.trim());
+
+  return (
+    <div className="px-4 pb-3">
+      {speakers.length > 0 ? (
+        <ul className="list-none m-0 p-0">
+          {speakers.map((s, idx) => (
+            <SpeakerRow key={s.id} number={idx + 1} speaker={s.data} speakerId={s.id} date={date} />
+          ))}
+        </ul>
+      ) : (
+        <PlanLink to={`/plan/${date}`} label="Plan speakers" />
+      )}
+      {hasPrayers ? (
+        <ul className="list-none m-0 p-0 border-t-2 border-walnut-3 pt-1 mt-2">
+          <PrayerRow role="opening" date={date} inlineName={openingName} hideEmpty />
+          <PrayerRow role="benediction" date={date} inlineName={benedictionName} hideEmpty />
+        </ul>
+      ) : (
+        <PlanLink to={`/plan/${date}/prayers`} label="Plan prayers" />
+      )}
+    </div>
+  );
+}
+
+function PlanLink({ to, label }: { to: string; label: string }) {
+  return (
+    <Link
+      to={to}
+      className="inline-flex items-center gap-1.5 text-[13px] font-sans font-semibold text-bordeaux py-3"
+    >
+      <span className="w-4 h-4 border border-bordeaux rounded-sm flex items-center justify-center">
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M12 5v14M5 12h14" />
+        </svg>
+      </span>
+      {label}
+    </Link>
+  );
+}

--- a/src/features/schedule/MobileSundayBody.tsx
+++ b/src/features/schedule/MobileSundayBody.tsx
@@ -1,4 +1,3 @@
-import { Link } from "react-router";
 import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
 import { SpeakerRow } from "./SpeakerRow";
@@ -10,55 +9,33 @@ interface Props {
   speakers: WithId<Speaker>[];
 }
 
+/** Mobile body for a regular Sunday. Real speakers + real prayers
+ *  only — empty slots collapse. The kebab menu in the date header is
+ *  the entry point for "Plan speakers" / "Plan prayers" so the body
+ *  stays purely informational. When a Sunday has nothing planned, the
+ *  body renders nothing — the date row alone communicates the state. */
 export function MobileSundayBody({ date, meeting, speakers }: Props) {
   const openingName = meeting?.openingPrayer?.person?.name ?? "";
   const benedictionName = meeting?.benediction?.person?.name ?? "";
   const hasPrayers = Boolean(openingName.trim() || benedictionName.trim());
 
+  if (speakers.length === 0 && !hasPrayers) return null;
+
   return (
     <div className="px-4 pb-3">
-      {speakers.length > 0 ? (
+      {speakers.length > 0 && (
         <ul className="list-none m-0 p-0">
           {speakers.map((s, idx) => (
             <SpeakerRow key={s.id} number={idx + 1} speaker={s.data} speakerId={s.id} date={date} />
           ))}
         </ul>
-      ) : (
-        <PlanLink to={`/plan/${date}`} label="Plan speakers" />
       )}
-      {hasPrayers ? (
+      {hasPrayers && (
         <ul className="list-none m-0 p-0 border-t-2 border-walnut-3 pt-1 mt-2">
           <PrayerRow role="opening" date={date} inlineName={openingName} hideEmpty />
           <PrayerRow role="benediction" date={date} inlineName={benedictionName} hideEmpty />
         </ul>
-      ) : (
-        <PlanLink to={`/plan/${date}/prayers`} label="Plan prayers" />
       )}
     </div>
-  );
-}
-
-function PlanLink({ to, label }: { to: string; label: string }) {
-  return (
-    <Link
-      to={to}
-      className="inline-flex items-center gap-1.5 text-[13px] font-sans font-semibold text-bordeaux py-3"
-    >
-      <span className="w-4 h-4 border border-bordeaux rounded-sm flex items-center justify-center">
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M12 5v14M5 12h14" />
-        </svg>
-      </span>
-      {label}
-    </Link>
   );
 }

--- a/src/features/schedule/MobileSundayBody.tsx
+++ b/src/features/schedule/MobileSundayBody.tsx
@@ -35,8 +35,6 @@ export function MobileSundayBody({ date, meeting, speakers }: Props) {
             />
           );
         })}
-      </ul>
-      <ul className="list-none m-0 p-0 border-t-2 border-walnut-3 pt-1 mt-2">
         <PrayerRow
           role="opening"
           date={date}

--- a/src/features/schedule/MobileSundayBody.tsx
+++ b/src/features/schedule/MobileSundayBody.tsx
@@ -2,6 +2,9 @@ import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
 import { SpeakerRow } from "./SpeakerRow";
 import { PrayerRow } from "./PrayerRow";
+import { EmptyRosterRow } from "./EmptyRosterRow";
+
+const SPEAKER_SLOT_COUNT = 4;
 
 interface Props {
   date: string;
@@ -9,33 +12,42 @@ interface Props {
   speakers: WithId<Speaker>[];
 }
 
-/** Mobile body for a regular Sunday. Real speakers + real prayers
- *  only — empty slots collapse. The kebab menu in the date header is
- *  the entry point for "Plan speakers" / "Plan prayers" so the body
- *  stays purely informational. When a Sunday has nothing planned, the
- *  body renders nothing — the date row alone communicates the state. */
+/** Mobile body for a regular Sunday. Always renders 4 speaker slots
+ *  + 2 prayer slots — empty slots fall back to "Not assigned"
+ *  placeholder rows. Mirrors the desktop card body's vertical rhythm
+ *  so the list reads as a consistent table without requiring the
+ *  user to count present-vs-missing. The kebab menu in the date row
+ *  is the entry point for "Plan speakers" / "Plan prayers" actions. */
 export function MobileSundayBody({ date, meeting, speakers }: Props) {
-  const openingName = meeting?.openingPrayer?.person?.name ?? "";
-  const benedictionName = meeting?.benediction?.person?.name ?? "";
-  const hasPrayers = Boolean(openingName.trim() || benedictionName.trim());
-
-  if (speakers.length === 0 && !hasPrayers) return null;
-
+  const placeholderCount = Math.max(0, SPEAKER_SLOT_COUNT - speakers.length);
   return (
     <div className="px-4 pb-3">
-      {speakers.length > 0 && (
-        <ul className="list-none m-0 p-0">
-          {speakers.map((s, idx) => (
-            <SpeakerRow key={s.id} number={idx + 1} speaker={s.data} speakerId={s.id} date={date} />
-          ))}
-        </ul>
-      )}
-      {hasPrayers && (
-        <ul className="list-none m-0 p-0 border-t-2 border-walnut-3 pt-1 mt-2">
-          <PrayerRow role="opening" date={date} inlineName={openingName} hideEmpty />
-          <PrayerRow role="benediction" date={date} inlineName={benedictionName} hideEmpty />
-        </ul>
-      )}
+      <ul className="list-none m-0 p-0">
+        {speakers.map((s, idx) => (
+          <SpeakerRow key={s.id} number={idx + 1} speaker={s.data} speakerId={s.id} date={date} />
+        ))}
+        {Array.from({ length: placeholderCount }, (_, i) => {
+          const slot = speakers.length + i + 1;
+          return (
+            <EmptyRosterRow
+              key={`empty-speaker-${slot}`}
+              leadingLabel={String(slot).padStart(2, "0")}
+            />
+          );
+        })}
+      </ul>
+      <ul className="list-none m-0 p-0 border-t-2 border-walnut-3 pt-1 mt-2">
+        <PrayerRow
+          role="opening"
+          date={date}
+          inlineName={meeting?.openingPrayer?.person?.name ?? ""}
+        />
+        <PrayerRow
+          role="benediction"
+          date={date}
+          inlineName={meeting?.benediction?.person?.name ?? ""}
+        />
+      </ul>
     </div>
   );
 }

--- a/src/features/schedule/PageHead.tsx
+++ b/src/features/schedule/PageHead.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import type { ReactNode } from "react";
 
 interface Props {
   eyebrow?: string;
@@ -9,7 +9,7 @@ interface Props {
 
 export function PageHead({ eyebrow, title, subtitle, rightSlot }: Props) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 sm:gap-6 pb-5 sm:pb-6 border-b border-border">
+    <div className="-mx-4 sm:mx-0 px-4 sm:px-0 flex flex-col sm:flex-row sm:items-end justify-between gap-4 sm:gap-6 pb-5 sm:pb-6 border-b border-border">
       <div className="flex-1 min-w-0">
         {eyebrow && (
           <p className="text-[9.5px] uppercase tracking-[0.14em] text-brass-deep mb-2 font-medium font-mono">

--- a/src/features/schedule/PrayerRow.tsx
+++ b/src/features/schedule/PrayerRow.tsx
@@ -11,6 +11,9 @@ interface Props {
   inlineName: string;
   role: PrayerRole;
   date: string;
+  /** Mobile list view collapses unfilled rows; pass `true` to render
+   *  nothing (instead of an `EmptyRosterRow`) when no name is set. */
+  hideEmpty?: boolean;
 }
 
 const STATE_CLS: Record<InvitationStatus, string> = {
@@ -36,13 +39,14 @@ const ROLE_WIDTH_CLS = "w-6";
  *  role label, name, status pill, chat launcher. Falls back to
  *  `EmptyRosterRow` when no name is set so unfilled prayer slots
  *  share their height + look with the speaker placeholder slots. */
-export function PrayerRow({ inlineName, role, date }: Props) {
+export function PrayerRow({ inlineName, role, date, hideEmpty = false }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId) ?? "";
   const { data: participant } = usePrayerParticipant(date, role);
   const name = participant?.name?.trim() || inlineName.trim();
   const status: InvitationStatus = participant?.status ?? "planned";
 
   if (!name) {
+    if (hideEmpty) return null;
     return <EmptyRosterRow leadingLabel={ROLE_LABEL[role]} leadingWidthCls={ROLE_WIDTH_CLS} />;
   }
 

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -17,7 +17,10 @@ import { groupByMonth } from "./utils/groupByMonth";
 
 const MOBILE_INITIAL_WEEKS = 4;
 const MOBILE_STEP_WEEKS = 4;
-const MOBILE_MAX_WEEKS = 52;
+// 26 weeks ≈ 6 months. Past that, the bishopric is planning further
+// out than is useful — speakers haven't even been assigned to wards
+// for those weeks yet — so the list caps and the bottom communicates.
+const MOBILE_MAX_WEEKS = 26;
 
 export function ScheduleView() {
   const wardId = useCurrentWardStore((s) => s.wardId);
@@ -78,12 +81,19 @@ export function ScheduleView() {
               leadTimeDays={leadTimeDays}
               nonMeetingSundays={nonMeeting}
             />
-            <div
-              ref={sentinelRef}
-              className="text-center py-6 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3"
-            >
-              {loadingMore ? "Loading…" : ""}
-            </div>
+            {mobileHorizon < MOBILE_MAX_WEEKS && (
+              <div
+                ref={sentinelRef}
+                className="text-center py-6 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3"
+              >
+                {loadingMore ? "Loading…" : ""}
+              </div>
+            )}
+            {mobileHorizon >= MOBILE_MAX_WEEKS && (
+              <div className="text-center py-6 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 border-t border-border/60">
+                Showing up to 6 months ahead
+              </div>
+            )}
           </>
         ) : (
           <div className="mt-8">

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -33,7 +33,11 @@ export function ScheduleView() {
     if (stored) setHorizon(Number(stored));
   }, []);
 
-  const { weeks: mobileHorizon, sentinelRef } = useInfiniteHorizon(isMobile, {
+  const {
+    weeks: mobileHorizon,
+    loading: loadingMore,
+    sentinelRef,
+  } = useInfiniteHorizon(isMobile, {
     initial: MOBILE_INITIAL_WEEKS,
     step: MOBILE_STEP_WEEKS,
     max: MOBILE_MAX_WEEKS,
@@ -74,7 +78,12 @@ export function ScheduleView() {
               leadTimeDays={leadTimeDays}
               nonMeetingSundays={nonMeeting}
             />
-            <div ref={sentinelRef} aria-hidden className="h-px" />
+            <div
+              ref={sentinelRef}
+              className="text-center py-6 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3"
+            >
+              {loadingMore ? "Loading…" : ""}
+            </div>
           </>
         ) : (
           <div className="mt-8">

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -17,10 +17,10 @@ import { groupByMonth } from "./utils/groupByMonth";
 
 const MOBILE_INITIAL_WEEKS = 4;
 const MOBILE_STEP_WEEKS = 4;
-// 26 weeks ≈ 6 months. Past that, the bishopric is planning further
+// 17 weeks ≈ 4 months. Past that, the bishopric is planning further
 // out than is useful — speakers haven't even been assigned to wards
 // for those weeks yet — so the list caps and the bottom communicates.
-const MOBILE_MAX_WEEKS = 26;
+const MOBILE_MAX_WEEKS = 17;
 
 export function ScheduleView() {
   const wardId = useCurrentWardStore((s) => s.wardId);
@@ -91,7 +91,7 @@ export function ScheduleView() {
             )}
             {mobileHorizon >= MOBILE_MAX_WEEKS && (
               <div className="text-center py-6 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 border-t border-border/60">
-                Showing up to 6 months ahead
+                Showing up to 4 months ahead
               </div>
             )}
           </>

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -4,6 +4,7 @@ import { TwilioAutoConnect } from "@/features/invitations/TwilioAutoConnect";
 import { TwilioChatProvider } from "@/features/invitations/TwilioChatProvider";
 import { SubscribePrompt } from "@/features/notifications/SubscribePrompt";
 import { useUpcomingMeetings } from "./hooks/useUpcomingMeetings";
+import { useInfiniteHorizon } from "./hooks/useInfiniteHorizon";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
@@ -13,6 +14,10 @@ import { SundayCard } from "./SundayCard";
 import { QuarterSection } from "./QuarterSection";
 import { MobileScheduleList } from "./MobileScheduleList";
 import { groupByMonth } from "./utils/groupByMonth";
+
+const MOBILE_INITIAL_WEEKS = 4;
+const MOBILE_STEP_WEEKS = 4;
+const MOBILE_MAX_WEEKS = 52;
 
 export function ScheduleView() {
   const wardId = useCurrentWardStore((s) => s.wardId);
@@ -28,7 +33,14 @@ export function ScheduleView() {
     if (stored) setHorizon(Number(stored));
   }, []);
 
-  const { slots, error } = useUpcomingMeetings(horizon);
+  const { weeks: mobileHorizon, sentinelRef } = useInfiniteHorizon(isMobile, {
+    initial: MOBILE_INITIAL_WEEKS,
+    step: MOBILE_STEP_WEEKS,
+    max: MOBILE_MAX_WEEKS,
+  });
+
+  const horizonInUse = isMobile ? mobileHorizon : horizon;
+  const { slots, error } = useUpcomingMeetings(horizonInUse);
 
   if (!wardId) return null;
 
@@ -52,15 +64,18 @@ export function ScheduleView() {
           eyebrow="Sacrament meeting"
           title="Schedule"
           subtitle="Assign speakers for the weeks ahead."
-          rightSlot={<HorizonSelect value={horizon} onChange={setHorizon} />}
+          rightSlot={isMobile ? null : <HorizonSelect value={horizon} onChange={setHorizon} />}
         />
 
         {isMobile ? (
-          <MobileScheduleList
-            monthGroups={monthGroups}
-            leadTimeDays={leadTimeDays}
-            nonMeetingSundays={nonMeeting}
-          />
+          <>
+            <MobileScheduleList
+              monthGroups={monthGroups}
+              leadTimeDays={leadTimeDays}
+              nonMeetingSundays={nonMeeting}
+            />
+            <div ref={sentinelRef} aria-hidden className="h-px" />
+          </>
         ) : (
           <div className="mt-8">
             {monthGroups.map((group) => (

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -5,11 +5,13 @@ import { TwilioChatProvider } from "@/features/invitations/TwilioChatProvider";
 import { SubscribePrompt } from "@/features/notifications/SubscribePrompt";
 import { useUpcomingMeetings } from "./hooks/useUpcomingMeetings";
 import { useWardSettings } from "@/hooks/useWardSettings";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { PageHead } from "./PageHead";
 import { HorizonSelect } from "./HorizonSelect";
 import { SundayCard } from "./SundayCard";
 import { QuarterSection } from "./QuarterSection";
+import { MobileScheduleList } from "./MobileScheduleList";
 import { groupByMonth } from "./utils/groupByMonth";
 
 export function ScheduleView() {
@@ -18,6 +20,7 @@ export function ScheduleView() {
   const defaultHorizon = settingsState.data?.settings.scheduleHorizonWeeks ?? 8;
   const leadTimeDays = settingsState.data?.settings.speakerLeadTimeDays ?? 14;
   const nonMeeting = settingsState.data?.settings.nonMeetingSundays ?? [];
+  const isMobile = useIsMobile();
 
   const [horizon, setHorizon] = useState(defaultHorizon);
   useEffect(() => {
@@ -52,26 +55,34 @@ export function ScheduleView() {
           rightSlot={<HorizonSelect value={horizon} onChange={setHorizon} />}
         />
 
-        <div className="mt-8">
-          {monthGroups.map((group) => (
-            <QuarterSection
-              key={`${group.year}-${group.month}`}
-              title={group.label}
-              count={group.sundays.length}
-            >
-              {group.sundays.map((sunday) => (
-                <SundayCard
-                  key={sunday.date}
-                  date={sunday.date}
-                  meeting={sunday.meeting}
-                  fallbackType={defaultMeetingType(sunday.date, nonMeeting)}
-                  leadTimeDays={leadTimeDays}
-                  nonMeetingSundays={nonMeeting}
-                />
-              ))}
-            </QuarterSection>
-          ))}
-        </div>
+        {isMobile ? (
+          <MobileScheduleList
+            monthGroups={monthGroups}
+            leadTimeDays={leadTimeDays}
+            nonMeetingSundays={nonMeeting}
+          />
+        ) : (
+          <div className="mt-8">
+            {monthGroups.map((group) => (
+              <QuarterSection
+                key={`${group.year}-${group.month}`}
+                title={group.label}
+                count={group.sundays.length}
+              >
+                {group.sundays.map((sunday) => (
+                  <SundayCard
+                    key={sunday.date}
+                    date={sunday.date}
+                    meeting={sunday.meeting}
+                    fallbackType={defaultMeetingType(sunday.date, nonMeeting)}
+                    leadTimeDays={leadTimeDays}
+                    nonMeetingSundays={nonMeeting}
+                  />
+                ))}
+              </QuarterSection>
+            ))}
+          </div>
+        )}
       </main>
     </TwilioChatProvider>
   );

--- a/src/features/schedule/SundayCardSpecial.tsx
+++ b/src/features/schedule/SundayCardSpecial.tsx
@@ -10,6 +10,9 @@ interface Props {
   description: string;
   date: string;
   meeting: SacramentMeeting | null;
+  /** Mobile list view surfaces "Plan prayers" inside the kebab menu;
+   *  set true to suppress the redundant inline link. */
+  hidePlanLink?: boolean;
 }
 
 const STAMP_ICON_CLS: Record<KindVariant, string> = {
@@ -26,7 +29,14 @@ const STAMP_LABEL_CLS: Record<KindVariant, string> = {
   general: "text-bordeaux",
 };
 
-export function SundayCardSpecial({ variant, stampLabel, description, date, meeting }: Props) {
+export function SundayCardSpecial({
+  variant,
+  stampLabel,
+  description,
+  date,
+  meeting,
+  hidePlanLink = false,
+}: Props) {
   return (
     <div className="flex flex-1 flex-col px-4 pb-4">
       <div className="flex items-center gap-2.5 pt-1 pb-1">
@@ -64,26 +74,28 @@ export function SundayCardSpecial({ variant, stampLabel, description, date, meet
           inlineName={meeting?.benediction?.person?.name ?? ""}
         />
       </ul>
-      <Link
-        to={`/plan/${date}/prayers`}
-        className="inline-flex items-center gap-1.5 text-[13px] font-sans font-semibold text-bordeaux hover:text-bordeaux-deep transition-colors py-1.5 md:opacity-0 md:group-hover:opacity-100 md:focus:opacity-100"
-      >
-        <span className="w-4 h-4 border border-bordeaux rounded-sm flex items-center justify-center">
-          <svg
-            width="10"
-            height="10"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M12 5v14M5 12h14" />
-          </svg>
-        </span>
-        Plan prayers
-      </Link>
+      {!hidePlanLink && (
+        <Link
+          to={`/plan/${date}/prayers`}
+          className="inline-flex items-center gap-1.5 text-[13px] font-sans font-semibold text-bordeaux hover:text-bordeaux-deep transition-colors py-1.5 md:opacity-0 md:group-hover:opacity-100 md:focus:opacity-100"
+        >
+          <span className="w-4 h-4 border border-bordeaux rounded-sm flex items-center justify-center">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </span>
+          Plan prayers
+        </Link>
+      )}
     </div>
   );
 }

--- a/src/features/schedule/SundayCardSpecial.tsx
+++ b/src/features/schedule/SundayCardSpecial.tsx
@@ -38,8 +38,8 @@ export function SundayCardSpecial({
   hidePlanLink = false,
 }: Props) {
   return (
-    <div className="flex flex-1 flex-col px-4 pb-4">
-      <div className="flex items-center gap-2.5 pt-1 pb-1">
+    <div className="flex flex-1 flex-col px-4 pt-3 pb-4">
+      <div className="flex items-center gap-2.5 pb-1">
         <span
           className={cn(
             "w-5.5 h-5.5 rounded-full border inline-flex items-center justify-center font-display text-[11px] shrink-0",

--- a/src/features/schedule/SundayMenuOptions.tsx
+++ b/src/features/schedule/SundayMenuOptions.tsx
@@ -1,0 +1,80 @@
+import type { MeetingType } from "@/lib/types";
+import { TYPE_LABELS } from "@/features/meetings/utils/meetingLabels";
+import { cn } from "@/lib/cn";
+import { SundayMenuPlanActions } from "./SundayMenuPlanActions";
+
+const TYPES: readonly MeetingType[] = ["regular", "fast", "stake", "general"];
+
+interface Props {
+  date: string;
+  currentType: MeetingType;
+  locked: boolean;
+  showPlanActions: boolean;
+  onSelect: (type: MeetingType) => void;
+  onClose: () => void;
+}
+
+/** Inner content of the SundayTypeMenu: Plan actions (mobile only) +
+ *  Sunday-type radio + locked notice. Rendered inside either the
+ *  desktop popover or the mobile bottom sheet. */
+export function SundayMenuOptions({
+  date,
+  currentType,
+  locked,
+  showPlanActions,
+  onSelect,
+  onClose,
+}: Props) {
+  return (
+    <>
+      {showPlanActions && <SundayMenuPlanActions date={date} onSelect={onClose} />}
+      <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-walnut-3 px-2.5 pt-1.5 pb-1">
+        Sunday type
+      </div>
+      {TYPES.map((type) => {
+        const active = type === currentType;
+        const disabled = locked && !active;
+        return (
+          <button
+            key={type}
+            role="menuitemradio"
+            aria-checked={active}
+            aria-disabled={disabled}
+            onClick={() => !disabled && onSelect(type)}
+            className={cn(
+              "grid grid-cols-[16px_1fr] items-center gap-1.5 w-full px-2.5 py-2 text-left font-display text-[13.5px] rounded-sm transition-colors",
+              active && "text-bordeaux font-medium",
+              !active && !disabled && "text-walnut hover:bg-parchment",
+              disabled && "text-walnut-3 opacity-40 cursor-not-allowed",
+            )}
+          >
+            <span className="text-[8px] text-bordeaux text-center leading-none">
+              {active ? "•" : ""}
+            </span>
+            <span>{TYPE_LABELS[type]}</span>
+          </button>
+        );
+      })}
+      {locked && (
+        <div className="flex items-start gap-1.5 px-2.5 pt-2 pb-1 mt-1 border-t border-border font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 leading-[1.35]">
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.75"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-bordeaux shrink-0 mt-0.5"
+            aria-hidden
+          >
+            <path d="M12 9v4M12 17h.01" />
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+          </svg>
+          <span>Locked — remove confirmed speakers to change.</span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/features/schedule/SundayMenuPlanActions.tsx
+++ b/src/features/schedule/SundayMenuPlanActions.tsx
@@ -1,0 +1,55 @@
+import { Link } from "react-router";
+
+interface Props {
+  date: string;
+  onSelect: () => void;
+}
+
+/** Top section of the SundayTypeMenu surfaced on the mobile list view.
+ *  Replaces the desktop card's hover-revealed plan links — the menu is
+ *  the only place these actions live on a phone. Calls `onSelect` after
+ *  navigation so the menu closes itself. */
+export function SundayMenuPlanActions({ date, onSelect }: Props) {
+  return (
+    <>
+      <Link
+        role="menuitem"
+        to={`/plan/${date}`}
+        onClick={onSelect}
+        className="flex items-center gap-2 w-full px-2.5 py-1.5 text-left font-display text-[13px] rounded-sm text-walnut hover:bg-parchment transition-colors"
+      >
+        <PlusIcon />
+        <span>Plan speakers</span>
+      </Link>
+      <Link
+        role="menuitem"
+        to={`/plan/${date}/prayers`}
+        onClick={onSelect}
+        className="flex items-center gap-2 w-full px-2.5 py-1.5 text-left font-display text-[13px] rounded-sm text-walnut hover:bg-parchment transition-colors"
+      >
+        <PlusIcon />
+        <span>Plan prayers</span>
+      </Link>
+      <div className="border-t border-border my-1.5" />
+    </>
+  );
+}
+
+function PlusIcon() {
+  return (
+    <span className="w-4 h-4 border border-bordeaux rounded-sm flex items-center justify-center text-bordeaux shrink-0">
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 5v14M5 12h14" />
+      </svg>
+    </span>
+  );
+}

--- a/src/features/schedule/SundayTypeMenu.tsx
+++ b/src/features/schedule/SundayTypeMenu.tsx
@@ -4,7 +4,7 @@ import { updateMeetingField } from "@/features/meetings/utils/updateMeeting";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { MobileBottomSheet } from "@/components/ui/MobileBottomSheet";
 import { SundayMenuOptions } from "./SundayMenuOptions";
-import { formatShortSunday, formatCountdown } from "./utils/dateFormat";
+import { formatShortDate, formatSundayOrdinal, formatCountdown } from "./utils/dateFormat";
 
 interface Props {
   wardId: string;
@@ -89,13 +89,12 @@ export function SundayTypeMenu({
       )}
       {isMobile && (
         <MobileBottomSheet open={open} onClose={() => setOpen(false)}>
-          <div className="px-2.5 pb-3 mb-1.5 border-b border-border">
-            <div className="font-display font-semibold text-walnut text-xl leading-tight">
-              {formatShortSunday(date)}
-            </div>
-            <div className="font-mono text-[10px] tracking-[0.08em] uppercase text-walnut-3 mt-0.5">
-              {formatCountdown(date)}
-            </div>
+          <div className="px-2.5 pb-3 mb-1.5 border-b border-border font-display text-walnut text-base">
+            <span className="font-semibold">{formatSundayOrdinal(date)}</span>
+            <span className="text-walnut-3 mx-2">·</span>
+            <span>{formatShortDate(date)}</span>
+            <span className="text-walnut-3 mx-2">·</span>
+            <span className="text-walnut-2">{formatCountdown(date)}</span>
           </div>
           <SundayMenuOptions
             date={date}

--- a/src/features/schedule/SundayTypeMenu.tsx
+++ b/src/features/schedule/SundayTypeMenu.tsx
@@ -4,6 +4,7 @@ import { updateMeetingField } from "@/features/meetings/utils/updateMeeting";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { MobileBottomSheet } from "@/components/ui/MobileBottomSheet";
 import { SundayMenuOptions } from "./SundayMenuOptions";
+import { formatShortSunday, formatCountdown } from "./utils/dateFormat";
 
 interface Props {
   wardId: string;
@@ -88,6 +89,14 @@ export function SundayTypeMenu({
       )}
       {isMobile && (
         <MobileBottomSheet open={open} onClose={() => setOpen(false)}>
+          <div className="px-2.5 pb-3 mb-1.5 border-b border-border">
+            <div className="font-display font-semibold text-walnut text-xl leading-tight">
+              {formatShortSunday(date)}
+            </div>
+            <div className="font-mono text-[10px] tracking-[0.08em] uppercase text-walnut-3 mt-0.5">
+              {formatCountdown(date)}
+            </div>
+          </div>
           <SundayMenuOptions
             date={date}
             currentType={currentType}

--- a/src/features/schedule/SundayTypeMenu.tsx
+++ b/src/features/schedule/SundayTypeMenu.tsx
@@ -3,6 +3,7 @@ import type { MeetingType, NonMeetingSunday } from "@/lib/types";
 import { updateMeetingField } from "@/features/meetings/utils/updateMeeting";
 import { TYPE_LABELS } from "@/features/meetings/utils/meetingLabels";
 import { cn } from "@/lib/cn";
+import { SundayMenuPlanActions } from "./SundayMenuPlanActions";
 
 interface Props {
   wardId: string;
@@ -10,11 +11,23 @@ interface Props {
   currentType: MeetingType;
   locked: boolean;
   nonMeetingSundays: readonly NonMeetingSunday[];
+  /** When true, surface "Plan speakers" / "Plan prayers" actions at
+   *  the top of the menu. Used by the mobile list view, where hover-
+   *  revealed plan links don't translate. Desktop cards keep their
+   *  inline plan links and leave this off. */
+  showPlanActions?: boolean;
 }
 
 const TYPES: readonly MeetingType[] = ["regular", "fast", "stake", "general"];
 
-export function SundayTypeMenu({ wardId, date, currentType, locked, nonMeetingSundays }: Props) {
+export function SundayTypeMenu({
+  wardId,
+  date,
+  currentType,
+  locked,
+  nonMeetingSundays,
+  showPlanActions = false,
+}: Props) {
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -64,6 +77,7 @@ export function SundayTypeMenu({ wardId, date, currentType, locked, nonMeetingSu
           role="menu"
           className="absolute right-0 mt-1.5 min-w-50 bg-chalk border border-border rounded-lg shadow-[0_10px_28px_rgba(58,37,25,0.12),0_2px_6px_rgba(58,37,25,0.06)] p-1.5 z-20 animate-[menuIn_120ms_ease-out]"
         >
+          {showPlanActions && <SundayMenuPlanActions date={date} onSelect={() => setOpen(false)} />}
           <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-walnut-3 px-2.5 pt-1.5 pb-1">
             Sunday type
           </div>

--- a/src/features/schedule/SundayTypeMenu.tsx
+++ b/src/features/schedule/SundayTypeMenu.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import type { MeetingType, NonMeetingSunday } from "@/lib/types";
 import { updateMeetingField } from "@/features/meetings/utils/updateMeeting";
-import { TYPE_LABELS } from "@/features/meetings/utils/meetingLabels";
-import { cn } from "@/lib/cn";
-import { SundayMenuPlanActions } from "./SundayMenuPlanActions";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { MobileBottomSheet } from "@/components/ui/MobileBottomSheet";
+import { SundayMenuOptions } from "./SundayMenuOptions";
 
 interface Props {
   wardId: string;
@@ -18,8 +18,6 @@ interface Props {
   showPlanActions?: boolean;
 }
 
-const TYPES: readonly MeetingType[] = ["regular", "fast", "stake", "general"];
-
 export function SundayTypeMenu({
   wardId,
   date,
@@ -31,9 +29,10 @@ export function SundayTypeMenu({
   const [open, setOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const isMobile = useIsMobile();
 
   useEffect(() => {
-    if (!open) return;
+    if (!open || isMobile) return;
     function handleClickOutside(e: MouseEvent) {
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) setOpen(false);
     }
@@ -46,7 +45,7 @@ export function SundayTypeMenu({
       document.removeEventListener("mousedown", handleClickOutside);
       document.removeEventListener("keydown", handleEsc);
     };
-  }, [open]);
+  }, [open, isMobile]);
 
   async function handleSelect(type: MeetingType) {
     if (locked || saving || type === currentType) {
@@ -72,59 +71,32 @@ export function SundayTypeMenu({
       >
         <span className="text-lg -mt-0.5">⋯</span>
       </button>
-      {open && (
+      {open && !isMobile && (
         <div
           role="menu"
           className="absolute right-0 mt-1.5 min-w-50 bg-chalk border border-border rounded-lg shadow-[0_10px_28px_rgba(58,37,25,0.12),0_2px_6px_rgba(58,37,25,0.06)] p-1.5 z-20 animate-[menuIn_120ms_ease-out]"
         >
-          {showPlanActions && <SundayMenuPlanActions date={date} onSelect={() => setOpen(false)} />}
-          <div className="font-mono text-[9px] uppercase tracking-[0.18em] text-walnut-3 px-2.5 pt-1.5 pb-1">
-            Sunday type
-          </div>
-          {TYPES.map((type) => {
-            const active = type === currentType;
-            const disabled = locked && !active;
-            return (
-              <button
-                key={type}
-                role="menuitemradio"
-                aria-checked={active}
-                aria-disabled={disabled}
-                onClick={() => !disabled && handleSelect(type)}
-                className={cn(
-                  "grid grid-cols-[16px_1fr] items-center gap-1.5 w-full px-2.5 py-1.5 text-left font-display text-[13px] rounded-sm transition-colors",
-                  active && "text-bordeaux font-medium",
-                  !active && !disabled && "text-walnut hover:bg-parchment",
-                  disabled && "text-walnut-3 opacity-40 cursor-not-allowed",
-                )}
-              >
-                <span className="text-[8px] text-bordeaux text-center leading-none">
-                  {active ? "•" : ""}
-                </span>
-                <span>{TYPE_LABELS[type]}</span>
-              </button>
-            );
-          })}
-          {locked && (
-            <div className="flex items-start gap-1.5 px-2.5 pt-2 pb-1 mt-1 border-t border-border font-mono text-[9.5px] uppercase tracking-[0.08em] text-walnut-3 leading-[1.35]">
-              <svg
-                width="12"
-                height="12"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.75"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="text-bordeaux shrink-0 mt-0.5"
-              >
-                <path d="M12 9v4M12 17h.01" />
-                <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-              </svg>
-              <span>Locked — remove confirmed speakers to change.</span>
-            </div>
-          )}
+          <SundayMenuOptions
+            date={date}
+            currentType={currentType}
+            locked={locked}
+            showPlanActions={showPlanActions}
+            onSelect={handleSelect}
+            onClose={() => setOpen(false)}
+          />
         </div>
+      )}
+      {isMobile && (
+        <MobileBottomSheet open={open} onClose={() => setOpen(false)}>
+          <SundayMenuOptions
+            date={date}
+            currentType={currentType}
+            locked={locked}
+            showPlanActions={showPlanActions}
+            onSelect={handleSelect}
+            onClose={() => setOpen(false)}
+          />
+        </MobileBottomSheet>
       )}
     </div>
   );

--- a/src/features/schedule/hooks/useInfiniteHorizon.ts
+++ b/src/features/schedule/hooks/useInfiniteHorizon.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
+const LOAD_DELAY_MS = 450;
+
 interface Options {
   /** First load — number of weeks rendered immediately. */
   initial: number;
@@ -13,36 +15,55 @@ interface Options {
 
 interface Result {
   weeks: number;
+  /** True while the load delay is in flight — caller should render a
+   *  "Loading…" indicator. Flips back to false once `weeks` updates. */
+  loading: boolean;
   /** Attach to a sentinel element rendered just below the bottom of
    *  the list. Once the sentinel scrolls into view (with a 200px
-   *  pre-roll), the horizon grows by `step`. */
+   *  pre-roll), the horizon grows by `step` after a short delay. */
   sentinelRef: React.RefObject<HTMLDivElement | null>;
 }
 
 /** Scroll-driven horizon for the mobile schedule. The user has no
  *  HorizonSelect on a phone — the list starts at `initial` weeks and
- *  grows by `step` each time they scroll near the bottom, capped at
- *  `max`. Pass `enabled: false` (i.e. on desktop) to short-circuit the
- *  IntersectionObserver entirely so the desktop path stays static. */
+ *  grows by `step` each time they scroll near the bottom (capped at
+ *  `max`). A 450ms delay between intersection and load + a `loading`
+ *  flag give the caller a chance to surface "Loading…" feedback so
+ *  the growth doesn't feel instantaneous and disorienting. Pass
+ *  `enabled: false` (i.e. on desktop) to short-circuit the
+ *  IntersectionObserver entirely. */
 export function useInfiniteHorizon(enabled: boolean, options: Options): Result {
   const [weeks, setWeeks] = useState(options.initial);
+  const [loading, setLoading] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!enabled || weeks >= options.max) return;
     const el = sentinelRef.current;
     if (!el) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
     const obs = new IntersectionObserver(
       (entries) => {
-        if (entries[0]?.isIntersecting) {
+        if (!entries[0]?.isIntersecting) return;
+        if (timer) return;
+        setLoading(true);
+        timer = setTimeout(() => {
           setWeeks((w) => Math.min(w + options.step, options.max));
-        }
+          setLoading(false);
+          timer = null;
+        }, LOAD_DELAY_MS);
       },
       { rootMargin: "200px" },
     );
     obs.observe(el);
-    return () => obs.disconnect();
+    return () => {
+      obs.disconnect();
+      if (timer) {
+        clearTimeout(timer);
+        setLoading(false);
+      }
+    };
   }, [enabled, weeks, options.step, options.max]);
 
-  return { weeks, sentinelRef };
+  return { weeks, loading, sentinelRef };
 }

--- a/src/features/schedule/hooks/useInfiniteHorizon.ts
+++ b/src/features/schedule/hooks/useInfiniteHorizon.ts
@@ -1,0 +1,48 @@
+import { useEffect, useRef, useState } from "react";
+
+interface Options {
+  /** First load — number of weeks rendered immediately. */
+  initial: number;
+  /** How many additional weeks to pull in each time the sentinel
+   *  enters view. */
+  step: number;
+  /** Hard ceiling. Once `weeks >= max`, the observer disconnects and
+   *  scroll won't trigger more loads. */
+  max: number;
+}
+
+interface Result {
+  weeks: number;
+  /** Attach to a sentinel element rendered just below the bottom of
+   *  the list. Once the sentinel scrolls into view (with a 200px
+   *  pre-roll), the horizon grows by `step`. */
+  sentinelRef: React.RefObject<HTMLDivElement | null>;
+}
+
+/** Scroll-driven horizon for the mobile schedule. The user has no
+ *  HorizonSelect on a phone — the list starts at `initial` weeks and
+ *  grows by `step` each time they scroll near the bottom, capped at
+ *  `max`. Pass `enabled: false` (i.e. on desktop) to short-circuit the
+ *  IntersectionObserver entirely so the desktop path stays static. */
+export function useInfiniteHorizon(enabled: boolean, options: Options): Result {
+  const [weeks, setWeeks] = useState(options.initial);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!enabled || weeks >= options.max) return;
+    const el = sentinelRef.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) {
+          setWeeks((w) => Math.min(w + options.step, options.max));
+        }
+      },
+      { rootMargin: "200px" },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [enabled, weeks, options.step, options.max]);
+
+  return { weeks, sentinelRef };
+}

--- a/src/features/schedule/utils/dateFormat.ts
+++ b/src/features/schedule/utils/dateFormat.ts
@@ -21,6 +21,22 @@ export function formatShortSunday(iso: string): string {
   });
 }
 
+/** "1st Sunday", "2nd Sunday", "5th Sunday" — based on which Sunday
+ *  of the month the given ISO date is. Sundays are 7 days apart, so
+ *  ceil(day-of-month / 7) gives the ordinal directly: day 1–7 → 1st,
+ *  8–14 → 2nd, 15–21 → 3rd, 22–28 → 4th, 29–31 → 5th. The caller is
+ *  expected to pass an actual Sunday date; no validation here. */
+export function formatSundayOrdinal(iso: string): string {
+  const [, , dStr] = iso.split("-");
+  const day = Number(dStr);
+  if (!Number.isInteger(day) || day < 1) return iso;
+  const ordinal = Math.ceil(day / 7);
+  const SUFFIX = ["th", "st", "nd", "rd"];
+  const v = ordinal % 100;
+  const suffix = SUFFIX[(v - 20) % 10] ?? SUFFIX[v] ?? SUFFIX[0];
+  return `${ordinal}${suffix} Sunday`;
+}
+
 export function formatCountdown(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number);
   if (!y || !m || !d) return iso;

--- a/src/stores/userMenuStore.ts
+++ b/src/stores/userMenuStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+interface UserMenuStore {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  toggle: () => void;
+  close: () => void;
+}
+
+/** Open/close state for the user menu. Lifted to a store because the
+ *  trigger (in Topbar/UserMenu) and the mobile side drawer (rendered
+ *  by AppShell so it can coordinate the page-push transform) live in
+ *  different parts of the tree. Desktop continues to use the inline
+ *  popover, which also reads from this same store so the trigger stays
+ *  in sync regardless of which surface is rendering the contents. */
+export const useUserMenuStore = create<UserMenuStore>((set) => ({
+  open: false,
+  setOpen: (open) => set({ open }),
+  toggle: () => set((s) => ({ open: !s.open })),
+  close: () => set({ open: false }),
+}));

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -264,6 +264,24 @@
   }
 }
 
+@keyframes drawerSlideInRight {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes drawerSlideOutRight {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
 @keyframes fadeOut {
   from {
     opacity: 1;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -264,24 +264,6 @@
   }
 }
 
-@keyframes drawerSlideInRight {
-  from {
-    transform: translateX(100%);
-  }
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes drawerSlideOutRight {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(100%);
-  }
-}
-
 @keyframes fadeOut {
   from {
     opacity: 1;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -255,6 +255,24 @@
   }
 }
 
+@keyframes drawerSlideDown {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(100%);
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
 /* Soft pulse ring for attention-worthy FABs. Used on the speaker
    invite page to draw the eye to the chat drawer when the speaker
    hasn't responded yet or the bishop has replied. */


### PR DESCRIPTION
## Summary

Mobile gets a real planning surface. Schedule becomes an edge-to-edge list with sticky per-Sunday date rows, infinite-scroll horizon (capped at 4 months), and dropdowns that open as native-feeling bottom sheets. The user menu becomes a right-side drawer. The top app bar goes properly dark on phone-class viewports.

Under the hood, every overlay surface in the app — the schedule's option dropdowns, both chat drawers, and the user menu — now runs on [`vaul`](https://vaul.emilkowal.ski/) for drag-to-dismiss + spring animations.

## What's in here

### Mobile schedule list
- New `MobileScheduleList` + `MobileSundayBlock` + `MobileSundayBody` swap in below the `md` breakpoint. Edge-to-edge, sticky per-Sunday date row, real speakers + 2 prayers slots (collapsed empties).
- Plan speakers / Plan prayers actions move into the per-Sunday kebab menu (no inline links cluttering the rows).
- Special Sundays (fast / stake / general) reuse `SundayCardSpecial` with a `hidePlanLink` prop so the inline link doesn't conflict with the menu action.
- Cancelled meetings render as a strikethrough date row with the reason below.

### Infinite-scroll horizon (mobile)
- New `useInfiniteHorizon` hook: starts at 4 weeks, loads 4 more each time the sentinel comes into view (with a 200px pre-roll + 450ms loading delay so the user sees a "Loading…" line). Capped at 4 months — bottom of list reads "Showing up to 4 months ahead."
- `HorizonSelect` dropdown is gated to desktop. Its options also tightened to 1/2/3/4 months.

### Bottom sheets (vaul)
- New `MobileBottomSheet` primitive. `HorizonSelect` + `SundayTypeMenu` use it on mobile (popover stays for desktop). Sheet header on the Sunday menu reads `1st Sunday · May 3 · In 6 days` so the user sees which week they're editing.
- Drag-to-dismiss, ESC, backdrop tap, body-scroll lock — all from vaul.

### Chat drawers (vaul)
- `BishopInvitationDialog` and `SpeakerChatFloatingDrawer` rebuilt on `Drawer.Root` (`direction="bottom"`). Bottom-anchored on mobile (full-width), bottom-anchored centered/right-docked on desktop. Same drag UX everywhere.
- Net ~200 lines deleted from those two files combined.

### User menu side drawer
- New `userMenuStore` (zustand) + `UserMenuContent` extracted shared between desktop popover and mobile side drawer.
- New `UserSideDrawer` — vaul `direction="right"` — slides in from the right on mobile. Dimmed backdrop tap closes; drag right also closes. Built-in close button at top-right; avatar bumps to 64px and stacks above name/email; built-by-credit + version pinned to bottom-center.
- `Topbar` darkens on mobile (`bg-walnut` + light text overrides), with a subtle elev-1 drop shadow on both layouts.

### Bug fixes along the way
- Sticky descendants killed by `will-change: transform` on the AppShell push wrapper → removed (push is gone now anyway).
- Sticky descendants killed by `overflow-x-hidden` (creates a scroll container) → switched to `overflow-x-clip` while the push existed; later removed entirely.
- Open/close flicker on the original hand-rolled animations → pinned `animation-fill-mode: backwards` on entry and `forwards` on exit before migrating to vaul.
- HorizonSelect popover at `z-10` covered by sticky list rows → bumped to `z-30`.

## Verification

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors (201 warnings, all pre-existing)
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 45 files / 346 tests pass
- [x] `pnpm build` — clean (3.58s)
- [ ] CI: full pipeline (lint + format + typecheck + unit + rules + e2e)
- [ ] Manual: phone viewport sweep

## Diff

`26 files changed, +1491 / −360`. Net code increase is mostly the new mobile components; the vaul migrations actually shed ~250 lines of mount/exit/animation state machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)