### PR TITLE
security(rules): tighten speaker-invitation update path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,9 @@ Thumbs.db
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 
+# Local-only working notes (kept on disk, never committed)
+*.local.md
+
 # Vercel
 .vercel
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -110,6 +110,46 @@ service cloud.firestore {
             && noApprovalTampering(oldApprovals, newApprovals));
     }
 
+    // `response.acknowledgedAt` is write-once. Once any active member sets
+    // it (via the bishop's Apply-response action), subsequent updates may
+    // not change or clear it. Closes the receipt-email replay vector — the
+    // onInvitationWrite trigger fires per `null → set` transition, so
+    // freezing the field after first set bounds receipts to one fan-out
+    // per response.
+    function ackOnceOk() {
+      let oldAck = resource.data.get('response', {}).get('acknowledgedAt', null);
+      let newAck = request.resource.data.get('response', {}).get('acknowledgedAt', null);
+      return oldAck == null || oldAck == newAck;
+    }
+
+    // Speaker-claim writes that touch the `response` subtree must pin
+    // `actorUid` to the caller's auth.uid (deterministic per invitation:
+    // `speaker:{wardId}:{invitationId}`) and may only set `actorEmail` to
+    // the auth token's verified email, if any. Capability-token sessions
+    // have no auth email, so they can't claim an actorEmail at all —
+    // closes the audit-trail forgery vector. Heartbeat-only writes (no
+    // `response` in affectedKeys) skip the check.
+    function speakerActorOk() {
+      let affected = request.resource.data.diff(resource.data).affectedKeys();
+      let response = request.resource.data.get('response', {});
+      let actorUid = response.get('actorUid', '');
+      let actorEmail = response.get('actorEmail', '');
+      let authEmail = request.auth.token.get('email', '');
+      return !affected.hasAny(['response'])
+        || (actorUid == request.auth.uid
+            && (actorEmail == '' || actorEmail == authEmail));
+    }
+
+    // Speaker-claim writes also have to clear `tokenExpiresAt` if it's
+    // present — defense-in-depth alongside the meeting-level `expiresAt`.
+    // Older invitations (pre-token-rotation rollout) may not carry the
+    // field; treat absence as no constraint so they continue to honour
+    // the `expiresAt` wall.
+    function speakerTokenLive() {
+      let tokenExp = resource.data.get('tokenExpiresAt', null);
+      return tokenExp == null || request.time < tokenExp;
+    }
+
     match /wards/{wardId} {
       allow read: if isActiveMember(wardId);
       // Settings live on the ward doc; only bishopric can change them.
@@ -142,13 +182,16 @@ service cloud.firestore {
       match /speakerInvitations/{invitationId} {
         allow read: if true;
         allow create, delete: if isActiveMember(wardId);
-        allow update: if isActiveMember(wardId)
+        allow update: if (isActiveMember(wardId) && ackOnceOk())
           || (isSignedIn()
               && request.auth.token.invitationId == invitationId
               && request.auth.token.wardId == wardId
               && request.time < resource.data.expiresAt
+              && speakerTokenLive()
               && request.resource.data.diff(resource.data).affectedKeys()
-                  .hasOnly(['response', 'speakerLastSeenAt']));
+                  .hasOnly(['response', 'speakerLastSeenAt'])
+              && speakerActorOk()
+              && ackOnceOk());
       }
 
       // Invites: bishopric creates/lists/revokes pending invites keyed by

--- a/tests/rules/speakerInvitations.test.ts
+++ b/tests/rules/speakerInvitations.test.ts
@@ -103,12 +103,14 @@ describe("speaker invitation rules", () => {
 
     async function seedWithContext(opts: {
       expiresAt?: Timestamp;
+      tokenExpiresAt?: Timestamp;
       response?: Record<string, unknown>;
     }): Promise<void> {
       await env.withSecurityRulesDisabled(async (ctx) => {
         await setDoc(doc(ctx.firestore(), PATH), {
           ...sample,
           ...(opts.expiresAt !== undefined ? { expiresAt: opts.expiresAt } : {}),
+          ...(opts.tokenExpiresAt !== undefined ? { tokenExpiresAt: opts.tokenExpiresAt } : {}),
           ...(opts.response !== undefined ? { response: opts.response } : {}),
         });
       });
@@ -222,6 +224,88 @@ describe("speaker invitation rules", () => {
       }).firestore();
       await assertFails(updateDoc(doc(db, PATH), { speakerLastSeenAt: serverTimestamp() }));
     });
+
+    it("blocks speaker writes past tokenExpiresAt even if expiresAt is future", async () => {
+      await seedWithContext({ expiresAt: FUTURE, tokenExpiresAt: PAST });
+      const db = authedAsSpeaker(env, SPEAKER_UID, {
+        invitationId: INVITATION_ID,
+        wardId: WARD,
+      }).firestore();
+      await assertFails(updateDoc(doc(db, PATH), { response: sampleResponse }));
+    });
+
+    it("allows speaker writes when tokenExpiresAt is set and in the future", async () => {
+      await seedWithContext({ expiresAt: FUTURE, tokenExpiresAt: FUTURE });
+      const db = authedAsSpeaker(env, SPEAKER_UID, {
+        invitationId: INVITATION_ID,
+        wardId: WARD,
+      }).firestore();
+      await assertSucceeds(updateDoc(doc(db, PATH), { response: sampleResponse }));
+    });
+
+    it("blocks speaker spoofing actorUid (different uid in response)", async () => {
+      await seedWithContext({ expiresAt: FUTURE });
+      const db = authedAsSpeaker(env, SPEAKER_UID, {
+        invitationId: INVITATION_ID,
+        wardId: WARD,
+      }).firestore();
+      await assertFails(
+        updateDoc(doc(db, PATH), {
+          response: { ...sampleResponse, actorUid: "bishop" },
+        }),
+      );
+    });
+
+    it("blocks capability-token speaker (no auth email) from claiming an actorEmail", async () => {
+      await seedWithContext({ expiresAt: FUTURE });
+      // authedAsSpeaker sets only invitationId+wardId+role claims; no email.
+      const db = authedAsSpeaker(env, SPEAKER_UID, {
+        invitationId: INVITATION_ID,
+        wardId: WARD,
+      }).firestore();
+      await assertFails(
+        updateDoc(doc(db, PATH), {
+          response: { ...sampleResponse, actorEmail: "bishop@x.com" },
+        }),
+      );
+    });
+
+    it("blocks speaker writing actorEmail that doesn't match auth.token.email", async () => {
+      await seedWithContext({ expiresAt: FUTURE });
+      // Speaker session minted with verified email; tries to claim a different one.
+      const db = env
+        .authenticatedContext(SPEAKER_UID, {
+          invitationId: INVITATION_ID,
+          wardId: WARD,
+          role: "speaker",
+          email: "speaker@example.com",
+          email_verified: true,
+        })
+        .firestore();
+      await assertFails(
+        updateDoc(doc(db, PATH), {
+          response: { ...sampleResponse, actorEmail: "different@x.com" },
+        }),
+      );
+    });
+
+    it("allows google-signed-in speaker writing matching actorEmail", async () => {
+      await seedWithContext({ expiresAt: FUTURE });
+      const db = env
+        .authenticatedContext(SPEAKER_UID, {
+          invitationId: INVITATION_ID,
+          wardId: WARD,
+          role: "speaker",
+          email: "speaker@example.com",
+          email_verified: true,
+        })
+        .firestore();
+      await assertSucceeds(
+        updateDoc(doc(db, PATH), {
+          response: { ...sampleResponse, actorEmail: "speaker@example.com" },
+        }),
+      );
+    });
   });
 
   describe("update — bishopric acknowledgement path", () => {
@@ -257,6 +341,69 @@ describe("speaker invitation rules", () => {
       });
       const db = authedAs(env, "clerk", "c@x.com").firestore();
       await assertSucceeds(updateDoc(doc(db, PATH), { bodyMarkdown: "edited letter body" }));
+    });
+
+    it("blocks overwriting an existing acknowledgedAt with a different value", async () => {
+      const ackedAt = Timestamp.fromDate(new Date("2026-04-21T10:00:00Z"));
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), PATH), {
+          ...sample,
+          expiresAt: FUTURE,
+          response: {
+            answer: "yes",
+            respondedAt: serverTimestamp(),
+            actorUid: "speaker-uid",
+            acknowledgedAt: ackedAt,
+            acknowledgedBy: "bishop",
+          },
+        });
+      });
+      const db = authedAs(env, "clerk", "c@x.com").firestore();
+      // Different timestamp than what's on the doc.
+      await assertFails(
+        updateDoc(doc(db, PATH), {
+          "response.acknowledgedAt": Timestamp.fromDate(new Date("2026-04-22T10:00:00Z")),
+        }),
+      );
+    });
+
+    it("blocks clearing an existing acknowledgedAt", async () => {
+      const ackedAt = Timestamp.fromDate(new Date("2026-04-21T10:00:00Z"));
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), PATH), {
+          ...sample,
+          expiresAt: FUTURE,
+          response: {
+            answer: "yes",
+            respondedAt: serverTimestamp(),
+            actorUid: "speaker-uid",
+            acknowledgedAt: ackedAt,
+            acknowledgedBy: "bishop",
+          },
+        });
+      });
+      const db = authedAs(env, "bishop", "b@x.com").firestore();
+      await assertFails(updateDoc(doc(db, PATH), { "response.acknowledgedAt": null }));
+    });
+
+    it("allows a content edit that preserves acknowledgedAt unchanged", async () => {
+      const ackedAt = Timestamp.fromDate(new Date("2026-04-21T10:00:00Z"));
+      await env.withSecurityRulesDisabled(async (ctx) => {
+        await setDoc(doc(ctx.firestore(), PATH), {
+          ...sample,
+          expiresAt: FUTURE,
+          response: {
+            answer: "yes",
+            respondedAt: serverTimestamp(),
+            actorUid: "speaker-uid",
+            acknowledgedAt: ackedAt,
+            acknowledgedBy: "bishop",
+          },
+        });
+      });
+      const db = authedAs(env, "bishop", "b@x.com").firestore();
+      // Editing a peer field — acknowledgedAt stays untouched.
+      await assertSucceeds(updateDoc(doc(db, PATH), { bodyMarkdown: "tweaked" }));
     });
   });
 });


### PR DESCRIPTION
## Summary

Layers three constraints onto the existing `speakerInvitations` update rule, plus adds a generic `*.local.md` ignore pattern for on-disk working notes.

**Rule changes** (in [firestore.rules](firestore.rules)):
- `ackOnceOk` — `response.acknowledgedAt` is write-once across the bishopric and speaker branches
- `speakerActorOk` — speaker-claim writes pin `actorUid` to the caller and only allow `actorEmail` matching the auth token
- `speakerTokenLive` — speaker writes also fail past `tokenExpiresAt` when set

**Tests:** 9 new rules tests (108 total green) — write-once enforcement, actor identity pinning across capability-token and Google-signed-in branches, and `tokenExpiresAt` cross-check.

## Test plan

- [x] `FIRESTORE_EMULATOR_HOST=127.0.0.1:8080 pnpm vitest run --config vitest.rules.config.ts` — 108/108 pass
- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — 0 errors (195 pre-existing warnings unchanged)
- [ ] Reviewer: walk a normal speaker flow in the emulator and confirm the bishop can still apply a response, the speaker can still write Yes/No + heartbeat, and stale invitations still expire

🤖 Generated with [Claude Code](https://claude.com/claude-code)