### PR TITLE
security(letter-render): allowlist URL schemes + style properties

### DIFF
--- a/src/features/page-editor/utils/__tests__/sanitize.test.ts
+++ b/src/features/page-editor/utils/__tests__/sanitize.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { isSafeImageSrc, isSafeUrl, safeStyle } from "../sanitize";
+
+describe("isSafeUrl", () => {
+  it.each([
+    "https://example.com",
+    "https://example.com/path?query=1#hash",
+    "http://example.com",
+    "HTTP://EXAMPLE.COM",
+    "/relative/path",
+    "/",
+  ])("accepts %s", (url) => {
+    expect(isSafeUrl(url)).toBe(true);
+  });
+
+  it.each([
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+    "about:blank",
+    "tel:+1234567890",
+    "mailto:bad@example.com",
+    "//evil.com",
+    "ftp://example.com",
+    "",
+    " ",
+  ])("rejects %s", (url) => {
+    expect(isSafeUrl(url)).toBe(false);
+  });
+
+  it("rejects null / undefined / non-string", () => {
+    expect(isSafeUrl(null)).toBe(false);
+    expect(isSafeUrl(undefined)).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(isSafeUrl(123 as unknown as string)).toBe(false);
+  });
+});
+
+describe("isSafeImageSrc", () => {
+  it("accepts the same URL shapes as isSafeUrl", () => {
+    expect(isSafeImageSrc("https://example.com/img.png")).toBe(true);
+    expect(isSafeImageSrc("/local/img.jpg")).toBe(true);
+  });
+
+  it.each([
+    "data:image/png;base64,iVBORw0KGgo=",
+    "data:image/jpeg;base64,abcdef==",
+    "data:image/jpg;base64,abcdef",
+    "data:image/gif;base64,abc=",
+    "data:image/webp;base64,abc/+/=",
+  ])("accepts base64 raster %s", (src) => {
+    expect(isSafeImageSrc(src)).toBe(true);
+  });
+
+  it.each([
+    // SVG can carry <script>
+    "data:image/svg+xml,<svg onload=alert(1)></svg>",
+    "data:image/svg+xml;base64,abc",
+    // Non-image data URLs
+    "data:text/html;base64,abc",
+    "data:application/javascript,alert(1)",
+    // javascript: still a no
+    "javascript:alert(1)",
+  ])("rejects %s", (src) => {
+    expect(isSafeImageSrc(src)).toBe(false);
+  });
+});
+
+describe("safeStyle", () => {
+  it("passes allowlisted properties through", () => {
+    expect(
+      safeStyle("color: red; background-color: #fff; font-size: 16px; font-family: serif"),
+    ).toEqual({
+      color: "red",
+      backgroundColor: "#fff",
+      fontSize: "16px",
+      fontFamily: "serif",
+    });
+  });
+
+  it("camel-cases hyphenated property names", () => {
+    expect(safeStyle("background-color: yellow")).toEqual({ backgroundColor: "yellow" });
+    expect(safeStyle("font-size: 14px")).toEqual({ fontSize: "14px" });
+  });
+
+  it("drops properties not on the allowlist", () => {
+    expect(safeStyle("color: red; position: fixed; top: 0; z-index: 9999")).toEqual({
+      color: "red",
+    });
+  });
+
+  it.each([
+    "color: expression(alert(1))",
+    "color: expression (alert(1))", // whitespace before paren
+    "color: javascript:alert(1)",
+    "background-color: url('http://evil.com/cookie?')",
+    "color: <script>",
+    "color: behavior: url(#x)",
+    "background-image: @import url(evil.css)",
+  ])("rejects unsafe value %s", (input) => {
+    expect(safeStyle(input)).toBeNull();
+  });
+
+  it.each([
+    "color: rgb(220, 38, 38)",
+    "color: rgba(255, 0, 0, 0.5)",
+    "background-color: hsl(120, 100%, 50%)",
+    "color: var(--brand-red)",
+    "font-size: calc(1rem + 2px)",
+  ])("allows legitimate CSS function value %s", (input) => {
+    expect(safeStyle(input)).not.toBeNull();
+  });
+
+  it("salvages safe declarations alongside malformed ones", () => {
+    // The /* comment */ fragment has no key:value pair so it's
+    // dropped by the parser (no colon to split on) — the safe
+    // `color: red` survives.
+    expect(safeStyle("color: red; /* comment */")).toEqual({ color: "red" });
+  });
+
+  it("returns null for empty / undefined / declaration-free input", () => {
+    expect(safeStyle("")).toBeNull();
+    expect(safeStyle(undefined)).toBeNull();
+    expect(safeStyle(null)).toBeNull();
+    expect(safeStyle(";;;")).toBeNull();
+    expect(safeStyle(":")).toBeNull();
+    expect(safeStyle("nope")).toBeNull();
+  });
+
+  it("preserves safe declarations even when adjacent ones are unsafe", () => {
+    // The unsafe `position` is dropped (not on allowlist); the safe
+    // `color` survives.
+    expect(safeStyle("position: fixed; color: blue")).toEqual({ color: "blue" });
+  });
+
+  it("trims whitespace around keys and values", () => {
+    expect(safeStyle("  color  :   red  ")).toEqual({ color: "red" });
+  });
+
+  it("handles values containing colons (e.g. url paths in a hypothetical future allow)", () => {
+    // font-family with a multi-word name should keep the full value.
+    expect(safeStyle('font-family: "Helvetica Neue", sans-serif')).toEqual({
+      fontFamily: '"Helvetica Neue", sans-serif',
+    });
+  });
+});

