### PR TITLE
security(invitations): revoke speaker session on bishop-driven rotation

### DIFF
--- a/functions/src/rotateInvitationLink.ts
+++ b/functions/src/rotateInvitationLink.ts
@@ -1,5 +1,6 @@
 import { FieldValue, getFirestore } from "firebase-admin/firestore";
 import { HttpsError } from "firebase-functions/v2/https";
+import { revokeSpeakerSession } from "./issueSpeakerSession.helpers.js";
 import { buildInviteUrl, tryEmail, trySms } from "./sendSpeakerInvitation.helpers.js";
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
@@ -54,6 +55,15 @@ export async function rotateInvitationLink(
     };
 
   await ref.update({ tokenHash, tokenStatus: "active" as const, ...writePatch });
+
+  // A new token means any session minted from the prior token is no
+  // longer the source of truth for this invitation. Revoke the
+  // speaker's refresh tokens so the next ID-token refresh forces them
+  // back through the issueSpeakerSession exchange — only the speaker
+  // tapping the freshly-delivered URL can recover a working session.
+  // Distinct from rotateTokenForBishopNotification, which intentionally
+  // doesn't revoke (the speaker may be actively in chat there).
+  await revokeSpeakerSession(input.wardId, input.invitationId);
 
   const inviteUrl = buildInviteUrl(origin, input.wardId, input.invitationId, plaintextToken);
   const freshInvitation: SpeakerInvitationShape = { ...invitation, ...effectiveContact };


### PR DESCRIPTION
## Summary

When the bishop rotates an invitation's capability token through `rotateInvitationLink` (the "Send fresh" / "Resend" path), the speaker's prior Firebase refresh tokens are now revoked. After the next ID-token refresh, any session minted from the prior token has to go through a fresh `issueSpeakerSession` exchange — which only the speaker tapping the freshly-delivered URL can complete.

Distinct from `rotateTokenForBishopNotification`, which intentionally does **not** revoke (speaker may be actively in chat) — that path's behavior is unchanged.

## Implementation note

The `revokeSpeakerSession` helper in `issueSpeakerSession.helpers.ts` already existed and was already in use on the visitor-rotation branch. This PR is a one-line import + one-line call to wire it into the bishop-driven rotation path. `revokeRefreshTokens` is idempotent and already swallows `auth/user-not-found`, so calling it on a rotation where no speaker session was ever minted is a no-op.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm format:check` — clean
- [x] `pnpm lint` — 0 errors
- [x] `pnpm --dir functions build` — clean
- [x] `pnpm --dir functions test` — 89/89 pass
- [x] `pnpm test` — 403/403 pass
- [ ] Reviewer: in the emulator, send an invitation, sign the speaker in, then rotate the link via the bishop UI. The speaker's old tab should fail on next write (within ≤1h on prod, immediately if you reload the tab and force a token refresh).

## Out of scope

A dedicated unit test would need a new vitest mock harness for `getFirestore` + `getAuth` admin SDK — no precedent for that in `functions/src/*.test.ts` today, and one line of plumbing isn't worth building it out. Manual emulator verification + code review on this PR + the existing `auth/user-not-found` swallow in `revokeSpeakerSession` cover this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)