### PR TITLE
Release: v0.17.0 — native-stack transitions + modal settings + sliver app bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-04-27
+
+A native-feel pass on navigation. Mobile gets iOS-style stacked page
+transitions — Schedule sits at the base of the stack, and any other
+page (Week, settings) slides on top from the right; the browser back
+gesture slides it back off. The user-menu destinations (Profile,
+Notifications, Ward settings, Templates) become full-screen modal
+pages with a sliver-style app bar that collapses smoothly as you
+scroll. Schedule remembers its scroll position when you open and
+dismiss a modal.
+
+### Added
+
+- **Native-stack page transitions** on mobile — built on React
+  Router v7's View Transitions integration. A wrapper around
+  `Link`/`useNavigate` (`@/lib/nav`) sets a `data-nav-direction`
+  attribute synchronously on every navigation; CSS keyframes keyed
+  off that attribute drive a slide-from-right (push) and
+  slide-to-right (pop). A `popstate` listener catches the browser
+  back button and iOS swipe-back. Desktop and `prefers-reduced-motion`
+  fall back to instant swaps with zero snapshot overhead.
+- **Full-screen modal layout** for user-menu pages — Profile,
+  Notifications, Ward settings, and Templates move out of `AppShell`
+  into a new `ModalPage` route layout with no Topbar. Settings now
+  feel like overlays sitting on top of Schedule rather than peer
+  pages with the same chrome.
+- **Sliver-style `AppBar`** on every modal page — large hero
+  (eyebrow + title + description) in normal flow with a 48px
+  compact bar (back arrow + small centered title) sticky at the top.
+  As the hero scrolls under the bar, the small title and a hairline
+  cross-fade in. Animation is opacity-only, GPU-composited, driven
+  by a rAF-throttled scroll handler reading the sentinel's viewport
+  position — no layout reflow per frame.
+- **Schedule scroll restoration** — `useScrollRestore` saves the
+  scroll position to `sessionStorage` on unmount and restores on
+  mount. Auto-detects the right scroll source (AppShell's inner
+  container on desktop, window on mobile). Opening a modal and
+  dismissing back to Schedule lands you at the same Sunday you left.
+
+### Changed
+
+- **Settings index `/settings` is no longer in-shell** — the legacy
+  redirect remains, but the four leaf pages route through the modal
+  layout instead of nesting under the AppShell topbar.
+
 ## [0.16.1] — 2026-04-27
 
 A polish-pass release on top of v0.16.0. Two layout fixes — desktop
@@ -1929,7 +1974,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/aylabyuk/steward/releases/tag/v0.17.0
 [0.16.1]: https://github.com/aylabyuk/steward/releases/tag/v0.16.1
 [0.16.0]: https://github.com/aylabyuk/steward/releases/tag/v0.16.0
 [0.15.0]: https://github.com/aylabyuk/steward/releases/tag/v0.15.0

--- a/firebase.json
+++ b/firebase.json
@@ -13,10 +13,10 @@
     }
   ],
   "emulators": {
-    "auth": { "port": 9099 },
-    "firestore": { "port": 8080 },
-    "functions": { "port": 5001 },
-    "pubsub": { "port": 8085 },
-    "ui": { "enabled": true, "port": 4000 }
+    "auth": { "host": "0.0.0.0", "port": 9099 },
+    "firestore": { "host": "0.0.0.0", "port": 8080 },
+    "functions": { "host": "0.0.0.0", "port": 5001 },
+    "pubsub": { "host": "0.0.0.0", "port": 8085 },
+    "ui": { "enabled": true, "host": "0.0.0.0", "port": 4000 }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Outlet } from "react-router";
 import { BuiltByCredit } from "@/components/BuiltByCredit";
+import { useNavDirection } from "@/app/hooks/useNavDirection";
 import { useHideOnScroll } from "./hooks/useHideOnScroll";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { cn } from "@/lib/cn";
