### PR TITLE
fix(invitations): prayer-flavoured chat copy + 24h edit/delete window

### DIFF
--- a/src/features/invitations/QuickActionButtons.tsx
+++ b/src/features/invitations/QuickActionButtons.tsx
@@ -2,6 +2,12 @@ import { useState } from "react";
 import type { Conversation } from "@twilio/conversations";
 import { formatShortSunday } from "@/features/schedule/utils/dateFormat";
 import { cn } from "@/lib/cn";
+import {
+  formatResponseBody,
+  formatResponsePrompt,
+  formatYesButtonLabel,
+  type ResponseKind,
+} from "./utils/quickResponseCopy";
 
 interface Props {
   conversation: Conversation | null;
@@ -13,6 +19,11 @@ interface Props {
    *  ("Can you speak on Sun May 20?") instead of the ambiguous
    *  "this Sunday". */
   meetingDate: string;
+  /** Discriminator from the invitation doc — flips the prompt /
+   *  Yes-button label / persisted message body to prayer-flavoured
+   *  copy ("offer the prayer") instead of speaker-flavoured. Default
+   *  `"speaker"` matches the historical behaviour for legacy callers. */
+  kind?: ResponseKind;
 }
 
 type Mode = "idle" | "noReason";
@@ -22,18 +33,17 @@ type Mode = "idle" | "noReason";
  *   1. ensureReady() — sign-in + email-match + Twilio connect
  *   2. onSubmit() — mirror the response into Firestore
  *   3. post a Twilio message with `{ responseType, reason? }` so the
- *      thread shows the structured bubble on both sides. */
-function formatResponseBody(answer: "yes" | "no", reasonText?: string): string {
-  if (answer === "yes") return "Yes, I can speak.";
-  if (reasonText) return `No — ${reasonText}`;
-  return "No, I can't.";
-}
-
+ *      thread shows the structured bubble on both sides.
+ *
+ *  Copy branches on `kind` via `quickResponseCopy` helpers — the
+ *  body posted to Twilio is the audit-trail piece, so accuracy
+ *  matters there even more than on the live UI. */
 export function QuickActionButtons({
   conversation,
   ensureReady,
   onSubmit,
   meetingDate,
+  kind = "speaker",
 }: Props): React.ReactElement {
   const [mode, setMode] = useState<Mode>("idle");
   const [reason, setReason] = useState("");
@@ -51,7 +61,7 @@ export function QuickActionButtons({
       }
       await onSubmit(answer, reasonText);
       if (conversation) {
-        const body = formatResponseBody(answer, reasonText);
+        const body = formatResponseBody({ answer, kind, reasonText });
         await conversation.sendMessage(body, { responseType: answer, reason: reasonText ?? null });
       }
       setMode("idle");
@@ -101,7 +111,7 @@ export function QuickActionButtons({
   return (
     <div className="flex flex-col gap-2 p-3 border-t border-border bg-chalk">
       <p className="font-serif text-[13.5px] text-walnut-2">
-        Can you speak on {formatShortSunday(meetingDate)}?
+        {formatResponsePrompt({ kind, shortSunday: formatShortSunday(meetingDate) })}
       </p>
       <div className="flex gap-2">
         <button
@@ -114,7 +124,7 @@ export function QuickActionButtons({
             "disabled:opacity-60",
           )}
         >
-          Yes, I can speak
+          {formatYesButtonLabel(kind)}
         </button>
         <button
           type="button"

--- a/src/features/invitations/SpeakerInvitationChat.tsx
+++ b/src/features/invitations/SpeakerInvitationChat.tsx
@@ -181,6 +181,7 @@ export function SpeakerInvitationChat(props: Props): React.ReactElement {
           ensureReady={ensureReady}
           onSubmit={submitResponse}
           meetingDate={props.meetingDate}
+          {...(props.kind ? { kind: props.kind } : {})}
         />
       )}
 

--- a/src/features/invitations/utils/__tests__/messageActions.test.ts
+++ b/src/features/invitations/utils/__tests__/messageActions.test.ts
@@ -111,7 +111,7 @@ describe("buildMessagePermissions", () => {
     expect(canEdit(messages[1]!)).toBe(false);
   });
 
-  it("a message older than 30 minutes is neither editable nor deletable", () => {
+  it("a message older than the edit/delete window is neither editable nor deletable", () => {
     const stale = msg({
       sid: "1",
       author: BISHOP_A,
@@ -122,7 +122,7 @@ describe("buildMessagePermissions", () => {
     expect(canEdit(stale)).toBe(false);
   });
 
-  it("a message exactly at the 30-minute boundary is still editable + deletable", () => {
+  it("a message exactly at the window boundary is still editable + deletable", () => {
     const onTheLine = msg({
       sid: "1",
       author: BISHOP_A,

--- a/src/features/invitations/utils/__tests__/quickResponseCopy.test.ts
+++ b/src/features/invitations/utils/__tests__/quickResponseCopy.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatResponseBody,
+  formatResponsePrompt,
+  formatYesButtonLabel,
+} from "../quickResponseCopy";
+
+describe("quickResponseCopy", () => {
+  describe("formatResponseBody", () => {
+    it("speaker yes → 'Yes, I can speak.'", () => {
+      expect(formatResponseBody({ answer: "yes", kind: "speaker" })).toBe("Yes, I can speak.");
+    });
+
+    it("prayer yes → 'Yes, I can offer the prayer.'", () => {
+      expect(formatResponseBody({ answer: "yes", kind: "prayer" })).toBe(
+        "Yes, I can offer the prayer.",
+      );
+    });
+
+    it("no without reason → 'No, I can't.' regardless of kind", () => {
+      expect(formatResponseBody({ answer: "no", kind: "speaker" })).toBe("No, I can't.");
+      expect(formatResponseBody({ answer: "no", kind: "prayer" })).toBe("No, I can't.");
+    });
+
+    it("no with reason → 'No — {reason}' regardless of kind", () => {
+      expect(
+        formatResponseBody({
+          answer: "no",
+          kind: "speaker",
+          reasonText: "out of town",
+        }),
+      ).toBe("No — out of town");
+      expect(
+        formatResponseBody({
+          answer: "no",
+          kind: "prayer",
+          reasonText: "out of town",
+        }),
+      ).toBe("No — out of town");
+    });
+  });
+
+  describe("formatResponsePrompt", () => {
+    it("speaker → 'Can you speak on …?'", () => {
+      expect(formatResponsePrompt({ kind: "speaker", shortSunday: "Sun May 17" })).toBe(
+        "Can you speak on Sun May 17?",
+      );
+    });
+
+    it("prayer → 'Can you offer the prayer on …?'", () => {
+      expect(formatResponsePrompt({ kind: "prayer", shortSunday: "Sun May 17" })).toBe(
+        "Can you offer the prayer on Sun May 17?",
+      );
+    });
+  });
+
+  describe("formatYesButtonLabel", () => {
+    it("speaker → 'Yes, I can speak'", () => {
+      expect(formatYesButtonLabel("speaker")).toBe("Yes, I can speak");
+    });
+
+    it("prayer → 'Yes, I can offer the prayer'", () => {
+      expect(formatYesButtonLabel("prayer")).toBe("Yes, I can offer the prayer");
+    });
+  });
+});

--- a/src/features/invitations/utils/messageActions.ts
+++ b/src/features/invitations/utils/messageActions.ts
@@ -20,10 +20,11 @@ export function findLastMineIndex(
 export const RECENT_EDITABLE_WINDOW = 5;
 
 /** After this many milliseconds from creation, edit + delete become
- *  unavailable on a message. Matches the "can retract" window most
- *  messengers use — long enough to fix a typo, short enough that
- *  older context stays stable for everyone else reading the thread. */
-export const EDIT_DELETE_WINDOW_MS = 30 * 60 * 1000;
+ *  unavailable on a message. Long enough to cover "noticed the
+ *  mistake later in the day"; the recent-N cap above is the
+ *  structural guard that prevents deep-history rewriting even within
+ *  the window. iOS mirrors this constant — keep them in sync. */
+export const EDIT_DELETE_WINDOW_MS = 24 * 60 * 60 * 1000;
 
 export interface Permissions {
   canDelete: (message: ChatMessage) => boolean;

--- a/src/features/invitations/utils/quickResponseCopy.ts
+++ b/src/features/invitations/utils/quickResponseCopy.ts
@@ -24,10 +24,7 @@ export function formatResponseBody(args: {
 }
 
 /** "Can you speak on Sun May 20?" / "Can you offer the prayer on Sun May 20?" */
-export function formatResponsePrompt(args: {
-  kind: ResponseKind;
-  shortSunday: string;
-}): string {
+export function formatResponsePrompt(args: { kind: ResponseKind; shortSunday: string }): string {
   const verb = args.kind === "prayer" ? "offer the prayer" : "speak";
   return `Can you ${verb} on ${args.shortSunday}?`;
 }

--- a/src/features/invitations/utils/quickResponseCopy.ts
+++ b/src/features/invitations/utils/quickResponseCopy.ts
@@ -1,0 +1,38 @@
+/** Speaker-side quick-response copy. The response message body is
+ *  persisted in Twilio and shows up in both the speaker's and the
+ *  bishopric's chat history forever, so it has to read as accurate
+ *  for the slot kind — a prayer-giver who taps Yes shouldn't see
+ *  "Yes, I can speak." in their own audit trail.
+ *
+ *  Lives in /utils so a vitest can pin every branch without having
+ *  to mount the React component. */
+
+export type ResponseKind = "speaker" | "prayer";
+
+/** Audit-trail body posted to Twilio when the speaker submits. */
+export function formatResponseBody(args: {
+  answer: "yes" | "no";
+  kind: ResponseKind;
+  reasonText?: string;
+}): string {
+  const { answer, kind, reasonText } = args;
+  if (answer === "yes") {
+    return kind === "prayer" ? "Yes, I can offer the prayer." : "Yes, I can speak.";
+  }
+  if (reasonText) return `No — ${reasonText}`;
+  return "No, I can't.";
+}
+
+/** "Can you speak on Sun May 20?" / "Can you offer the prayer on Sun May 20?" */
+export function formatResponsePrompt(args: {
+  kind: ResponseKind;
+  shortSunday: string;
+}): string {
+  const verb = args.kind === "prayer" ? "offer the prayer" : "speak";
+  return `Can you ${verb} on ${args.shortSunday}?`;
+}
+
+/** Yes-button label. "Yes, I can speak" / "Yes, I can offer the prayer". */
+export function formatYesButtonLabel(kind: ResponseKind): string {
+  return kind === "prayer" ? "Yes, I can offer the prayer" : "Yes, I can speak";
+}


### PR DESCRIPTION
## Summary

Two related chat-module polish items, mirrored from the iOS port (`steward-ios`):

- **Prayer-flavoured quick-response copy.** The speaker-side Yes/No card was speaker-flavoured for every kind: prompt read \"Can you speak on Sun May 17?\", Yes-button read \"Yes, I can speak\", and the **persisted Twilio body** posted \"Yes, I can speak.\" — even when the assignee was a prayer giver. Misleading on the live UI, worse in the audit trail (the body lives forever in chat history on both sides). Extracted to `utils/quickResponseCopy` and now branches on a \`ResponseKind = \"speaker\" | \"prayer\"\` discriminator. Decline copy stays kind-agnostic. \`SpeakerInvitationChat\` already had \`kind\` on its props — just threaded through.
- **Edit/delete window bumped 30 min → 24 h.** The 30-minute window was tight for bishopric workflows where mistakes are often noticed later in the day. 24 h covers \"I just realized I sent the wrong date\" without enabling rewriting last week's history. The recent-5 cap stays as the structural guard against selective deep-history rewriting.

## Test plan

- [x] \`pnpm vitest run src/features/invitations/utils/__tests__/quickResponseCopy.test.ts\` — 8 new tests pinning every branch of the three copy helpers.
- [x] \`pnpm vitest run src/features/invitations/utils/__tests__/messageActions.test.ts\` — existing 14 tests still pass; window boundary tests reference \`EDIT_DELETE_WINDOW_MS\` so they're insulated from the constant value.
- [x] \`pnpm vitest run src/features/invitations\` — full suite (45 / 45) green.
- [x] \`tsc --noEmit\` — clean.
- [ ] Manual smoke: open a prayer invitation as a prayer giver in the speaker page, verify the prompt / Yes button / posted message body all read prayer-flavoured.
- [ ] Manual smoke: bishop opens a chat, sends a message, edits/deletes within 24 h — affordance still appears; past 24 h disappears.

## iOS counterpart

Mirroring commit landed in \`steward-ios\` as \`edf0258\` (banner + heartbeat + system-notice prayer copy), \`fd1cbef\` (24 h window). The iOS side already documents this in \`docs/web-deviations.md\`; once this PR merges, the ledger entry stops being a deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)