### PR TITLE
docs: speaker/prayer invitation flow diagrams

### DIFF
--- a/.claude/hooks/invitation-flow-doc-reminder.sh
+++ b/.claude/hooks/invitation-flow-doc-reminder.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Posted-tool hook: nudges the agent to update docs/invitation-flow.md
+# after editing any file in the invitation flow surface area.
+#
+# Reads PostToolUse JSON on stdin, emits a system-reminder JSON on stdout
+# only when the edited path matches. See .claude/skills/invitation-flow-doc-sync.md
+# for the surface area + decision rules.
+
+set -u
+
+path=$(jq -r '.tool_input.file_path // ""' 2>/dev/null) || exit 0
+[[ -z "$path" ]] && exit 0
+
+# Extended-regex pattern listing every path in the invitation flow surface.
+pattern='(functions/src/(sendSpeakerInvitation|freshInvitation|rotateInvitationLink|issueSpeakerSession|issueSpeakerSession\.helpers|onInvitationWrite|onTwilioWebhook|invitationDelivery|invitationResponseNotify|invitationReplyNotify|invitationReplyPush|invitationToken|invitationTypes|messageTemplates|emailTemplateBody)\.ts|functions/src/(twilio|sendgrid)/|src/app/routes/(assign-speaker|assign-prayer|prepare-invitation|prepare-prayer-invitation|invite-speaker)/|src/features/invitations/|src/lib/types/speakerInvitation\.ts)'
+
+if echo "$path" | grep -qE "$pattern"; then
+  jq -nc --arg p "$path" '{
+    hookSpecificOutput: {
+      hookEventName: "PostToolUse",
+      additionalContext: ("Edited \($p), which is part of the invitation flow surface area. If this change is doc-relevant (new phase, delivery channel, token-lifecycle change, recipient-set change, file rename in the source-files table, etc.), update docs/invitation-flow.md in the same PR. Skip the doc update for cosmetic refactors / template-key parity / quiet-hours tweaks. See .claude/skills/invitation-flow-doc-sync.md for the full decision rubric.")
+    }
+  }'
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "enabledPlugins": {
     "agent-skills@addy-agent-skills": true
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/invitation-flow-doc-reminder.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/invitation-flow-doc-sync.md
+++ b/.claude/skills/invitation-flow-doc-sync.md
@@ -1,0 +1,129 @@
+---
+name: invitation-flow-doc-sync
+description: Keep docs/invitation-flow.md aligned with the speaker/prayer invitation pipeline. Trigger whenever editing any file in the invitation flow surface area (list below). Decide whether the change is doc-relevant; if yes, update the doc in the same PR.
+---
+
+# Invitation flow doc sync
+
+`docs/invitation-flow.md` is the canonical map of the speaker/prayer
+invitation pipeline — it has a bishopric-facing flowchart and an
+engineering sequence diagram, plus a source-files table. The doc only
+stays useful if it's updated alongside the code it describes.
+
+## Trigger
+
+Activate this skill whenever you touch any file in the invitation
+flow surface area. Treat any of the following as the trigger — file
+edits, renames, deletes, or adding a new file in these directories:
+
+**Cloud Functions (the canonical "what happens" surface):**
+- `functions/src/sendSpeakerInvitation.ts`
+- `functions/src/freshInvitation.ts`
+- `functions/src/rotateInvitationLink.ts`
+- `functions/src/issueSpeakerSession.ts`
+- `functions/src/issueSpeakerSession.helpers.ts`
+- `functions/src/onInvitationWrite.ts`
+- `functions/src/onTwilioWebhook.ts`
+- `functions/src/invitationDelivery.ts`
+- `functions/src/invitationResponseNotify.ts`
+- `functions/src/invitationReplyNotify.ts`
+- `functions/src/invitationReplyPush.ts`
+- `functions/src/invitationToken.ts`
+- `functions/src/invitationTypes.ts`
+- `functions/src/messageTemplates.ts`
+- `functions/src/emailTemplateBody.ts`
+- `functions/src/twilio/**`
+- `functions/src/sendgrid/**`
+
+**Frontend (the bishop + speaker entry points):**
+- `src/app/routes/assign-speaker/**`
+- `src/app/routes/assign-prayer/**`
+- `src/app/routes/prepare-invitation/**`
+- `src/app/routes/prepare-prayer-invitation/**`
+- `src/app/routes/invite-speaker/**`
+- `src/features/invitations/**`
+- `src/lib/types/speakerInvitation.ts`
+- `src/features/invitations/utils/invitationsCallable.ts`
+
+**Firestore rules (the auth model the diagrams describe):**
+- `firestore.rules` — only the `speakerInvitations`, participant
+  status, and chat-related rules
+
+If the user adds a brand-new file in any of those directories, treat
+it as a trigger too (the surface area itself just grew).
+
+## Decision: is the change doc-relevant?
+
+Walk through these questions in order. Stop at the first **Yes**.
+
+1. **Does it change a phase boundary?** New step (e.g. a reminder
+   nudge), removed step, or reordered phase → update both diagrams.
+2. **Does it change a delivery channel?** Adding/removing email, SMS,
+   chat, or push fan-out → update both diagrams.
+3. **Does it change the token lifecycle?** New token states, changed
+   rotation cap, expiry policy shift → update Phase 3 in the sequence
+   diagram + the "Captured" callout list.
+4. **Does it change who gets notified?** Recipient list change for
+   FCM pushes or receipt emails (e.g. clerks added, sender filtered
+   differently) → update Phase 5 / 7.
+5. **Does it rename or move a file in the source-files table?** →
+   Update the table (and verify the relative link still resolves).
+6. **Does it add a new Cloud Function in the eight-function surface?**
+   → Update the sequence diagram + the "Cloud Functions" lane note.
+7. **Does it change the speaker auth model or invite URL shape?** →
+   Update Phase 3.
+
+If none of the above apply, the change is **doc-irrelevant**. Don't
+touch the doc — false-positive updates are noise. Examples of
+doc-irrelevant changes:
+
+- Internal refactor inside a function with no behavior change.
+- Quiet-hours / template-variable tweaks (already in "simplified
+  out").
+- Speaker↔prayer template-key parity work (already in "simplified
+  out").
+- Component splits to stay under the 150-line cap.
+- Test-only edits.
+- Type-only edits that don't change runtime shape.
+
+## How to update
+
+1. Open `docs/invitation-flow.md`. The mermaid diagrams sit in
+   ```` ```mermaid ```` fences — edit the source directly. Validate
+   syntax mentally as you go (it's a small language).
+2. If updating phases: keep the rectangle colors stable so phase
+   numbering reads consistently. Don't introduce new lane names
+   without adding the matching `participant` line at the top.
+3. If updating the source-files table: keep the relative path format
+   (`../functions/src/foo.ts`) so VS Code + GitHub both resolve the
+   link.
+4. **Render-check the change.** GitHub renders Mermaid natively —
+   open the doc on the PR's "Files changed" tab and confirm both
+   blocks still render. Or paste the changed diagram into
+   <https://mermaid.live> for a quick syntax check.
+5. **Land the doc update in the same PR as the code change.**
+   Splitting it into a follow-up PR breaks the bisect story — anyone
+   landing between the two PRs sees a stale doc. One PR, one commit,
+   or two commits on the same branch.
+
+## When in doubt
+
+- If you're 70/30 on whether the change is doc-relevant, **ask the
+  user once**: "This touches `<file>` — does the invitation flow doc
+  need an update for this?" One-line confirmation, then act.
+- If the change is large enough that the diagrams would need a real
+  redesign (e.g. a new phase or a major rearchitecture), surface that
+  to the user before editing. Don't try to redraw a sequence diagram
+  silently.
+
+## Guardrails
+
+- Don't update the doc for purely cosmetic refactors. The doc
+  describes behavior, not file structure.
+- Don't reach into `docs/notifications.md`, `docs/features.md`, or
+  `docs/domain.md` from this skill — they overlap thematically but
+  aren't the invitation pipeline. If something belongs in those
+  docs, surface it as a separate todo.
+- Never auto-render PNGs and commit them. The Mermaid source is the
+  source of truth; renders are a local convenience (and they bloat
+  diffs).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ entries reference the issue inline as `(#N)`.
 - **[docs/notifications.md](docs/notifications.md)** — push subscribe flow, change notifications, finalization nudges, mention notifications, iOS caveats
 - **[docs/access.md](docs/access.md)** — roles matrix, sign-in allowlist, ward bootstrap, email CC policy
 - **[docs/engineering.md](docs/engineering.md)** — state management, component size limit, lint/format, testing, CI
-- **[docs/invitation-flow.md](docs/invitation-flow.md)** — speaker/prayer invitation flow: bishopric-facing flowchart + engineering sequence diagram (delivery, token rotation, response handling)
+- **[docs/invitation-flow.md](docs/invitation-flow.md)** — speaker/prayer invitation flow: bishopric-facing flowchart + engineering sequence diagram (delivery, token rotation, response handling). Keep this in sync when changing the invite pipeline — see the [`invitation-flow-doc-sync`](.claude/skills/invitation-flow-doc-sync.md) skill for the trigger list and decision rules.
 
 ## Decisions (resolved)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ entries reference the issue inline as `(#N)`.
 - **[docs/notifications.md](docs/notifications.md)** — push subscribe flow, change notifications, finalization nudges, mention notifications, iOS caveats
 - **[docs/access.md](docs/access.md)** — roles matrix, sign-in allowlist, ward bootstrap, email CC policy
 - **[docs/engineering.md](docs/engineering.md)** — state management, component size limit, lint/format, testing, CI
+- **[docs/invitation-flow.md](docs/invitation-flow.md)** — speaker/prayer invitation flow: bishopric-facing flowchart + engineering sequence diagram (delivery, token rotation, response handling)
 
 ## Decisions (resolved)
 

--- a/docs/invitation-flow.md
+++ b/docs/invitation-flow.md
@@ -1,0 +1,192 @@
+# Speaker / Prayer Invitation Flow
+
+This doc traces the end-to-end flow for inviting a speaker or prayer to a sacrament meeting — from the moment a bishopric member adds them to a meeting, through delivery (email + SMS + web chat), the speaker's response, and the receipts that fan back to the bishopric.
+
+It holds two diagrams at different altitudes:
+
+- **[Bishopric flow](#bishopric-flow)** — high-level, suitable for sharing with the bishopric.
+- **[Engineering sequence](#engineering-sequence)** — full lanes (Cloud Functions, Twilio, SendGrid, Firestore, FCM) for contributors and review.
+
+Speaker invitations and prayer invitations follow the *same* flow — the same Cloud Functions, the same capability-token model, the same Twilio Conversation. The only differences are template keys (`speakerLetter` vs `prayerLetter`, etc.) and a handful of UI strings.
+
+---
+
+## Bishopric flow
+
+```mermaid
+flowchart TD
+    A[Bishop opens<br/>Schedule view] --> B[Adds speaker or prayer<br/>to a meeting]
+    B --> C[Captures name,<br/>phone, email, topic]
+    C --> D[Opens 'Prepare invitation'<br/>page — customizes letter]
+    D --> E{Send via?}
+    E -->|Email| F[Speaker gets email<br/>with invite link]
+    E -->|SMS| G[Speaker gets SMS<br/>with invite link]
+    E -->|Both| F & G
+
+    F --> H[Speaker taps link →<br/>opens invite page]
+    G --> H
+    H --> I[Reads the letter,<br/>can chat with bishopric]
+    I --> J{Accept or decline?}
+    J -->|Accepts| K[Speaker taps Yes<br/>+ optional note]
+    J -->|Declines| L[Speaker taps No<br/>+ optional reason]
+    J -->|Replies via SMS<br/>or chat instead| M[Conversation<br/>continues in chat]
+
+    K --> N[Bishopric gets push notification<br/>+ confirmation email]
+    L --> N
+    M --> O[Bishopric sees the message<br/>in the chat thread + push]
+
+    N --> P[Bishop opens response<br/>in the app]
+    P --> Q[Taps 'Apply response'<br/>→ speaker status updates<br/>to Confirmed / Declined]
+    Q --> R[Speaker gets receipt email<br/>confirming Yes/No on file]
+```
+
+### Walkthrough
+
+1. **Assign.** From the Schedule view a bishop adds a speaker or prayer participant to a Sunday meeting and captures their contact info (and topic, for speakers).
+2. **Prepare.** The bishop opens a "Prepare invitation" page that loads the ward's letter template into a WYSIWYG editor. The bishop can tweak the letter for this specific person before sending.
+3. **Send.** The bishop chooses Email, SMS, or both. The speaker receives a personalized message with a one-tap invite link.
+4. **Speaker reads + chats.** The link opens a public web page showing the letter. The speaker can chat back-and-forth with the bishopric directly on the page, or reply by SMS — both feed the same thread.
+5. **Speaker responds.** The speaker either taps Yes/No on the page (with an optional note) or just sends a reply by SMS / chat. Either way the bishopric is notified.
+6. **Apply.** The bishop opens the response in the app and taps "Apply" to lock the participant's status to Confirmed or Declined. The speaker gets a receipt email confirming what's on file.
+
+---
+
+## Engineering sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Bishop as Bishop (web app)
+    participant Fn as Cloud Functions
+    participant FS as Firestore
+    participant Twilio
+    participant SG as SendGrid
+    participant SpkPhone as Speaker (SMS)
+    participant SpkEmail as Speaker (email)
+    participant SpkWeb as Speaker (invite page)
+    participant FCM as FCM (bishopric push)
+
+    rect rgb(240,248,255)
+    Note over Bishop,FS: Phase 1 — Assign + Prepare
+    Bishop->>FS: Create / update speaker or prayer participant
+    Bishop->>FS: Read letter template (speakerLetter / prayerLetter)
+    Bishop->>Bishop: Edit letter (Lexical WYSIWYG)
+    end
+
+    rect rgb(245,255,245)
+    Note over Bishop,SG: Phase 2 — Send invitation
+    Bishop->>Fn: sendSpeakerInvitation { mode: "fresh", channels }
+    Fn->>Twilio: Create Conversation, add bishopric + speaker
+    Fn->>Fn: Generate token, hash it (SHA-256)
+    Fn->>FS: Write speakerInvitations/{id}<br/>{ tokenHash, conversationSid, letter snapshot }
+    Fn->>FS: Stamp participant: status="invited"
+    par Email channel
+        Fn->>SG: Send invitation email (template + invite URL)
+        SG->>SpkEmail: Inbox: invitation email
+    and SMS channel
+        Fn->>Twilio: SMS to speaker phone (template + invite URL)
+        Twilio->>SpkPhone: SMS: invitation
+    end
+    Fn-->>Bishop: deliveryRecord { email: sent, sms: sent }
+    end
+
+    rect rgb(255,250,240)
+    Note over SpkWeb,Twilio: Phase 3 — Speaker opens link
+    SpkPhone->>SpkWeb: Tap invite URL
+    SpkEmail->>SpkWeb: Tap invite URL
+    SpkWeb->>FS: Public read: invitation doc (letter snapshot)
+    SpkWeb->>SpkWeb: Render letter
+    SpkWeb->>Fn: issueSpeakerSession { invitationToken }
+    Fn->>FS: TX: hash token, compare, flip "consumed"
+    alt token active
+        Fn-->>SpkWeb: Firebase custom token + Twilio chat JWT
+    else token consumed/expired
+        Fn->>Fn: Rotate token (cap 3/day)
+        Fn->>Twilio: Re-send SMS w/ fresh URL
+        Fn-->>SpkWeb: { status: "rotated", phoneLast4 }
+    end
+    end
+
+    rect rgb(255,245,245)
+    Note over SpkWeb,FCM: Phase 4 — Speaker responds
+    alt Yes / No on web page
+        SpkWeb->>FS: Write response { answer, reason, respondedAt }
+    else SMS reply
+        SpkPhone->>Twilio: Reply SMS
+        Twilio->>Fn: onTwilioWebhook (Conversations event)
+        Fn->>FCM: Push to bishopric: "{name} replied"
+    else Web chat message
+        SpkWeb->>Twilio: Conversation message
+        Twilio->>Fn: onTwilioWebhook
+        Fn->>FCM: Push to bishopric
+    end
+    end
+
+    rect rgb(248,240,255)
+    Note over FS,SG: Phase 5 — Receipt + notify (Yes/No path)
+    FS->>Fn: onInvitationWrite (response set)
+    Fn->>SG: Speaker receipt email (Yes/No template, CC bishopric)
+    SG->>SpkEmail: Receipt: "We have your Yes/No on file"
+    Fn->>FCM: Push: "{name} accepted/declined"
+    FCM->>Bishop: Notification
+    end
+
+    rect rgb(240,255,255)
+    Note over Bishop,FS: Phase 6 — Apply response
+    Bishop->>FS: applyResponseToSpeaker { acknowledgedAt, bishopUid }
+    FS->>FS: Participant status → "confirmed" or "declined"
+    FS->>Fn: onInvitationWrite (acknowledgedAt set)
+    Fn->>SG: Bishopric receipt email (per-member)
+    end
+
+    rect rgb(255,255,235)
+    Note over Bishop,SpkPhone: Phase 7 — Bishop replies in chat (later)
+    Bishop->>Twilio: Conversation message
+    Twilio->>Fn: onTwilioWebhook
+    par Notify speaker
+        Fn->>Fn: Check speaker heartbeat (online?)
+        alt offline (>120s)
+            Fn->>Fn: Rotate token (no daily cap)
+            Fn->>Twilio: SMS w/ fresh invite URL
+            Twilio->>SpkPhone: SMS: bishop replied
+            Fn->>SG: Email: bishop replied
+            SG->>SpkEmail: Inbox
+        else online
+            Note over Fn: Skip SMS — speaker is reading chat live
+        end
+    and Notify other bishopric
+        Fn->>FCM: Push to other active bishopric
+    end
+    end
+```
+
+---
+
+## Source files by phase
+
+| Phase | File |
+|------|------|
+| Bishop assigns speaker | [src/app/routes/assign-speaker/AssignSpeakerPage.tsx](../src/app/routes/assign-speaker/AssignSpeakerPage.tsx) |
+| Bishop assigns prayer | [src/app/routes/assign-prayer/AssignPrayerPage.tsx](../src/app/routes/assign-prayer/AssignPrayerPage.tsx) |
+| Bishop prepares letter (speaker) | [src/app/routes/prepare-invitation/PrepareInvitationPage.tsx](../src/app/routes/prepare-invitation/PrepareInvitationPage.tsx) |
+| Bishop prepares letter (prayer) | [src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationPage.tsx](../src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationPage.tsx) |
+| Send invitation (callable) | [functions/src/sendSpeakerInvitation.ts](../functions/src/sendSpeakerInvitation.ts) → [functions/src/freshInvitation.ts](../functions/src/freshInvitation.ts) |
+| Email + SMS delivery | [functions/src/invitationDelivery.ts](../functions/src/invitationDelivery.ts) |
+| Speaker invite page | [src/app/routes/invite-speaker/SpeakerInvitationLandingPage.tsx](../src/app/routes/invite-speaker/SpeakerInvitationLandingPage.tsx) |
+| Token exchange | [functions/src/issueSpeakerSession.ts](../functions/src/issueSpeakerSession.ts) |
+| Speaker writes Yes/No, bishop applies | [src/features/invitations/utils/invitationActions.ts](../src/features/invitations/utils/invitationActions.ts) |
+| Receipt emails + response push | [functions/src/onInvitationWrite.ts](../functions/src/onInvitationWrite.ts), [functions/src/invitationResponseNotify.ts](../functions/src/invitationResponseNotify.ts) |
+| Twilio reply webhook | [functions/src/onTwilioWebhook.ts](../functions/src/onTwilioWebhook.ts) |
+
+---
+
+## Intentionally simplified out
+
+The diagrams omit a few branches that exist in the code but would clutter the picture. Pointers for when you need them:
+
+- **Quiet hours / timezone filtering on FCM pushes** — applied per-recipient inside `notifyBishopricOfResponse` and the reply-push helpers.
+- **Per-template variable interpolation** (`{{speakerName}}`, `{{topic}}`, `{{wardName}}`, …) — handled by `messageTemplates.ts` in `functions/src/`.
+- **Speaker vs prayer template keys** — every notification lookup branches on `kind` to pick the right template (e.g. `speakerResponseAccepted` vs `prayerResponseAccepted`). Parity was finished in commit `8660a98`.
+- **Twilio Conversation cleanup on re-send** — `freshInvitation.ts` deletes any prior Conversation for the same (ward, speaker, meeting) before creating a new one.
+- **Token rate-limit response** — when a speaker burns through the 3/day rotation cap, `issueSpeakerSession` returns `{ status: "rate-limited" }` and the invite page tells them to contact the bishopric.
+- **iOS WebView `mintWebSession` branch** — `issueSpeakerSession` mints an extra session shape when called with `mintWebSession: true` from the iOS app.


### PR DESCRIPTION
## Summary
- Add `docs/invitation-flow.md` with two views of the speaker/prayer invitation pipeline: a high-level flowchart suitable for sharing with the bishopric, and a full sequence diagram covering Cloud Functions, Twilio, SendGrid, Firestore, FCM, plus the heartbeat-aware token-rotation branches.
- Link the new doc from `CLAUDE.md`'s topic-docs block.
- Docs only — no code changes.

## Test plan
- [ ] Open `docs/invitation-flow.md` on GitHub and confirm both Mermaid blocks render.
- [ ] Spot-check a couple of `Source files by phase` links resolve to existing files on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)