--- a/src/features/page-editor/utils/renderLetterBlocks.tsx
+++ b/src/features/page-editor/utils/renderLetterBlocks.tsx
@@ -2,6 +2,7 @@
  *  of `renderLetterState` to keep the entry file under the per-file
  *  LOC cap. Each function maps one DecoratorNode's serialized shape
  *  to its read-only React presentation. */
+import { isSafeImageSrc } from "./sanitize";
 
 export function renderLetterhead(
   node: { eyebrow?: string; title?: string; subtitle?: string },
@@ -88,7 +89,10 @@ export function renderImage(
   node: { src?: string; alt?: string; widthPct?: number; caption?: string },
   key: string,
 ) {
-  if (!node.src) return null;
+  // `data:image/svg+xml,...` and other non-allowlisted schemes drop
+  // through here — sanitize.ts allows http(s), same-origin paths, and
+  // base64 raster data URLs. Falsy / rejected sources render nothing.
+  if (!isSafeImageSrc(node.src)) return null;
   return (
     <figure
       key={key}

--- a/src/features/page-editor/utils/renderLetterInline.tsx
+++ b/src/features/page-editor/utils/renderLetterInline.tsx
@@ -1,4 +1,5 @@
 import type { SerializedLexicalNode } from "lexical";
+import { safeStyle } from "./sanitize";
 
 interface SerializedTextNode extends SerializedLexicalNode {
   type: "text";
@@ -26,7 +27,7 @@ export function renderText(node: SerializedTextNode, key: string): React.ReactNo
   if (f & FORMAT_ITALIC) el = <em>{el}</em>;
   if (f & FORMAT_UNDERLINE) el = <u>{el}</u>;
   if (f & FORMAT_STRIKE) el = <s>{el}</s>;
-  const style = parseStyle(node.style);
+  const style = safeStyle(node.style);
   if (style)
     return (
       <span key={key} style={style}>
@@ -47,7 +48,7 @@ export function renderChip(node: { token?: string; format?: number; style?: stri
   if (f & FORMAT_ITALIC) element = <em>{element}</em>;
   if (f & FORMAT_UNDERLINE) element = <u>{element}</u>;
   if (f & FORMAT_STRIKE) element = <s>{element}</s>;
-  const inlineStyle = parseStyle(node.style);
+  const inlineStyle = safeStyle(node.style);
   if (inlineStyle) {
     return (
       <span key={key} style={inlineStyle}>
@@ -56,18 +57,6 @@ export function renderChip(node: { token?: string; format?: number; style?: stri
     );
   }
   return <span key={key}>{element}</span>;
-}
-
-function parseStyle(s: string | undefined): React.CSSProperties | null {
-  if (!s) return null;
-  const out: Record<string, string> = {};
-  for (const decl of s.split(";")) {
-    const [k, v] = decl.split(":").map((p) => p.trim());
-    if (!k || !v) continue;
-    const camel = k.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
-    out[camel] = v;
-  }
-  return out as React.CSSProperties;
 }
 
 export type { SerializedTextNode };

--- a/src/features/page-editor/utils/renderLetterState.tsx
+++ b/src/features/page-editor/utils/renderLetterState.tsx
@@ -7,6 +7,7 @@ import {
   renderSignature,
 } from "./renderLetterBlocks";
 import { renderChip, renderText, type SerializedTextNode } from "./renderLetterInline";
+import { isSafeUrl } from "./sanitize";
 
 interface SerializedElementNode extends SerializedLexicalNode {
   children?: SerializedLexicalNode[];
@@ -158,15 +159,19 @@ function renderLink(
   key: string,
   opts: RenderLetterStateOptions,
 ) {
+  // Drop the anchor for non-http(s) / non-same-origin URLs
+  // (`javascript:`, `data:`, …) — render the children as inline text.
+  const kids = (node.children ?? []).map((c, i) => renderNode(c, `${key}.${i}`, opts));
+  if (!isSafeUrl(node.url)) return <span key={key}>{kids}</span>;
   return (
     <a
       key={key}
-      href={node.url ?? "#"}
+      href={node.url}
       target="_blank"
       rel="noopener noreferrer"
       className="underline text-bordeaux hover:text-bordeaux-deep"
     >
-      {(node.children ?? []).map((c, i) => renderNode(c, `${key}.${i}`, opts))}
+      {kids}
     </a>
   );
 }

--- a/src/features/page-editor/utils/sanitize.ts
+++ b/src/features/page-editor/utils/sanitize.ts
@@ -1,0 +1,73 @@
+/** URL + style sanitizers shared by the Lexical letter walker. The
+ *  walker renders bishop-authored content into the speaker's browser,
+ *  so anything that crosses an HTML attribute (href, src, style) goes
+ *  through these allowlists first. The bishopric is treated as
+ *  semi-trusted (they author the content) — these helpers exist to
+ *  bound what kind of mistake a typo or template paste can produce. */
+import type { CSSProperties } from "react";
+
+// `\/(?!\/)` means single leading slash NOT followed by another slash —
+// that excludes protocol-relative URLs (`//evil.com` inherits the
+// page protocol and points off-origin) while still allowing `/path`
+// and bare `/` for same-origin navigation.
+const SAFE_URL_PATTERN = /^(https?:\/\/|\/(?!\/))/i;
+const SAFE_IMAGE_DATA_PATTERN = /^data:image\/(png|jpe?g|gif|webp);base64,[a-z0-9+/=]+$/i;
+
+/** True for absolute http(s) URLs and same-origin paths. Any other
+ *  scheme (`javascript:`, `data:`, `vbscript:`, etc.) returns false
+ *  and the caller should fall back to rendering the text without a
+ *  link. */
+export function isSafeUrl(url: string | undefined | null): boolean {
+  if (!url || typeof url !== "string") return false;
+  return SAFE_URL_PATTERN.test(url);
+}
+
+/** Same as `isSafeUrl` plus base64 data URLs of common raster image
+ *  formats. SVG is intentionally excluded — `data:image/svg+xml,…` can
+ *  carry a `<script>` payload. */
+export function isSafeImageSrc(src: string | undefined | null): boolean {
+  if (!src || typeof src !== "string") return false;
+  return SAFE_URL_PATTERN.test(src) || SAFE_IMAGE_DATA_PATTERN.test(src);
+}
+
+/** Property allowlist for inline `style=` declarations the WYSIWYG
+ *  toolbar emits today: text colour, highlight, font size, font
+ *  family. Block-level alignment (`textAlign`) and bold/italic are
+ *  handled via Lexical's `format` field elsewhere — they don't reach
+ *  this helper. Add to this list deliberately when the toolbar starts
+ *  producing a new property. */
+const ALLOWED_CSS_PROPERTIES = new Set<keyof CSSProperties>([
+  "color",
+  "backgroundColor",
+  "fontSize",
+  "fontFamily",
+]);
+
+/** Reject specific dangerous tokens — `expression(...)`, `url(...)`,
+ *  `@import`, comments, embedded HTML, pseudo schemes — without
+ *  blanket-blocking parens (legitimate color values like
+ *  `rgb(220, 38, 38)` need them). Modern browsers ignore
+ *  `expression()` and `behavior:`, but defence in depth is cheap. */
+const UNSAFE_VALUE_PATTERN =
+  /[<>]|\/\*|\*\/|expression\s*\(|url\s*\(|@import|javascript:|behavior:/i;
+
+/** Like the previous `parseStyle`, but only properties on the
+ *  allowlist with safe-looking values survive. Returns `null` when
+ *  nothing valid remains so the caller can omit the `style=` attribute
+ *  entirely. */
+export function safeStyle(s: string | undefined | null): CSSProperties | null {
+  if (!s || typeof s !== "string") return null;
+  const out: Record<string, string> = {};
+  for (const decl of s.split(";")) {
+    const idx = decl.indexOf(":");
+    if (idx < 0) continue;
+    const rawKey = decl.slice(0, idx).trim();
+    const rawValue = decl.slice(idx + 1).trim();
+    if (!rawKey || !rawValue) continue;
+    const camel = rawKey.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+    if (!ALLOWED_CSS_PROPERTIES.has(camel as keyof CSSProperties)) continue;
+    if (UNSAFE_VALUE_PATTERN.test(rawValue)) continue;
+    out[camel] = rawValue;
+  }
+  return Object.keys(out).length > 0 ? (out as CSSProperties) : null;
+}


### PR DESCRIPTION
## Summary

Adds a small `sanitize` utility used by the Lexical letter walker (speaker invitation page + print views), and routes the three render sites through it.

- **`isSafeUrl`** (used in `renderLink`): accepts `http(s)://` and same-origin (`/path`) only. Protocol-relative (`//host`) and pseudo-schemes (`javascript:`, `data:`, `vbscript:`, etc.) fall through. Non-allowed URLs render as inline `<span>` text — the visible content is preserved, the navigation is dropped.
- **`isSafeImageSrc`** (used in `renderImage`): same plus base64 raster data URLs (`data:image/(png|jpe?g|gif|webp);base64,...`). `data:image/svg+xml` is excluded — SVG can carry `<script>` payloads. Rejected sources render nothing.
- **`safeStyle`** (used in `renderText` + `renderChip`): replaces the prior `parseStyle` passthrough. Only four properties survive — `color`, `backgroundColor`, `fontSize`, `fontFamily`, the set the WYSIWYG toolbar emits today. Values matching `expression(`, `url(`, `@import`, `javascript:`, `behavior:`, comment delimiters, or embedded HTML are dropped. Legitimate CSS function values like `rgb(...)` and `var(...)` still pass.

The bishopric is treated as semi-trusted (they author the content) — these helpers exist to bound what kind of mistake a typo or template paste can produce, not to defend against an adversarial author.

## Test plan

- [x] `pnpm test src/features/page-editor` — 79/79 (43 new sanitize tests + existing render tests)
- [x] `pnpm test` — 453/453
- [x] Rules tests — 108/108
- [x] `pnpm typecheck` / `pnpm format:check` / `pnpm lint` — clean
- [ ] Reviewer: open a speaker invite page in the emulator with a normal letter (chip styling, hyperlinks, images) — should render unchanged.

## Notes

- `renderLetterState.tsx` was bumping the 150-line code cap; the new `renderLink` is compressed accordingly (children extracted into a local, single-line guard).
- The `parseStyle` private function in `renderLetterInline.tsx` is gone; both call sites use the shared `safeStyle`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)