### PR TITLE
fix(chat-drawer): drop interactive-widget meta so vaul handles the keyboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
+      content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
     />
     <meta name="theme-color" content="#8B2E2A" />
     <link rel="manifest" href="/manifest.webmanifest" />


### PR DESCRIPTION
## Summary

- The OS keyboard was pushing the entire chat drawer (header + thread + composer) upward on mobile.
- Root cause: `interactive-widget=resizes-content` in `index.html` was shrinking the layout viewport (and `dvh`) when the keyboard opened, which silently disabled vaul's own `visualViewport`-based keyboard handler.
- Fix: remove `interactive-widget=resizes-content`. Vaul now detects the keyboard via `visualViewport`, pins the drawer's bottom edge just above the keyboard, and keeps the top anchored.

## Why this is safe

- The meta was added in f9e174e four days ago for a hand-rolled chat drawer that didn't have its own keyboard handling.
- The chat drawers were rebuilt on `vaul` in f8a0a59 (one day ago) — vaul ships keyboard repositioning out of the box, but it requires `window.innerHeight !== visualViewport.height`, which the meta was erasing.
- Other `dvh` usages in the app are page-level `min-h-dvh` wrappers, `lg:h-dvh` desktop-only layouts, and one other vaul drawer (`MobileBottomSheet`) — none of them rely on the layout viewport shrinking when the keyboard opens.

## Test plan

- [ ] iPhone Safari: open a Sunday card → tap the chat icon → focus the composer. Expect the keyboard to slide up beneath the drawer, composer pinned just above it, thread above unchanged.
- [ ] Android Chrome: same flow.
- [ ] Speaker invite landing page: tap the chat FAB → focus the composer. Same expected behavior.
- [ ] Desktop regression check: chat drawers still center/right-pin correctly with no layout drift.
- [ ] Forms outside chat (e.g. prepare-invitation): keyboard behavior reverts to standard iOS auto-scroll. No regression vs. pre-f9e174e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)