### PR TITLE
security(stubs): redact invite token in dev SMS/email log entries

### DIFF
--- a/functions/src/invitationToken.test.ts
+++ b/functions/src/invitationToken.test.ts
@@ -3,6 +3,7 @@ import {
   generateInvitationToken,
   hashInvitationToken,
   phoneLast4,
+  redactInviteUrls,
   rotationBucketKey,
   ROTATION_DAILY_CAP,
   tokenHashMatches,
@@ -83,5 +84,46 @@ describe("ROTATION_DAILY_CAP", () => {
   it("is a positive integer", () => {
     expect(Number.isInteger(ROTATION_DAILY_CAP)).toBe(true);
     expect(ROTATION_DAILY_CAP).toBeGreaterThan(0);
+  });
+});
+
+describe("redactInviteUrls", () => {
+  it("masks the token segment of an invite URL", () => {
+    const url = "https://steward-app.ca/invite/speaker/ward1/inv1/abc123XYZ_-token";
+    expect(redactInviteUrls(url)).toBe(
+      "https://steward-app.ca/invite/speaker/ward1/inv1/<redacted>",
+    );
+  });
+
+  it("works inline in a longer SMS body", () => {
+    const body =
+      "Hi Sebastian — please respond at https://steward-app.ca/invite/speaker/w1/i1/secret-token-zzz. Thanks!";
+    expect(redactInviteUrls(body)).toBe(
+      "Hi Sebastian — please respond at https://steward-app.ca/invite/speaker/w1/i1/<redacted>. Thanks!",
+    );
+  });
+
+  it("redacts every URL when multiple appear in the same string", () => {
+    const body = "Old: https://x/invite/speaker/w/i/aaa New: https://x/invite/speaker/w/j/bbb End.";
+    expect(redactInviteUrls(body)).toBe(
+      "Old: https://x/invite/speaker/w/i/<redacted> New: https://x/invite/speaker/w/j/<redacted> End.",
+    );
+  });
+
+  it("leaves strings without an invite URL unchanged", () => {
+    expect(redactInviteUrls("Plain text body, no URL.")).toBe("Plain text body, no URL.");
+    expect(redactInviteUrls("https://example.com/other/path/abc")).toBe(
+      "https://example.com/other/path/abc",
+    );
+  });
+
+  it("preserves the URL prefix (origin + invitation path)", () => {
+    // Operators reading logs should still see which invitation the
+    // entry refers to — only the trailing token is masked.
+    const out = redactInviteUrls(
+      "https://steward-app.ca/invite/speaker/eglinton/abc123/secrettoken",
+    );
+    expect(out).toContain("/invite/speaker/eglinton/abc123/");
+    expect(out).not.toContain("secrettoken");
   });
 });

--- a/functions/src/invitationToken.ts
+++ b/functions/src/invitationToken.ts
@@ -45,3 +45,17 @@ export function phoneLast4(e164: string | undefined): string | null {
   if (digits.length < 4) return null;
   return digits.slice(-4);
 }
+
+/** Mask the capability-token segment in any invite URL embedded in a
+ *  string. Used to keep dev SMS / email stub log entries from carrying
+ *  a working token into Cloud Logging — production sends don't log the
+ *  body at all, but the stubs do (so the emulator can show what was
+ *  "sent"), and a logged URL is a usable credential until consumed.
+ *
+ *  Pattern: `/invite/speaker/{wardId}/{invitationId}/{token}` becomes
+ *  `/invite/speaker/{wardId}/{invitationId}/<redacted>`. Multiple URLs
+ *  in the same string are all redacted. Strings without an invite URL
+ *  pass through unchanged. */
+export function redactInviteUrls(s: string): string {
+  return s.replace(/(\/invite\/speaker\/[^/\s]+\/[^/\s]+\/)[A-Za-z0-9_-]+/g, "$1<redacted>");
+}

--- a/functions/src/sendgrid/client.ts
+++ b/functions/src/sendgrid/client.ts
@@ -1,5 +1,6 @@
 import sgMail from "@sendgrid/mail";
 import { logger } from "firebase-functions/v2";
+import { redactInviteUrls } from "../invitationToken.js";
 
 /** In local dev the Firebase emulator sets `FUNCTIONS_EMULATOR=true`.
  *  We use that as the single signal to stub SendGrid delivery — real
@@ -40,13 +41,18 @@ export interface EmailInput {
 
 export async function sendEmail(input: EmailInput): Promise<string | null> {
   if (isStubbed()) {
+    // Slice first, then redact — a 400-char preview commonly contains
+    // the invite URL with a working token. Production sends don't log
+    // the body at all; the stub is dev-only but Cloud Logging still
+    // ingests it.
+    const textPreview = redactInviteUrls(input.text.slice(0, 400));
     logger.info("[sendgrid:stub] email captured (not sent)", {
       to: input.to,
       cc: input.cc,
       replyTo: input.replyTo,
       fromDisplayName: input.fromDisplayName,
       subject: input.subject,
-      textPreview: input.text.slice(0, 400),
+      textPreview,
     });
     return `stub-${Date.now()}`;
   }

--- a/functions/src/twilio/messaging.ts
+++ b/functions/src/twilio/messaging.ts
@@ -1,4 +1,5 @@
 import { logger } from "firebase-functions/v2";
+import { redactInviteUrls } from "../invitationToken.js";
 import { getTwilioClient } from "./client.js";
 import { resolveFromNumber, type FromNumberMode } from "./fromNumber.js";
 
@@ -24,8 +25,17 @@ export interface SendSmsInput {
  *  (chat JWTs, participants) still uses real Twilio creds. */
 export async function sendSmsDirect({ to, body, fromMode }: SendSmsInput): Promise<string> {
   if (process.env.STEWARD_DEV_STUB_SMS === "true") {
-    const url = body.match(/https?:\/\/\S+/)?.[0];
-    logger.info("[SMS stub] would send", { to, body, fromMode: fromMode ?? "production" });
+    // Mask the capability token in any invite URL before logging —
+    // a logged URL is a usable credential until the speaker consumes
+    // it. The body still shows everything else (template variables,
+    // phrasing) so the emulator log remains useful for debugging.
+    const safeBody = redactInviteUrls(body);
+    const url = safeBody.match(/https?:\/\/\S+/)?.[0];
+    logger.info("[SMS stub] would send", {
+      to,
+      body: safeBody,
+      fromMode: fromMode ?? "production",
+    });
     if (url) logger.info("[SMS stub] invite URL →", url);
     return `SM_stub_${Date.now()}`;
   }


### PR DESCRIPTION
## Summary

Adds a small `redactInviteUrls(s)` helper in `functions/src/invitationToken.ts` and wires it into the two dev stubs that previously logged invite URLs verbatim.

- **`twilio/messaging.ts` `sendSmsDirect` dev stub** — redact the body before logging the "would send" entry. The displayed URL is derived from the already-redacted body.
- **`sendgrid/client.ts` `sendEmail` stub** — redact the `textPreview` (first 400 chars of the email body) before logging.

The URL prefix (origin + ward + invitation path) survives so log entries remain useful for debugging — only the trailing capability token is replaced with `<redacted>`. Multiple URLs in the same string all get redacted; strings without an invite URL pass through unchanged.

## Why

Production paths don't log the URL. The stubs are dev-only, but the emulator's log entries still land in Cloud Logging when configured, and a logged URL is a usable credential until the speaker consumes it.

## Test plan

- [x] `pnpm --dir functions test` — 94/94 pass (5 new `redactInviteUrls` tests)
- [x] `pnpm test` — 453/453
- [x] `pnpm --dir functions build` — clean
- [x] `pnpm typecheck` / `format:check` / `lint` — clean
- [ ] Reviewer: with `STEWARD_DEV_STUB_SMS=true`, send an invitation in the emulator and check Functions logs. The "[SMS stub] would send" entry should show `/invite/speaker/.../<redacted>` instead of the raw token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)