### PR TITLE
ui(desktop): right-side chat drawer + scrollbar behind topbar + weeks-based horizon

### DIFF
--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -11,23 +11,31 @@ export function AppShell() {
   const isMobile = useIsMobile();
   const hidden = useHideOnScroll(isMobile);
 
+  // Mobile: body scrolls. Sticky topbar with auto-hide on scroll. The
+  // browser's vertical scrollbar runs full-height — fine on touch
+  // devices where it's an overlay.
+  // Desktop: outer is `h-dvh + overflow-hidden`; the inner content
+  // wrapper owns the scroll. That way the vertical scrollbar starts
+  // BELOW the topbar instead of running edge-to-edge alongside it.
   return (
-    <div className="flex min-h-dvh flex-col bg-parchment paper-grain">
+    <div className="flex flex-col bg-parchment paper-grain min-h-dvh sm:h-dvh sm:overflow-hidden">
       <div
         className={cn(
-          "sticky top-0 z-20 transition-transform duration-200 ease-out will-change-transform",
+          "z-20 sticky top-0 sm:static transition-transform duration-200 ease-out will-change-transform",
           hidden && "-translate-y-full",
         )}
       >
         <Topbar />
         <OnlineStatusBanner />
       </div>
-      <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
-        <Outlet />
+      <div className="flex flex-1 flex-col sm:overflow-y-auto sm:overflow-x-clip">
+        <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
+          <Outlet />
+        </div>
+        <footer className="flex justify-center py-3 px-4">
+          <BuiltByCredit />
+        </footer>
       </div>
-      <footer className="flex justify-center py-3 px-4">
-        <BuiltByCredit />
-      </footer>
       {isMobile && <UserSideDrawer />}
     </div>
   );

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { Drawer } from "vaul";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { CtaVariant } from "./SpeakerChatCTABanner";
 
 interface Props {
@@ -15,27 +16,35 @@ interface Props {
 }
 
 /** Floating chat drawer for the speaker invite page. Collapsed, it
- *  shows a pill-shaped FAB bottom-right. Opened, it slides up as a
- *  `vaul` Drawer — full-width on mobile, max-width centered-bottom
- *  on desktop. Vaul handles drag-to-dismiss, ESC, backdrop tap, and
- *  scroll lock; we just render the chrome. */
+ *  shows a pill-shaped FAB bottom-right. Mobile gets a bottom sheet
+ *  that slides up; desktop gets a side drawer that slides in from the
+ *  right edge so the speaker's letter behind it stays glanceable.
+ *  Vaul handles drag-to-dismiss (down on mobile, right on desktop),
+ *  ESC, backdrop tap, and scroll lock; we just render the chrome. */
 export function SpeakerChatFloatingDrawer({
   open,
   onOpenChange,
   attention,
   children,
 }: Props): React.ReactElement {
+  const isMobile = useIsMobile();
+  const contentClass = isMobile
+    ? "fixed bottom-0 left-0 right-0 z-20 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
+    : "fixed inset-y-0 right-0 z-20 flex w-[min(26.25rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
   return (
     <>
       {!open && <Fab attention={attention ?? null} onClick={() => onOpenChange(true)} />}
-      <Drawer.Root open={open} onOpenChange={onOpenChange}>
+      <Drawer.Root
+        open={open}
+        onOpenChange={onOpenChange}
+        direction={isMobile ? "bottom" : "right"}
+      >
         <Drawer.Portal>
           <Drawer.Overlay className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)]" />
-          <Drawer.Content
-            aria-describedby={undefined}
-            className="fixed bottom-0 left-0 right-0 z-20 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none sm:left-auto sm:right-4 sm:bottom-4 sm:h-[80dvh] sm:w-[min(26.25rem,calc(100dvw-2rem))] sm:rounded-[14px] sm:border-b"
-          >
-            <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40 sm:hidden" />
+          <Drawer.Content aria-describedby={undefined} className={contentClass}>
+            {isMobile && (
+              <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
+            )}
             <Drawer.Title className="sr-only">Conversation with the bishopric</Drawer.Title>
             {children}
           </Drawer.Content>

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,4 +1,5 @@
 import { Drawer } from "vaul";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
 import { InvitationLinkActions } from "./InvitationLinkActions";
@@ -29,10 +30,13 @@ interface Props {
 
 /** Bishop-side conversation panel. Hosts BishopInvitationChat (or the
  *  no-invitation placeholder when the speaker hasn't been invited
- *  yet) inside a `vaul` Drawer — gives us native drag-to-dismiss,
- *  ESC, backdrop tap, and spring animations on both mobile and
- *  desktop. Z-index pinned to 60 so the panel sits above the Assign
- *  Speakers modal (z-50) it's launched from. */
+ *  yet) inside a `vaul` Drawer. Mobile gets a bottom sheet that
+ *  slides up; desktop gets a side drawer that slides in from the
+ *  right edge — better than a centered modal because the speaker's
+ *  schedule context behind it stays glanceable. Drag-to-dismiss
+ *  works on both (down on mobile, right on desktop). Z-index pinned
+ *  to 60 so the panel sits above the Assign Speakers modal (z-50)
+ *  it's launched from. */
 export function BishopInvitationDialog({
   open,
   onClose,
@@ -44,20 +48,24 @@ export function BishopInvitationDialog({
   speakerId,
   kind = "speaker",
 }: Props): React.ReactElement | null {
+  const isMobile = useIsMobile();
+  const contentClass = isMobile
+    ? "fixed bottom-0 left-0 right-0 z-60 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
+    : "fixed inset-y-0 right-0 z-60 flex w-[min(28rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
   return (
     <Drawer.Root
       open={open}
       onOpenChange={(o) => {
         if (!o) onClose();
       }}
+      direction={isMobile ? "bottom" : "right"}
     >
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)]" />
-        <Drawer.Content
-          aria-describedby={undefined}
-          className="fixed bottom-0 left-0 right-0 z-60 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none sm:left-1/2 sm:right-auto sm:bottom-4 sm:h-auto sm:min-h-140 sm:max-h-[94dvh] sm:w-[min(40rem,calc(100dvw-2rem))] sm:-translate-x-1/2 sm:rounded-[14px] sm:border-b"
-        >
-          <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40 sm:hidden" />
+        <Drawer.Content aria-describedby={undefined} className={contentClass}>
+          {isMobile && (
+            <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
+          )}
           <Drawer.Title className="sr-only">Conversation with {speaker.name}</Drawer.Title>
           <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
             <div className="flex-1 min-w-0">

--- a/src/features/schedule/HorizonSelect/HorizonSelect.tsx
+++ b/src/features/schedule/HorizonSelect/HorizonSelect.tsx
@@ -3,12 +3,15 @@ import { useIsMobile } from "@/hooks/useMediaQuery";
 import { MobileBottomSheet } from "@/components/ui/MobileBottomSheet";
 import { cn } from "@/lib/cn";
 
-const HORIZON_OPTIONS = [
-  { label: "1 month", display: "Next 1 month", weeks: 4 },
-  { label: "2 months", display: "Next 2 months", weeks: 9 },
-  { label: "3 months", display: "Next 3 months", weeks: 13 },
-  { label: "4 months", display: "Next 4 months", weeks: 17 },
-];
+// Sundays are weekly, so "weeks" is the natural unit — sidesteps the
+// 4-vs-5-week-month ambiguity. Going in 4-week increments keeps the
+// labels readable and the upper bound (16 weeks ≈ 4 months) consistent
+// with the mobile infinite-scroll cap.
+const HORIZON_OPTIONS = [{ weeks: 4 }, { weeks: 8 }, { weeks: 12 }, { weeks: 16 }];
+
+function displayFor(weeks: number): string {
+  return `Next ${weeks} ${weeks === 1 ? "week" : "weeks"}`;
+}
 
 interface Props {
   value: number;
@@ -21,8 +24,7 @@ export function HorizonSelect({ value, onChange }: Props) {
   const menuRef = useRef<HTMLDivElement>(null);
   const isMobile = useIsMobile();
 
-  const selectedOption = HORIZON_OPTIONS.find((o) => o.weeks === value);
-  const display = selectedOption?.display ?? "Schedule";
+  const display = displayFor(value);
 
   useEffect(() => {
     if (!open || isMobile) return;
@@ -119,7 +121,7 @@ function Options({ value, onSelect }: OptionsProps) {
           <span className="text-[8px] text-center text-bordeaux leading-none">
             {value === option.weeks ? "•" : ""}
           </span>
-          <span>{option.display}</span>
+          <span>{displayFor(option.weeks)}</span>
         </button>
       ))}
     </>

--- a/src/features/schedule/HorizonSelect/__tests__/HorizonSelect.test.tsx
+++ b/src/features/schedule/HorizonSelect/__tests__/HorizonSelect.test.tsx
@@ -13,50 +13,50 @@ describe("HorizonSelect", () => {
   });
 
   it("renders with initial value", () => {
-    render(<HorizonSelect value={9} onChange={() => {}} />);
-    expect(screen.getByText("Next 2 months")).toBeInTheDocument();
+    render(<HorizonSelect value={8} onChange={() => {}} />);
+    expect(screen.getByText("Next 8 weeks")).toBeInTheDocument();
   });
 
   it("persists selection to localStorage", async () => {
     const onChange = vi.fn();
-    render(<HorizonSelect value={9} onChange={onChange} />);
+    render(<HorizonSelect value={8} onChange={onChange} />);
 
-    const button = screen.getByRole("button", { name: /Next 2 months/ });
+    const button = screen.getByRole("button", { name: /Next 8 weeks/ });
     await userEvent.click(button);
 
-    const option = screen.getByRole("button", { name: "Next 3 months" });
+    const option = screen.getByRole("button", { name: "Next 12 weeks" });
     await userEvent.click(option);
 
-    expect(onChange).toHaveBeenCalledWith(13);
-    expect(localStorage.getItem("schedule-horizon-weeks")).toBe("13");
+    expect(onChange).toHaveBeenCalledWith(12);
+    expect(localStorage.getItem("schedule-horizon-weeks")).toBe("12");
   });
 
   it("shows dropdown menu on click", async () => {
-    render(<HorizonSelect value={9} onChange={() => {}} />);
-    const button = screen.getByRole("button", { name: /Next 2 months/ });
+    render(<HorizonSelect value={8} onChange={() => {}} />);
+    const button = screen.getByRole("button", { name: /Next 8 weeks/ });
     await userEvent.click(button);
 
-    expect(screen.getByText("Next 1 month")).toBeInTheDocument();
-    expect(screen.getByText("Next 4 months")).toBeInTheDocument();
+    expect(screen.getByText("Next 4 weeks")).toBeInTheDocument();
+    expect(screen.getByText("Next 16 weeks")).toBeInTheDocument();
   });
 
   it("closes dropdown on selection", async () => {
-    render(<HorizonSelect value={9} onChange={() => {}} />);
-    const button = screen.getByRole("button", { name: /Next 2 months/ });
+    render(<HorizonSelect value={8} onChange={() => {}} />);
+    const button = screen.getByRole("button", { name: /Next 8 weeks/ });
     await userEvent.click(button);
 
-    const option = screen.getByRole("button", { name: "Next 3 months" });
+    const option = screen.getByRole("button", { name: "Next 12 weeks" });
     await userEvent.click(option);
 
-    expect(screen.queryByText("Next 1 month")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next 4 weeks")).not.toBeInTheDocument();
   });
 
   it("closes dropdown on Escape key", async () => {
-    render(<HorizonSelect value={9} onChange={() => {}} />);
-    const button = screen.getByRole("button", { name: /Next 2 months/ });
+    render(<HorizonSelect value={8} onChange={() => {}} />);
+    const button = screen.getByRole("button", { name: /Next 8 weeks/ });
     await userEvent.click(button);
 
     await userEvent.keyboard("{Escape}");
-    expect(screen.queryByText("Next 1 month")).not.toBeInTheDocument();
+    expect(screen.queryByText("Next 4 weeks")).not.toBeInTheDocument();
   });
 });

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -17,10 +17,10 @@ import { groupByMonth } from "./utils/groupByMonth";
 
 const MOBILE_INITIAL_WEEKS = 4;
 const MOBILE_STEP_WEEKS = 4;
-// 17 weeks ≈ 4 months. Past that, the bishopric is planning further
-// out than is useful — speakers haven't even been assigned to wards
-// for those weeks yet — so the list caps and the bottom communicates.
-const MOBILE_MAX_WEEKS = 17;
+// Matches the desktop dropdown's max (4-week increments up to 16).
+// Past that, the bishopric is planning further out than is useful —
+// speakers haven't been assigned to wards for those weeks yet.
+const MOBILE_MAX_WEEKS = 16;
 
 export function ScheduleView() {
   const wardId = useCurrentWardStore((s) => s.wardId);
@@ -91,7 +91,7 @@ export function ScheduleView() {
             )}
             {mobileHorizon >= MOBILE_MAX_WEEKS && (
               <div className="text-center py-6 font-mono text-[10px] uppercase tracking-[0.14em] text-walnut-3 border-t border-border/60">
-                Showing up to 4 months ahead
+                Showing up to 16 weeks ahead
               </div>
             )}
           </>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -85,9 +85,21 @@
    ========================================================= */
 @layer base {
   html {
-    /* Always reserve room for the scrollbar so the centered main element
-       doesn't shift horizontally between short and long pages. */
+    /* Mobile only: reserve room for the scrollbar so the centered
+       main element doesn't shift horizontally between short and long
+       pages. Desktop owns scrolling on an inner content wrapper (so
+       the topbar visually sits above the scrollbar) — html-level
+       overflow stays hidden so no gutter strip appears on the right. */
     scrollbar-gutter: stable;
+  }
+  @media (min-width: 768px) {
+    html,
+    body {
+      overflow: hidden;
+    }
+    html {
+      scrollbar-gutter: auto;
+    }
   }
   html,
   body {


### PR DESCRIPTION
## Summary

Three small desktop-focused refinements following v0.16.0:

1. **Chat drawers slide in from the right on desktop.** Bishop-side `BishopInvitationDialog` and speaker-side `SpeakerChatFloatingDrawer` were both bottom-anchored on every breakpoint after the vaul migration. On desktop, a right-edge inspector panel reads better — the underlying schedule (or letter) stays glanceable. Mobile remains a bottom sheet. Vaul's drag-to-dismiss adapts to the direction.

2. **Desktop scrollbar moves behind the topbar.** The full-height vertical scrollbar running alongside the topbar was visually noisy. Switched desktop scrolling onto an inner content wrapper so the scrollbar's track starts **below** the topbar. Mobile keeps body scrolling so the sticky-topbar auto-hide-on-scroll still works.

3. **Horizon dropdown speaks in weeks, not months.** Sundays are weekly, so "Next 8 weeks" is unambiguous where "Next 2 months" had to mentally translate. Same 4-week stride; the user picks 4 / 8 / 12 / 16 weeks. Mobile cap aligned from 17 → 16 to match.

## Risk callouts

- **AppShell layout split by breakpoint.** Mobile: `min-h-dvh`, body scrolls, sticky topbar. Desktop: `h-dvh + overflow-hidden`, inner content wrapper scrolls, static topbar. Sticky descendants inside the desktop scroll wrapper (e.g. the schedule's per-Sunday date row) bind to the inner wrapper's scroll context — verified working on a quick smoke.
- **`html, body { overflow: hidden }` on desktop.** Required to kill the html-level scrollbar gutter that was leaving an empty stripe on the right. Anything that historically relied on body scrolling on desktop (none I can find) would need updating.
- **Existing localStorage horizon values may not snap to new options.** Old values like 9 (was "Next 2 months") or 13 ("Next 3 months") fall through `displayFor()` cleanly as "Next 9 weeks" / "Next 13 weeks" — informative, not broken. Users see whatever they had, can pick a new option.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm format:check` clean
- [x] `pnpm test` — 45 files / 346 tests pass
- [x] `pnpm build` — clean
- [ ] CI: full pipeline
- [ ] Manual: desktop schedule (open a Sunday's chat → drawer slides from right; scroll the page → scrollbar within content area), mobile schedule unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)