### PR TITLE
fix(chat-drawer): drive bottom + height from visualViewport on mobile

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -13,10 +13,10 @@
     }
   ],
   "emulators": {
-    "auth": { "port": 9099 },
-    "firestore": { "port": 8080 },
-    "functions": { "port": 5001 },
-    "pubsub": { "port": 8085 },
-    "ui": { "enabled": true, "port": 4000 }
+    "auth": { "host": "0.0.0.0", "port": 9099 },
+    "firestore": { "host": "0.0.0.0", "port": 8080 },
+    "functions": { "host": "0.0.0.0", "port": 5001 },
+    "pubsub": { "host": "0.0.0.0", "port": 8085 },
+    "ui": { "enabled": true, "host": "0.0.0.0", "port": 4000 }
   }
 }

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { Drawer } from "vaul";
+import { useKeyboardAwareViewport } from "@/hooks/useKeyboardAwareViewport";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { CtaVariant } from "./SpeakerChatCTABanner";
 
@@ -28,6 +29,11 @@ export function SpeakerChatFloatingDrawer({
   children,
 }: Props): React.ReactElement {
   const isMobile = useIsMobile();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Keyboard-aware sizing only applies on the mobile bottom sheet.
+  // Desktop is `inset-y-0 right-0` and never collides with the soft
+  // keyboard.
+  useKeyboardAwareViewport(contentRef, isMobile && open);
   const contentClass = isMobile
     ? "fixed bottom-0 left-0 right-0 z-20 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
     : "fixed inset-y-0 right-0 z-20 flex w-[min(26.25rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
@@ -38,10 +44,15 @@ export function SpeakerChatFloatingDrawer({
         open={open}
         onOpenChange={onOpenChange}
         direction={isMobile ? "bottom" : "right"}
+        repositionInputs={false}
       >
         <Drawer.Portal>
           <Drawer.Overlay className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)]" />
-          <Drawer.Content aria-describedby={undefined} className={contentClass}>
+          <Drawer.Content
+            ref={contentRef}
+            aria-describedby={undefined}
+            className={contentClass}
+          >
             {isMobile && (
               <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
             )}

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,4 +1,6 @@
+import { useRef } from "react";
 import { Drawer } from "vaul";
+import { useKeyboardAwareViewport } from "@/hooks/useKeyboardAwareViewport";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
@@ -49,6 +51,11 @@ export function BishopInvitationDialog({
   kind = "speaker",
 }: Props): React.ReactElement | null {
   const isMobile = useIsMobile();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Keyboard-aware sizing only applies on the mobile bottom sheet.
+  // Desktop is `inset-y-0 right-0` and never collides with the soft
+  // keyboard.
+  useKeyboardAwareViewport(contentRef, isMobile && open);
   const contentClass = isMobile
     ? "fixed bottom-0 left-0 right-0 z-60 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
     : "fixed inset-y-0 right-0 z-60 flex w-[min(28rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
@@ -59,10 +66,15 @@ export function BishopInvitationDialog({
         if (!o) onClose();
       }}
       direction={isMobile ? "bottom" : "right"}
+      repositionInputs={false}
     >
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)]" />
-        <Drawer.Content aria-describedby={undefined} className={contentClass}>
+        <Drawer.Content
+          ref={contentRef}
+          aria-describedby={undefined}
+          className={contentClass}
+        >
           {isMobile && (
             <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
           )}

--- a/src/hooks/useKeyboardAwareViewport.ts
+++ b/src/hooks/useKeyboardAwareViewport.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+/** Pins a fixed, bottom-anchored element (a chat drawer) to the
+ *  visual viewport so the OS keyboard slides up *under* it instead of
+ *  pushing it out of frame. iOS Safari is the offender:
+ *
+ *  - `position: fixed` is anchored to the *layout* viewport, which
+ *    doesn't shrink when the soft keyboard appears.
+ *  - iOS auto-scrolls the page to bring focused inputs into the
+ *    *visual* viewport, dragging fixed elements with it.
+ *  - `dvh` doesn't track the keyboard reliably across browsers, and
+ *    vaul's built-in keyboard handler depends on layout/visual
+ *    viewport drift that several iOS configurations don't expose.
+ *
+ *  This hook reads `visualViewport` directly on every `resize` /
+ *  `scroll` and writes inline `bottom` + `height` to the ref'd
+ *  element, so the drawer's bottom edge stays at the bottom of the
+ *  visible area and its height clamps to the available space minus a
+ *  caller-controlled top inset (the "peek" of the page behind it).
+ *
+ *  No-op on non-mobile (≥ md) and when `enabled` is false. When
+ *  disabled or unmounted, the inline styles are cleared so Tailwind's
+ *  classes take over again. */
+export function useKeyboardAwareViewport(
+  ref: React.RefObject<HTMLElement | null>,
+  enabled: boolean,
+  options: { topInset?: number } = {},
+): void {
+  const { topInset = 96 } = options;
+  useEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    function apply() {
+      if (!el || !vv) return;
+      const layoutHeight = window.innerHeight;
+      const visibleBottomFromLayoutBottom =
+        layoutHeight - (vv.offsetTop + vv.height);
+      el.style.bottom = `${Math.max(visibleBottomFromLayoutBottom, 0)}px`;
+      el.style.height = `${Math.max(vv.height - topInset, 0)}px`;
+    }
+
+    apply();
+    vv.addEventListener("resize", apply);
+    vv.addEventListener("scroll", apply);
+    return () => {
+      vv.removeEventListener("resize", apply);
+      vv.removeEventListener("scroll", apply);
+      if (el) {
+        el.style.bottom = "";
+        el.style.height = "";
+      }
+    };
+  }, [ref, enabled, topInset]);
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -30,10 +30,22 @@ function readConfig() {
   };
 }
 