@@ -10,6 +11,7 @@ import { UserSideDrawer } from "./UserSideDrawer";
 export function AppShell() {
   const isMobile = useIsMobile();
   const hidden = useHideOnScroll(isMobile);
+  useNavDirection();
 
   // Mobile: body scrolls. Sticky topbar with auto-hide on scroll. The
   // browser's vertical scrollbar runs full-height — fine on touch
@@ -28,8 +30,11 @@ export function AppShell() {
         <Topbar />
         <OnlineStatusBanner />
       </div>
-      <div className="flex flex-1 flex-col sm:overflow-y-auto sm:overflow-x-clip">
-        <div className="flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
+      <div
+        data-app-scroll
+        className="flex flex-1 flex-col sm:overflow-y-auto sm:overflow-x-clip"
+      >
+        <div className="shell-content flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
           <Outlet />
         </div>
         <footer className="flex justify-center py-3 px-4">

--- a/src/app/components/AppShell.tsx
+++ b/src/app/components/AppShell.tsx
@@ -30,10 +30,7 @@ export function AppShell() {
         <Topbar />
         <OnlineStatusBanner />
       </div>
-      <div
-        data-app-scroll
-        className="flex flex-1 flex-col sm:overflow-y-auto sm:overflow-x-clip"
-      >
+      <div data-app-scroll className="flex flex-1 flex-col sm:overflow-y-auto sm:overflow-x-clip">
         <div className="shell-content flex flex-1 flex-col w-full max-w-380 mx-auto px-4 sm:px-8 pt-4 sm:pt-7">
           <Outlet />
         </div>

--- a/src/app/components/ModalPage.tsx
+++ b/src/app/components/ModalPage.tsx
@@ -1,0 +1,27 @@
+import { Outlet } from "react-router";
+import { useNavDirection } from "@/app/hooks/useNavDirection";
+
+/** Layout for routes that live "on top of" Schedule as full-screen
+ *  modals — Profile, Notifications, Ward settings, Templates. No
+ *  Topbar, no AppShell chrome. Each page renders its own `<AppBar>`
+ *  for navigation + title + description.
+ *
+ *  Centered content columns are owned by the page bodies (not the
+ *  layout) so the sticky AppBar can span the viewport width while
+ *  the content stays gutter-aligned.
+ *
+ *  Reuses the `.shell-content` view-transition slot so the slide
+ *  animation is continuous with the rest of the stack: opening a
+ *  modal slides in from the right; dismissing back to /schedule
+ *  slides out to the right (driven by the wrapped Link/useNavigate
+ *  in `@/lib/nav`). */
+export function ModalPage() {
+  useNavDirection();
+  return (
+    <div className="shell-content flex flex-col min-h-dvh sm:h-dvh sm:overflow-hidden">
+      <div className="flex flex-1 flex-col sm:overflow-y-auto sm:overflow-x-clip">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/src/app/components/Topbar.tsx
+++ b/src/app/components/Topbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { UserMenu } from "./UserMenu";
 

--- a/src/app/components/UserMenuItems.tsx
+++ b/src/app/components/UserMenuItems.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { cn } from "@/lib/cn";
 
 interface MenuLinkProps {

--- a/src/app/hooks/useNavDirection.ts
+++ b/src/app/hooks/useNavDirection.ts
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router";
+
+const RESET_DELAY_MS = 400;
+
+/** Tracks navigation direction on `<html data-nav-direction>` so CSS
+ *  view-transition rules can pick the right animation (slide in,
+ *  slide out, fade, none).
+ *
+ *  - Forward / replace are set synchronously by the wrapped `<Link>`
+ *    + `useNavigate` in `@/lib/nav` on click / call.
+ *  - Back is set here on every `popstate` event (browser back/forward
+ *    button, iOS swipe-back).
+ *  - After each navigation the attribute resets to `"none"` so a
+ *    subsequent first-paint or `<Navigate replace>` redirect doesn't
+ *    inherit a stale direction.
+ *
+ *  Mount once, near the root of the in-shell tree (AppShell). */
+export function useNavDirection(): void {
+  const location = useLocation();
+
+  useEffect(() => {
+    const onPopState = () => {
+      document.documentElement.dataset.navDirection = "back";
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  useEffect(() => {
+    // Wait long enough for the View Transition's animations to play
+    // out (260ms slide / 140ms fade) before resetting. Resetting
+    // mid-flight would re-evaluate the pseudo-element selectors and
+    // can drop the running animation.
+    const id = window.setTimeout(() => {
+      document.documentElement.dataset.navDirection = "none";
+    }, RESET_DELAY_MS);
+    return () => window.clearTimeout(id);
+  }, [location.key]);
+}

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -3,6 +3,7 @@ import { CongregationProgram } from "@/features/print/CongregationProgram";
 import { ConductingProgram } from "@/features/print/ConductingProgram";
 import { ScheduleView } from "@/features/schedule/ScheduleView";
 import { AuthGate } from "./AuthGate";
+import { ModalPage } from "./components/ModalPage";
 import { AcceptInvitePage } from "./routes/accept-invite";
 import { InvitationViewPage } from "./routes/invitation-view";
 import { SpeakerInvitationLandingPage } from "./routes/invite-speaker";
@@ -32,10 +33,6 @@ export const router = createBrowserRouter([
       // a bookmark or old link gets bounced back to Schedule. Specific
       // destinations (ward/profile/templates) are reached via UserMenu.
       { path: "settings", element: <Navigate to="/schedule" replace /> },
-      { path: "settings/ward", element: <WardSettingsPage /> },
-      { path: "settings/profile", element: <ProfilePage /> },
-      { path: "settings/notifications", element: <NotificationsPage /> },
-      { path: "settings/templates", element: <TemplatesPage /> },
       {
         path: "ward/:wardId/invitations/:invitationId/view",
         element: <InvitationViewPage />,
@@ -50,6 +47,18 @@ export const router = createBrowserRouter([
   {
     element: <AuthGate appShell={false} />,
     children: [
+      // Settings pages reached from the user menu — full-screen
+      // modal layout sitting on top of Schedule. Each page handles
+      // its own back link to /schedule.
+      {
+        element: <ModalPage />,
+        children: [
+          { path: "/settings/ward", element: <WardSettingsPage /> },
+          { path: "/settings/profile", element: <ProfilePage /> },
+          { path: "/settings/notifications", element: <NotificationsPage /> },
+          { path: "/settings/templates", element: <TemplatesPage /> },
+        ],
+      },
       { path: "/print/:date/congregation", element: <CongregationProgram /> },
       { path: "/print/:date/conducting", element: <ConductingProgram /> },
       {

--- a/src/app/routes/invitation-view/InvitationViewPage.tsx
+++ b/src/app/routes/invitation-view/InvitationViewPage.tsx
@@ -1,4 +1,5 @@
-import { Link, useParams } from "react-router";
+import { useParams } from "react-router";
+import { Link } from "@/lib/nav";
 import { Avatar } from "@/components/ui/Avatar";
 import { ScaledLetterPreview } from "@/features/templates/ScaledLetterPreview";
 import { useSpeakerInvitation } from "@/features/templates/hooks/useSpeakerInvitation";

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -48,11 +48,7 @@ export function SpeakerChatFloatingDrawer({
       >
         <Drawer.Portal>
           <Drawer.Overlay className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)]" />
-          <Drawer.Content
-            ref={contentRef}
-            aria-describedby={undefined}
-            className={contentClass}
-          >
+          <Drawer.Content ref={contentRef} aria-describedby={undefined} className={contentClass}>
             {isMobile && (
               <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
             )}

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -1,5 +1,6 @@
-import type { ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
 import { Drawer } from "vaul";
+import { useKeyboardAwareViewport } from "@/hooks/useKeyboardAwareViewport";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { CtaVariant } from "./SpeakerChatCTABanner";
 
@@ -28,6 +29,11 @@ export function SpeakerChatFloatingDrawer({
   children,
 }: Props): React.ReactElement {
   const isMobile = useIsMobile();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Keyboard-aware sizing only applies on the mobile bottom sheet.
+  // Desktop is `inset-y-0 right-0` and never collides with the soft
+  // keyboard.
+  useKeyboardAwareViewport(contentRef, isMobile && open);
   const contentClass = isMobile
     ? "fixed bottom-0 left-0 right-0 z-20 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
     : "fixed inset-y-0 right-0 z-20 flex w-[min(26.25rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
@@ -38,10 +44,15 @@ export function SpeakerChatFloatingDrawer({
         open={open}
         onOpenChange={onOpenChange}
         direction={isMobile ? "bottom" : "right"}
+        repositionInputs={false}
       >
         <Drawer.Portal>
           <Drawer.Overlay className="fixed inset-0 z-20 bg-[rgba(35,24,21,0.32)]" />
-          <Drawer.Content aria-describedby={undefined} className={contentClass}>
+          <Drawer.Content
+            ref={contentRef}
+            aria-describedby={undefined}
+            className={contentClass}
+          >
             {isMobile && (
               <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
             )}

--- a/src/app/routes/notifications/NotificationsPage.tsx
+++ b/src/app/routes/notifications/NotificationsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router";
 import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { AppBar } from "@/components/ui/AppBar";
 import { NotificationsSection } from "@/features/profile/NotificationsSection";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
@@ -38,9 +38,12 @@ export function NotificationsPage(): React.ReactElement {
 
   if (!wardId || !me || !draft || !source) {
     return (
-      <main className="pb-24">
-        <p className="font-serif italic text-[14px] text-walnut-2">Loading notifications…</p>
-      </main>
+      <>
+        <AppBar eyebrow="Your account" title="Notifications" />
+        <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-24">
+          <p className="font-serif italic text-[14px] text-walnut-2">Loading notifications…</p>
+        </main>
+      </>
     );
   }
 
@@ -64,43 +67,33 @@ export function NotificationsPage(): React.ReactElement {
   }
 
   return (
-    <main className="pb-24">
-      <nav className="mb-4 text-sm text-walnut-2">
-        <Link to="/schedule" className="hover:text-walnut">
-          ← Schedule
-        </Link>
-      </nav>
-      <header className="mb-6">
-        <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1.5">
-          Your account
-        </div>
-        <h1 className="font-display text-[2.25rem] font-semibold text-walnut leading-tight">
-          Notifications
-        </h1>
-        <p className="font-serif italic text-[16px] text-walnut-2 mt-1">
-          Choose what you want to be notified about, and how Steward reaches you.
-        </p>
-      </header>
-
-      <NotificationsSection
-        wardId={wardId}
-        uid={me.id}
-        tokens={me.data.fcmTokens}
-        prefs={draft}
-        onPrefsChange={setDraft}
+    <>
+      <AppBar
+        eyebrow="Your account"
+        title="Notifications"
+        description="Choose what you want to be notified about, and how Steward reaches you."
       />
+      <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-24">
+        <NotificationsSection
+          wardId={wardId}
+          uid={me.id}
+          tokens={me.data.fcmTokens}
+          prefs={draft}
+          onPrefsChange={setDraft}
+        />
 
-      <SaveBar
-        dirty={dirty}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={() => {
-          setDraft(source);
-          setError(null);
-        }}
-        onSave={() => void save()}
-      />
-    </main>
+        <SaveBar
+          dirty={dirty}
+          saving={saving}
+          savedAt={savedAt}
+          error={error}
+          onDiscard={() => {
+            setDraft(source);
+            setError(null);
+          }}
+          onSave={() => void save()}
+        />
+      </main>
+    </>
   );
 }

--- a/src/app/routes/profile/ProfilePage.tsx
+++ b/src/app/routes/profile/ProfilePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router";
 import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { AppBar } from "@/components/ui/AppBar";
 import { DevModeSection } from "@/features/profile/DevModeSection";
 import { IdentitySection } from "@/features/profile/IdentitySection";
 import { PageRail } from "@/components/ui/PageRail";
@@ -55,9 +55,12 @@ export function ProfilePage(): React.ReactElement {
 
   if (!wardId || !authUser || !me || !draft || !source) {
     return (
-      <main className="pb-24">
-        <p className="font-serif italic text-[14px] text-walnut-2">Loading your profile…</p>
-      </main>
+      <>
+        <AppBar eyebrow="Your account" title="Profile" />
+        <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-24">
+          <p className="font-serif italic text-[14px] text-walnut-2">Loading your profile…</p>
+        </main>
+      </>
     );
   }
 
@@ -86,51 +89,41 @@ export function ProfilePage(): React.ReactElement {
   }
 
   return (
-    <main className="pb-24">
-      <nav className="mb-4 text-sm text-walnut-2">
-        <Link to="/schedule" className="hover:text-walnut">
-          ← Schedule
-        </Link>
-      </nav>
-      <header className="mb-6">
-        <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1.5">
-          Your account
-        </div>
-        <h1 className="font-display text-[2.25rem] font-semibold text-walnut leading-tight">
-          Profile
-        </h1>
-        <p className="font-serif italic text-[16px] text-walnut-2 mt-1">
-          Your name and how you appear to other bishopric members.
-        </p>
-      </header>
-
-      <div className="grid grid-cols-1 sm:grid-cols-[1fr_180px] gap-8 items-start">
-        <div>
-          <IdentitySection
-            uid={authUser.uid}
-            email={authUser.email ?? ""}
-            displayName={draft.displayName}
-            photoURL={authUser.photoURL ?? me.data.photoURL ?? null}
-            onDisplayNameChange={(displayName) => setDraft({ ...draft, displayName })}
-          />
-          <SessionSection />
-          {isDevModeEmail(authUser.email) && <DevModeSection />}
-        </div>
-
-        <PageRail
-          items={isDevModeEmail(authUser.email) ? RAIL_ITEMS_DEV : RAIL_ITEMS}
-          elsewhere={RAIL_ELSEWHERE}
-        />
-      </div>
-
-      <SaveBar
-        dirty={dirty}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={discard}
-        onSave={() => void save()}
+    <>
+      <AppBar
+        eyebrow="Your account"
+        title="Profile"
+        description="Your name and how you appear to other bishopric members."
       />
-    </main>
+      <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-24">
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_180px] gap-8 items-start">
+          <div>
+            <IdentitySection
+              uid={authUser.uid}
+              email={authUser.email ?? ""}
+              displayName={draft.displayName}
+              photoURL={authUser.photoURL ?? me.data.photoURL ?? null}
+              onDisplayNameChange={(displayName) => setDraft({ ...draft, displayName })}
+            />
+            <SessionSection />
+            {isDevModeEmail(authUser.email) && <DevModeSection />}
+          </div>
+
+          <PageRail
+            items={isDevModeEmail(authUser.email) ? RAIL_ITEMS_DEV : RAIL_ITEMS}
+            elsewhere={RAIL_ELSEWHERE}
+          />
+        </div>
+
+        <SaveBar
+          dirty={dirty}
+          saving={saving}
+          savedAt={savedAt}
+          error={error}
+          onDiscard={discard}
+          onSave={() => void save()}
+        />
+      </main>
+    </>
   );
 }

--- a/src/app/routes/templates/TemplatesPage.tsx
+++ b/src/app/routes/templates/TemplatesPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { AppBar } from "@/components/ui/AppBar";
 import { PageRail } from "@/components/ui/PageRail";
 import { ProgramTemplatesSection } from "@/features/program-templates/ProgramTemplatesSection";
 import { BishopReplyEmailSection } from "@/features/templates/BishopReplyEmailSection";
@@ -38,41 +38,31 @@ const RAIL_ELSEWHERE = [
  *  full viewport — the section here links out in a new tab. */
 export function TemplatesPage(): React.ReactElement {
   return (
-    <main className="pb-16">
-      <nav className="mb-4 text-sm text-walnut-2">
-        <Link to="/schedule" className="hover:text-walnut">
-          ← Schedule
-        </Link>
-      </nav>
-      <header className="mb-6">
-        <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1.5">
-          Ward administration
-        </div>
-        <h1 className="font-display text-[2.25rem] font-semibold text-walnut leading-tight">
-          Templates
-        </h1>
-        <p className="font-serif italic text-[16px] text-walnut-2 mt-1">
-          The messages Steward sends on your behalf — invitations, receipts, and chat notifications.
-        </p>
-      </header>
+    <>
+      <AppBar
+        eyebrow="Ward administration"
+        title="Templates"
+        description="The messages Steward sends on your behalf — invitations, receipts, and chat notifications."
+      />
+      <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-16">
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_220px] gap-8 items-start">
+          <div>
+            <ProgramTemplatesSection />
+            <SpeakerLetterSection />
+            <SpeakerEmailSection />
+            <InitialSmsSection />
+            <PrayerLetterSection />
+            <SpeakerResponseAcceptedSection />
+            <SpeakerResponseDeclinedSection />
+            <BishopricResponseReceiptSection />
+            <BishopReplySmsSection />
+            <BishopReplyEmailSection />
+            <WardInviteSection />
+          </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-[1fr_220px] gap-8 items-start">
-        <div>
-          <ProgramTemplatesSection />
-          <SpeakerLetterSection />
-          <SpeakerEmailSection />
-          <InitialSmsSection />
-          <PrayerLetterSection />
-          <SpeakerResponseAcceptedSection />
-          <SpeakerResponseDeclinedSection />
-          <BishopricResponseReceiptSection />
-          <BishopReplySmsSection />
-          <BishopReplyEmailSection />
-          <WardInviteSection />
+          <PageRail items={RAIL_ITEMS} elsewhere={RAIL_ELSEWHERE} label="Templates sections" />
         </div>
-
-        <PageRail items={RAIL_ITEMS} elsewhere={RAIL_ELSEWHERE} label="Templates sections" />
-      </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/src/app/routes/ward-settings/WardSettingsPage.tsx
+++ b/src/app/routes/ward-settings/WardSettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
+import { AppBar } from "@/components/ui/AppBar";
 import { PageRail } from "@/components/ui/PageRail";
 import { SaveBar } from "@/components/ui/SaveBar";
 import { InviteMemberDialog } from "@/features/invites/InviteMemberDialog";
@@ -43,9 +43,12 @@ export function WardSettingsPage() {
 
   if (!wardId || !ward.data || !draft) {
     return (
-      <main className="pb-24">
-        <p className="font-serif italic text-[14px] text-walnut-2">Loading ward settings…</p>
-      </main>
+      <>
+        <AppBar eyebrow="Ward administration" title="Ward settings" />
+        <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-24">
+          <p className="font-serif italic text-[14px] text-walnut-2">Loading ward settings…</p>
+        </main>
+      </>
     );
   }
 
@@ -83,59 +86,49 @@ export function WardSettingsPage() {
   ];
 
   return (
-    <main className="pb-24">
-      <nav className="mb-4 text-sm text-walnut-2">
-        <Link to="/schedule" className="hover:text-walnut">
-          ← Schedule
-        </Link>
-      </nav>
-      <header className="mb-6">
-        <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mb-1.5">
-          Ward administration
-        </div>
-        <h1 className="font-display text-[2.25rem] font-semibold text-walnut leading-tight">
-          Ward settings
-        </h1>
-        <p className="font-serif italic text-[16px] text-walnut-2 mt-1">
-          Preferences and member roster for the bishopric.
-        </p>
-      </header>
+    <>
+      <AppBar
+        eyebrow="Ward administration"
+        title="Ward settings"
+        description="Preferences and member roster for the bishopric."
+      />
+      <main className="w-full max-w-380 mx-auto px-4 sm:px-8 py-6 pb-24">
+        <div className="grid grid-cols-1 sm:grid-cols-[1fr_180px] gap-8 items-start">
+          <div>
+            <WardPrefsSection value={draft} onChange={setDraft} canEdit={Boolean(canEdit)} />
+            {!membersLoading && (
+              <>
+                <PendingInvitesList wardId={wardId} canEdit={Boolean(canEdit)} />
+                <MembersSection
+                  wardId={wardId}
+                  members={members}
+                  canEdit={Boolean(canEdit)}
+                  onInvite={() => setInviteOpen(true)}
+                />
+              </>
+            )}
+          </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-[1fr_180px] gap-8 items-start">
-        <div>
-          <WardPrefsSection value={draft} onChange={setDraft} canEdit={Boolean(canEdit)} />
-          {!membersLoading && (
-            <>
-              <PendingInvitesList wardId={wardId} canEdit={Boolean(canEdit)} />
-              <MembersSection
-                wardId={wardId}
-                members={members}
-                canEdit={Boolean(canEdit)}
-                onInvite={() => setInviteOpen(true)}
-              />
-            </>
-          )}
+          <PageRail items={rail} elsewhere={RAIL_ELSEWHERE} label="Ward settings sections" />
         </div>
 
-        <PageRail items={rail} elsewhere={RAIL_ELSEWHERE} label="Ward settings sections" />
-      </div>
+        <SaveBar
+          dirty={dirty && !hasErrors}
+          saving={saving}
+          savedAt={savedAt}
+          error={error ?? (hasErrors ? "Fix the highlighted fields to save." : null)}
+          onDiscard={discard}
+          onSave={() => void save()}
+        />
 
-      <SaveBar
-        dirty={dirty && !hasErrors}
-        saving={saving}
-        savedAt={savedAt}
-        error={error ?? (hasErrors ? "Fix the highlighted fields to save." : null)}
-        onDiscard={discard}
-        onSave={() => void save()}
-      />
-
-      <InviteMemberDialog
-        wardId={wardId}
-        ward={ward.data}
-        inviter={me ? { uid: me.id, displayName: me.data.displayName } : null}
-        open={inviteOpen}
-        onClose={() => setInviteOpen(false)}
-      />
-    </main>
+        <InviteMemberDialog
+          wardId={wardId}
+          ward={ward.data}
+          inviter={me ? { uid: me.id, displayName: me.data.displayName } : null}
+          open={inviteOpen}
+          onClose={() => setInviteOpen(false)}
+        />
+      </main>
+    </>
   );
 }

--- a/src/components/ui/AppBar.tsx
+++ b/src/components/ui/AppBar.tsx
@@ -81,10 +81,7 @@ export function AppBar({
   return (
     <>
       {/* Compact bar — only this element is sticky. */}
-      <div
-        ref={barRef}
-        className="sticky top-0 z-20 bg-parchment/85 backdrop-blur-sm"
-      >
+      <div ref={barRef} className="sticky top-0 z-20 bg-parchment/85 backdrop-blur-sm">
         <div className="w-full max-w-380 mx-auto px-4 sm:px-8">
           <div className="relative flex items-center h-12">
             <Link

--- a/src/components/ui/AppBar.tsx
+++ b/src/components/ui/AppBar.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef } from "react";
+import { Link } from "@/lib/nav";
+
+interface Props {
+  /** Optional small uppercase label above the title — e.g. "Your
+   *  account", "Ward administration". */
+  eyebrow?: string;
+  title: string;
+  /** Optional italic blurb under the title. */
+  description?: string;
+  /** Where the back link points. Defaults to /schedule. */
+  backTo?: string;
+  /** Label for the back link. Defaults to "Schedule". */
+  backLabel?: string;
+}
+
+/** Sliver-style app bar — large hero at the top with eyebrow, title,
+ *  and description; a compact 48px bar with the back arrow + small
+ *  centered title pinned above it.
+ *
+ *  The hero is in normal flow and scrolls naturally with the page;
+ *  only the compact bar is sticky. As the hero scrolls under the
+ *  compact bar, the small title fades in (and the hairline beneath
+ *  the bar fades in too). Because we only animate `opacity` — no
+ *  height, no transforms — every frame is GPU-composited and the
+ *  scroll stays smooth.
+ *
+ *  A 0-height sentinel placed just after the hero drives the fade.
+ *  Its viewport-relative position vs. the compact bar's bottom edge
+ *  gives us a continuous progress value, updated inside a
+ *  rAF-throttled scroll handler. */
+const FADE_RANGE_PX = 36;
+
+export function AppBar({
+  eyebrow,
+  title,
+  description,
+  backTo = "/schedule",
+  backLabel = "Schedule",
+}: Props) {
+  const barRef = useRef<HTMLDivElement>(null);
+  const compactTitleRef = useRef<HTMLHeadingElement>(null);
+  const hairlineRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const bar = barRef.current;
+    const compactTitle = compactTitleRef.current;
+    const hairline = hairlineRef.current;
+    const sentinel = sentinelRef.current;
+    if (!bar || !compactTitle || !hairline || !sentinel) return;
+
+    const scroller = findScrollContainer(sentinel);
+    let raf = 0;
+
+    const update = () => {
+      raf = 0;
+      const sentinelTop = sentinel.getBoundingClientRect().top;
+      const barBottom = bar.getBoundingClientRect().bottom;
+      // distance > 0 → sentinel below the bar (hero still visible).
+      // distance < 0 → sentinel above the bar (hero scrolled out).
+      const distance = sentinelTop - barBottom;
+      const progress = clamp01(-distance / FADE_RANGE_PX);
+      compactTitle.style.opacity = String(progress);
+      hairline.style.opacity = String(progress);
+    };
+
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(update);
+    };
+
+    update();
+    scroller.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      scroller.removeEventListener("scroll", onScroll);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <>
+      {/* Compact bar — only this element is sticky. */}
+      <div
+        ref={barRef}
+        className="sticky top-0 z-20 bg-parchment/85 backdrop-blur-sm"
+      >
+        <div className="w-full max-w-380 mx-auto px-4 sm:px-8">
+          <div className="relative flex items-center h-12">
+            <Link
+              to={backTo}
+              className="inline-flex items-center gap-1.5 text-[13px] text-walnut-2 hover:text-walnut transition-colors shrink-0"
+            >
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.75"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden
+              >
+                <path d="M15 18l-6-6 6-6" />
+              </svg>
+              {backLabel}
+            </Link>
+            <h2
+              ref={compactTitleRef}
+              aria-hidden="true"
+              style={{ opacity: 0 }}
+              className="absolute left-1/2 -translate-x-1/2 max-w-[60%] truncate font-display text-[15px] font-semibold text-walnut will-change-[opacity]"
+            >
+              {title}
+            </h2>
+          </div>
+        </div>
+        <div
+          ref={hairlineRef}
+          aria-hidden
+          style={{ opacity: 0 }}
+          className="absolute inset-x-0 bottom-0 h-px bg-border pointer-events-none will-change-[opacity]"
+        />
+      </div>
+
+      {/* Hero — sits in normal flow; scrolls under the sticky bar. */}
+      <div className="w-full max-w-380 mx-auto px-4 sm:px-8 pt-1 pb-5">
+        {eyebrow && (
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep font-medium mt-1 mb-1.5">
+            {eyebrow}
+          </div>
+        )}
+        <h1 className="font-display text-[1.75rem] sm:text-[2.25rem] font-semibold text-walnut leading-tight">
+          {title}
+        </h1>
+        {description && (
+          <p className="font-serif italic text-[14.5px] sm:text-[16px] text-walnut-2 mt-1">
+            {description}
+          </p>
+        )}
+      </div>
+      <div ref={sentinelRef} aria-hidden className="h-0" />
+    </>
+  );
+}
+
+function clamp01(n: number): number {
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}
+
+function findScrollContainer(start: HTMLElement): HTMLElement | Window {
+  let el: HTMLElement | null = start.parentElement;
+  while (el) {
+    const overflow = getComputedStyle(el).overflowY;
+    if (overflow === "auto" || overflow === "scroll") return el;
+    el = el.parentElement;
+  }
+  return window;
+}

--- a/src/components/ui/PageRail.tsx
+++ b/src/components/ui/PageRail.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { cn } from "@/lib/cn";
 
 interface RailItem {

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,4 +1,6 @@
+import { useRef } from "react";
 import { Drawer } from "vaul";
+import { useKeyboardAwareViewport } from "@/hooks/useKeyboardAwareViewport";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
 import { BishopInvitationChat } from "./BishopInvitationChat";
@@ -49,6 +51,11 @@ export function BishopInvitationDialog({
   kind = "speaker",
 }: Props): React.ReactElement | null {
   const isMobile = useIsMobile();
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Keyboard-aware sizing only applies on the mobile bottom sheet.
+  // Desktop is `inset-y-0 right-0` and never collides with the soft
+  // keyboard.
+  useKeyboardAwareViewport(contentRef, isMobile && open);
   const contentClass = isMobile
     ? "fixed bottom-0 left-0 right-0 z-60 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
     : "fixed inset-y-0 right-0 z-60 flex w-[min(28rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
@@ -59,10 +66,15 @@ export function BishopInvitationDialog({
         if (!o) onClose();
       }}
       direction={isMobile ? "bottom" : "right"}
+      repositionInputs={false}
     >
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)]" />
-        <Drawer.Content aria-describedby={undefined} className={contentClass}>
+        <Drawer.Content
+          ref={contentRef}
+          aria-describedby={undefined}
+          className={contentClass}
+        >
           {isMobile && (
             <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
           )}

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -70,11 +70,7 @@ export function BishopInvitationDialog({
     >
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 z-60 bg-[rgba(35,24,21,0.42)]" />
-        <Drawer.Content
-          ref={contentRef}
-          aria-describedby={undefined}
-          className={contentClass}
-        >
+        <Drawer.Content ref={contentRef} aria-describedby={undefined} className={contentClass}>
           {isMobile && (
             <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
           )}

--- a/src/features/meetings/WeekEditorActions.tsx
+++ b/src/features/meetings/WeekEditorActions.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import type { MeetingType, SacramentMeeting } from "@/lib/types";
 import { ApprovalPanel } from "./ApprovalPanel";
 

--- a/src/features/meetings/program/ProgramHead.tsx
+++ b/src/features/meetings/program/ProgramHead.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import type { MeetingType } from "@/lib/types";
 import { TYPE_LABELS } from "../utils/meetingLabels";
 import { cn } from "@/lib/cn";

--- a/src/features/program-templates/ProgramTemplatesSection.tsx
+++ b/src/features/program-templates/ProgramTemplatesSection.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 
 /** Templates → Program templates section. The conducting + congregation

--- a/src/features/schedule/MobileSundayBlock.tsx
+++ b/src/features/schedule/MobileSundayBlock.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { useSpeakers } from "@/hooks/useMeeting";
 import { useSundayInvitationsSummary } from "@/features/invitations/hooks/useSundayInvitationsSummary";
 import { leadTimeSeverity } from "@/features/speakers/utils/leadTime";

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -5,6 +5,7 @@ import { TwilioChatProvider } from "@/features/invitations/TwilioChatProvider";
 import { SubscribePrompt } from "@/features/notifications/SubscribePrompt";
 import { useUpcomingMeetings } from "./hooks/useUpcomingMeetings";
 import { useInfiniteHorizon } from "./hooks/useInfiniteHorizon";
+import { useScrollRestore } from "@/hooks/useScrollRestore";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
@@ -23,6 +24,7 @@ const MOBILE_STEP_WEEKS = 4;
 const MOBILE_MAX_WEEKS = 16;
 
 export function ScheduleView() {
+  useScrollRestore("schedule");
   const wardId = useCurrentWardStore((s) => s.wardId);
   const settingsState = useWardSettings();
   const defaultHorizon = settingsState.data?.settings.scheduleHorizonWeeks ?? 8;

--- a/src/features/schedule/SundayCardBody.tsx
+++ b/src/features/schedule/SundayCardBody.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
 import { EmptyRosterRow } from "./EmptyRosterRow";

--- a/src/features/schedule/SundayCardHeader.tsx
+++ b/src/features/schedule/SundayCardHeader.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import type { MeetingType, NonMeetingSunday } from "@/lib/types";
 import { cn } from "@/lib/cn";
 import { useSundayInvitationsSummary } from "@/features/invitations/hooks/useSundayInvitationsSummary";

--- a/src/features/schedule/SundayCardSpecial.tsx
+++ b/src/features/schedule/SundayCardSpecial.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import type { SacramentMeeting } from "@/lib/types";
 import { cn } from "@/lib/cn";
 import type { KindVariant } from "./utils/kindLabel";

--- a/src/features/schedule/SundayMenuPlanActions.tsx
+++ b/src/features/schedule/SundayMenuPlanActions.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 
 interface Props {
   date: string;

--- a/src/features/templates/PrayerLetterSection.tsx
+++ b/src/features/templates/PrayerLetterSection.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 
 /** Templates → Prayer invitation letter section. Sits beside the

--- a/src/features/templates/SpeakerLetterSection.tsx
+++ b/src/features/templates/SpeakerLetterSection.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router";
+import { Link } from "@/lib/nav";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 
 /** Templates → Speaker invitation letter section. The letter editor

--- a/src/hooks/useKeyboardAwareViewport.ts
+++ b/src/hooks/useKeyboardAwareViewport.ts
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+
+/** Pins a fixed, bottom-anchored element (a chat drawer) to the
+ *  visual viewport so the OS keyboard slides up *under* it instead of
+ *  pushing it out of frame. iOS Safari is the offender:
+ *
+ *  - `position: fixed` is anchored to the *layout* viewport, which
+ *    doesn't shrink when the soft keyboard appears.
+ *  - iOS auto-scrolls the page to bring focused inputs into the
+ *    *visual* viewport, dragging fixed elements with it.
+ *  - `dvh` doesn't track the keyboard reliably across browsers, and
+ *    vaul's built-in keyboard handler depends on layout/visual
+ *    viewport drift that several iOS configurations don't expose.
+ *
+ *  This hook reads `visualViewport` directly on every `resize` /
+ *  `scroll` and writes inline `bottom` + `height` to the ref'd
+ *  element, so the drawer's bottom edge stays at the bottom of the
+ *  visible area and its height clamps to the available space minus a
+ *  caller-controlled top inset (the "peek" of the page behind it).
+ *
+ *  No-op on non-mobile (≥ md) and when `enabled` is false. When
+ *  disabled or unmounted, the inline styles are cleared so Tailwind's
+ *  classes take over again. */
+export function useKeyboardAwareViewport(
+  ref: React.RefObject<HTMLElement | null>,
+  enabled: boolean,
+  options: { topInset?: number } = {},
+): void {
+  const { topInset = 96 } = options;
+  useEffect(() => {
+    const el = ref.current;
+    if (!enabled || !el) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    function apply() {
+      if (!el || !vv) return;
+      const layoutHeight = window.innerHeight;
+      const visibleBottomFromLayoutBottom =
+        layoutHeight - (vv.offsetTop + vv.height);
+      el.style.bottom = `${Math.max(visibleBottomFromLayoutBottom, 0)}px`;
+      el.style.height = `${Math.max(vv.height - topInset, 0)}px`;
+    }
+
+    apply();
+    vv.addEventListener("resize", apply);
+    vv.addEventListener("scroll", apply);
+    return () => {
+      vv.removeEventListener("resize", apply);
+      vv.removeEventListener("scroll", apply);
+      if (el) {
+        el.style.bottom = "";
+        el.style.height = "";
+      }
+    };
+  }, [ref, enabled, topInset]);
+}

--- a/src/hooks/useKeyboardAwareViewport.ts
+++ b/src/hooks/useKeyboardAwareViewport.ts
@@ -36,8 +36,7 @@ export function useKeyboardAwareViewport(
     function apply() {
       if (!el || !vv) return;
       const layoutHeight = window.innerHeight;
-      const visibleBottomFromLayoutBottom =
-        layoutHeight - (vv.offsetTop + vv.height);
+      const visibleBottomFromLayoutBottom = layoutHeight - (vv.offsetTop + vv.height);
       el.style.bottom = `${Math.max(visibleBottomFromLayoutBottom, 0)}px`;
       el.style.height = `${Math.max(vv.height - topInset, 0)}px`;
     }

--- a/src/hooks/useScrollRestore.ts
+++ b/src/hooks/useScrollRestore.ts
@@ -1,0 +1,54 @@
+import { useEffect } from "react";
+
+/** Restore the scroll position of a route across navigations within
+ *  a session. On mount, jumps the page back to the value last saved
+ *  under `key`; on unmount, captures the current scroll for next
+ *  time. Persists in `sessionStorage` so a full reload also keeps
+ *  the position (within the same tab session).
+ *
+ *  Picks the right scroll source automatically: AppShell's inner
+ *  scroll container on desktop (marked with `data-app-scroll`),
+ *  falling back to the window when no container is present (mobile,
+ *  or modal pages with their own layout). */
+export function useScrollRestore(key: string): void {
+  useEffect(() => {
+    const storageKey = `scroll-restore:${key}`;
+    const saved = sessionStorage.getItem(storageKey);
+    const target = pickScrollTarget();
+
+    if (saved !== null) {
+      const y = Number.parseInt(saved, 10);
+      if (Number.isFinite(y) && y > 0) {
+        // Defer to the next frame so any layout/data the page mounts
+        // with has settled. Jumping pre-paint to a position past the
+        // current document height is a no-op.
+        requestAnimationFrame(() => setScroll(target, y));
+      }
+    }
+
+    return () => {
+      sessionStorage.setItem(storageKey, String(getScroll(target)));
+    };
+  }, [key]);
+}
+
+type Target = HTMLElement | Window;
+
+function pickScrollTarget(): Target {
+  const el = document.querySelector<HTMLElement>("[data-app-scroll]");
+  if (el && el.scrollHeight > el.clientHeight) return el;
+  return window;
+}
+
+function getScroll(target: Target): number {
+  if (target === window) return window.scrollY;
+  return (target as HTMLElement).scrollTop;
+}
+
+function setScroll(target: Target, y: number): void {
+  if (target === window) {
+    window.scrollTo({ top: y, behavior: "instant" as ScrollBehavior });
+    return;
+  }
+  (target as HTMLElement).scrollTop = y;
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -30,10 +30,22 @@ function readConfig() {
   };
 }
 
+// Resolve the emulator host from `window.location.hostname` so the
+// SDK reaches the emulators on whatever interface the page was
+// loaded over: `127.0.0.1` from desktop localhost, the Mac's LAN IP
+// (e.g. `192.168.2.24`) when testing from a phone on the same WiFi.
+// Pair with `firebase.json`'s `"host": "0.0.0.0"` so the emulators
+// actually listen on the LAN interface.
+function emulatorHost(): string {
+  if (typeof window === "undefined") return "127.0.0.1";
+  return window.location.hostname || "127.0.0.1";
+}
+
 function connectEmulators(auth: Auth, db: Firestore, functions: Functions): void {
-  connectAuthEmulator(auth, "http://127.0.0.1:9099", { disableWarnings: true });
-  connectFirestoreEmulator(db, "127.0.0.1", 8080);
-  connectFunctionsEmulator(functions, "127.0.0.1", 5001);
+  const host = emulatorHost();
+  connectAuthEmulator(auth, `http://${host}:9099`, { disableWarnings: true });
+  connectFirestoreEmulator(db, host, 8080);
+  connectFunctionsEmulator(functions, host, 5001);
 }
 
 export const app: FirebaseApp = initializeApp(readConfig());

--- a/src/lib/nav.tsx
+++ b/src/lib/nav.tsx
@@ -1,0 +1,88 @@
+import { type ComponentProps, type MouseEvent, forwardRef, useCallback } from "react";
+import {
+  Link as RRLink,
+  type NavigateFunction,
+  type To,
+  useNavigate as useRRNavigate,
+} from "react-router";
+
+type LinkProps = ComponentProps<typeof RRLink>;
+
+type Direction = "forward" | "back" | "replace" | "none";
+
+function setDirection(dir: Direction): void {
+  document.documentElement.dataset.navDirection = dir;
+}
+
+function isModifiedClick(e: MouseEvent<HTMLAnchorElement>): boolean {
+  return e.metaKey || e.ctrlKey || e.shiftKey || e.altKey || e.button !== 0;
+}
+
+// Schedule is the base of the stack. Any navigation TO it — link click,
+// programmatic navigate, or the "/" → "/schedule" router redirect — is a
+// dismissal: the top page slides off to the right and Schedule is
+// revealed underneath.
+function isBasePath(pathname: string | undefined): boolean {
+  return pathname === "/" || pathname === "/schedule";
+}
+
+function getPathname(to: To): string | undefined {
+  if (typeof to === "string") return to.split("?")[0]?.split("#")[0];
+  return to.pathname;
+}
+
+function pickDirection(to: To, replace: boolean | undefined): Direction {
+  if (replace) return "replace";
+  if (isBasePath(getPathname(to))) return "back";
+  return "forward";
+}
+
+// Native-stack transitions are mobile-only. On desktop we skip the
+// `startViewTransition` call entirely — instant route swap, no
+// snapshot/composite overhead. Breakpoint matches `useIsMobile` and
+// the matching media query in styles/index.css.
+function shouldTransition(): boolean {
+  if (typeof window === "undefined") return false;
+  if (typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(max-width: 767.98px)").matches;
+}
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  { to, onClick, replace, viewTransition, ...rest },
+  ref,
+) {
+  return (
+    <RRLink
+      ref={ref}
+      to={to}
+      replace={replace}
+      viewTransition={viewTransition ?? shouldTransition()}
+      onClick={(e) => {
+        if (!e.defaultPrevented && !isModifiedClick(e) && shouldTransition()) {
+          setDirection(pickDirection(to, replace));
+        }
+        onClick?.(e);
+      }}
+      {...rest}
+    />
+  );
+});
+
+export function useNavigate(): NavigateFunction {
+  const nav = useRRNavigate();
+  return useCallback<NavigateFunction>(
+    ((to: unknown, opts?: { replace?: boolean; viewTransition?: boolean }) => {
+      if (typeof to === "number") {
+        // Browser back/forward delta — popstate listener handles direction.
+        return nav(to);
+      }
+      const transition = shouldTransition();
+      if (transition) setDirection(pickDirection(to as To, opts?.replace));
+      return nav(to as Parameters<NavigateFunction>[0], {
+        viewTransition: transition,
+        ...opts,
+      });
+    }) as NavigateFunction,
+    [nav],
+  );
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -301,6 +301,124 @@
 }
 
 /* --------------------------------------------------------------------
+   Native-stack page transitions. The body wrapper inside <AppShell>
+   carries `view-transition-name: shell-content`, so route swaps
+   animate the body alone — the topbar (outside this slot) stays
+   put. Direction is set on `<html data-nav-direction>` synchronously
+   by `@/lib/nav` (forward / replace) and by the popstate listener
+   in useNavDirection (back) before the browser snapshots the old
+   DOM. After the animation runs, the attribute resets to "none".
+   -------------------------------------------------------------------- */
+
+.shell-content {
+  view-transition-name: shell-content;
+  /* Opaque background so the View Transition snapshot isn't see-through.
+     Without this, both old + new snapshots stack transparently during
+     a slide and the off-screen page bleeds through ("ghosting"). The
+     parchment + grain match the AppShell's outer wrapper so the page
+     looks identical when no transition is running. */
+  background-color: var(--color-parchment);
+  background-image:
+    radial-gradient(rgba(139, 46, 42, 0.03) 1px, transparent 1px),
+    radial-gradient(rgba(59, 42, 34, 0.035) 1px, transparent 1px);
+  background-size:
+    3px 3px,
+    7px 7px;
+  background-position:
+    0 0,
+    1px 2px;
+}
+
+@keyframes stack-slide-in-right {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes stack-slide-out-right {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes stack-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes stack-fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+/* Default: no animation on the named slot — direction selectors
+   below re-enable it for user-initiated navigation. */
+::view-transition-old(shell-content),
+::view-transition-new(shell-content) {
+  animation: none;
+}
+
+/* Kill the browser's default cross-fade on the unnamed root snapshot
+   so the topbar + footer (captured under root) stay visually
+   stationary. Routes that cross out of the shell — where the
+   shell-content slot has no partner on the other side — also fall
+   back to an instant swap thanks to this override. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation: none;
+}
+
+/* Animations are mobile-only — on desktop the default `animation: none`
+   above wins and route swaps stay instant. The native-stack idiom
+   only really lands on phone-class viewports; on desktop a sliding
+   page reads as gimmicky. Breakpoint matches `useIsMobile`. */
+@media (max-width: 767.98px) {
+  html[data-nav-direction="forward"]::view-transition-old(shell-content) {
+    animation: none;
+  }
+  html[data-nav-direction="forward"]::view-transition-new(shell-content) {
+    animation: 260ms cubic-bezier(0.32, 0.72, 0, 1) both stack-slide-in-right;
+    z-index: 2;
+  }
+
+  html[data-nav-direction="back"]::view-transition-old(shell-content) {
+    animation: 240ms cubic-bezier(0.32, 0.72, 0, 1) both stack-slide-out-right;
+    z-index: 2;
+  }
+  html[data-nav-direction="back"]::view-transition-new(shell-content) {
+    animation: none;
+  }
+
+  html[data-nav-direction="replace"]::view-transition-old(shell-content) {
+    animation: 140ms ease-out both stack-fade-out;
+  }
+  html[data-nav-direction="replace"]::view-transition-new(shell-content) {
+    animation: 140ms ease-out both stack-fade-in;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(shell-content),
+  ::view-transition-new(shell-content) {
+    animation: none !important;
+  }
+}
+
+/* --------------------------------------------------------------------
    Speaker-letter print rules. A `<PrintOnlyLetter>` portal mounts a
    copy of the letter at `document.body` level; on screen it stays
    `display: none`, in print it's the only thing that renders. Keeps


### PR DESCRIPTION
## v0.17.0

A native-feel pass on navigation. Mobile gets iOS-style stacked page transitions — Schedule sits at the base of the stack, and any other page (Week, settings) slides on top from the right; browser back / iOS swipe-back slides it off. The user-menu destinations (Profile, Notifications, Ward settings, Templates) become full-screen modal pages with a sliver-style app bar that collapses smoothly as you scroll. Schedule remembers its scroll position when you open and dismiss a modal.

### Highlights

- **Native-stack page transitions** — React Router v7 View Transitions integration, mobile-only. Schedule is the base; other pages push on top with a slide-from-right (and slide-out-to-right on back). Desktop and `prefers-reduced-motion` get instant swaps with no snapshot overhead.
- **Full-screen modal layout** for user-menu pages — Profile, Notifications, Ward settings, Templates leave AppShell and route through a new `ModalPage` layout. No topbar; settings feel like overlays.
- **Sliver-style `AppBar`** — large hero in normal flow + 48px sticky compact bar (back arrow + small centered title). Smooth opacity-only cross-fade as the hero scrolls under the bar, GPU-composited.
- **Schedule scroll restoration** — `useScrollRestore` parks Schedule at the same position after dismissing a modal.

### Test plan

- [ ] iOS Safari 18.2+: tap Sunday card → /week/:date slides in from right; back gesture slides it out. UserMenu → Profile pushes modal in over Schedule; "← Schedule" slides it off.
- [ ] iOS: scroll Schedule, open Profile, navigate back — Schedule restores scroll position.
- [ ] iOS: slow-scroll a modal page — sliver app bar's small title fades smoothly into the compact bar with no jank.
- [ ] Android Chrome: same as above.
- [ ] Desktop Chrome/Safari: route swaps are instant; modal pages render full-viewport with no topbar.
- [ ] Firefox / Reduce Motion: no view transitions, no regressions.

### Post-merge automation

The release workflow will tag `v0.17.0`, publish a GitHub Release, and deploy Firestore rules + Cloud Functions to `steward-prod-65a36`. Vercel handles the frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)