+// Resolve the emulator host from `window.location.hostname` so the
+// SDK reaches the emulators on whatever interface the page was
+// loaded over: `127.0.0.1` from desktop localhost, the Mac's LAN IP
+// (e.g. `192.168.2.24`) when testing from a phone on the same WiFi.
+// Pair with `firebase.json`'s `"host": "0.0.0.0"` so the emulators
+// actually listen on the LAN interface.
+function emulatorHost(): string {
+  if (typeof window === "undefined") return "127.0.0.1";
+  return window.location.hostname || "127.0.0.1";
+}
+
 function connectEmulators(auth: Auth, db: Firestore, functions: Functions): void {
-  connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
-  connectFirestoreEmulator(db, "127.0.0.1", 8080);
-  connectFunctionsEmulator(functions, "127.0.0.1", 5001);
+  const host = emulatorHost();
+  connectAuthEmulator(auth, `http://${host}:9099`, { disableWarnings: true });
+  connectFirestoreEmulator(db, host, 8080);
+  connectFunctionsEmulator(functions, host, 5001);
 }
 
 export const app: FirebaseApp = initializeApp(readConfig());


### PR DESCRIPTION
## Summary

The v0.16.1 meta-tag removal wasn't enough — vaul's built-in keyboard handler still didn't engage reliably on real iOS devices, and the chat drawer kept riding upward when the soft keyboard opened.

This branch replaces it with an explicit `visualViewport`-driven hook and adds a couple of dev-environment conveniences for catching this kind of issue earlier next time.

## Fix

- New [`useKeyboardAwareViewport`](src/hooks/useKeyboardAwareViewport.ts) hook reads `visualViewport.height` and `visualViewport.offsetTop` on every `resize` / `scroll` and writes inline `bottom` + `height` to a ref'd element so its bottom edge tracks the visible viewport's bottom and its height clamps to the available space minus a top peek.
- Both chat drawers — [`SpeakerChatFloatingDrawer`](src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx) and [`BishopInvitationDialog`](src/features/invitations/BishopInvitationDialog.tsx) — pass a ref to `Drawer.Content`, call the hook on `isMobile && open`, and set `repositionInputs={false}` so vaul's stalled handler doesn't fight the inline styles.
- Hook clears its inline styles on cleanup so Tailwind's classes take over again when the drawer closes or shrinks past mobile.

## Dev-environment convenience

Tested by running the dev server on the Mac's LAN interface and hitting it from a real iPhone. Two small changes made that loop work end-to-end (auth + Firestore + Functions, not just token-only routes):

- [`firebase.json`](firebase.json) — bind each emulator to `0.0.0.0` instead of the default `127.0.0.1` so the Mac's LAN interface accepts connections.
- [`src/lib/firebase.ts`](src/lib/firebase.ts) — emulator host now derives from `window.location.hostname` instead of being hardcoded to `127.0.0.1`. Localhost still hits `127.0.0.1`; a phone hitting `http://<lan-ip>:5173` hits the emulator at the same LAN IP. Falls back to `127.0.0.1` for SSR / no-window paths.

Production is unaffected — `VITE_USE_EMULATORS` is false there, so neither emulator-host branch runs.

## Test plan

- [x] Bench-test on iPhone Safari via `http://<lan-ip>:5173` against local emulators: top of drawer stays anchored, composer pins just above the keyboard, thread above remains in place.
- [ ] Same flow on a real Android device.
- [ ] Desktop regression: chat drawer side-mounts (right edge), no inline-style leakage when toggling open/closed.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)