### PR TITLE
security(twilio): route invitation SMS through Messaging Service

### DIFF
--- a/functions/src/secrets.ts
+++ b/functions/src/secrets.ts
@@ -26,6 +26,21 @@ export const TWILIO_FROM_NUMBER = defineSecret("TWILIO_FROM_NUMBER");
  *  wrong number. */
 export const TWILIO_FROM_NUMBER_TESTING = defineSecret("TWILIO_FROM_NUMBER_TESTING");
 
+/** Optional Messaging Service SID. When set, production-mode SMS
+ *  sends route through the service (Twilio picks the actual sender
+ *  from the pool attached to the service) instead of the raw
+ *  TWILIO_FROM_NUMBER. The service-level "Disable Inbound and
+ *  Outbound Message Body Logging" toggle then applies — Twilio
+ *  redacts message bodies in its retained logs after delivery,
+ *  bounding the lifetime of any logged invitation URL.
+ *
+ *  Add the same TWILIO_FROM_NUMBER as a sender on the service so
+ *  Twilio has a number to send from. Testing-mode sends still use
+ *  TWILIO_FROM_NUMBER_TESTING directly — the testing number isn't
+ *  in the service's pool and doesn't need the same retention
+ *  treatment. */
+export const TWILIO_MESSAGING_SERVICE_SID = defineSecret("TWILIO_MESSAGING_SERVICE_SID");
+
 /** Public origin of the web app (e.g. https://steward-app.ca) —
  *  used by Cloud Functions to build invite URLs in outbound
  *  correspondence. Runtime-configurable, not a secret. */
@@ -43,6 +58,7 @@ export const TWILIO_SECRETS = [
   TWILIO_CONVERSATIONS_SERVICE_SID,
   TWILIO_FROM_NUMBER,
   TWILIO_FROM_NUMBER_TESTING,
+  TWILIO_MESSAGING_SERVICE_SID,
 ];
 
 // SendGrid (SENDGRID_API_KEY / INVITATION_FROM_EMAIL) is intentionally

--- a/functions/src/twilio/messaging.test.ts
+++ b/functions/src/twilio/messaging.test.ts
@@ -25,8 +25,9 @@ describe("sendSmsDirect dev stub", () => {
     expect(messagesCreate).not.toHaveBeenCalled();
   });
 
-  it("calls Twilio when STEWARD_DEV_STUB_SMS is absent", async () => {
+  it("calls Twilio with raw from number when no messaging service configured", async () => {
     delete process.env.STEWARD_DEV_STUB_SMS;
+    delete process.env.TWILIO_MESSAGING_SERVICE_SID;
     process.env.TWILIO_FROM_NUMBER = "+15550000000";
     messagesCreate.mockResolvedValue({ sid: "SMreal" });
     const sid = await sendSmsDirect({ to: "+15551234567", body: "hello" });
@@ -38,12 +39,38 @@ describe("sendSmsDirect dev stub", () => {
     });
   });
 
-  it("throws if TWILIO_FROM_NUMBER missing in non-stub mode", async () => {
+  it("routes through messagingServiceSid when TWILIO_MESSAGING_SERVICE_SID is set (production)", async () => {
     delete process.env.STEWARD_DEV_STUB_SMS;
+    process.env.TWILIO_FROM_NUMBER = "+15550000000";
+    process.env.TWILIO_MESSAGING_SERVICE_SID = "MGabc123";
+    messagesCreate.mockResolvedValue({ sid: "SMservice" });
+    const sid = await sendSmsDirect({ to: "+15551234567", body: "hello" });
+    expect(sid).toBe("SMservice");
+    expect(messagesCreate).toHaveBeenCalledWith({
+      to: "+15551234567",
+      messagingServiceSid: "MGabc123",
+      body: "hello",
+    });
+    // No raw `from` when routing through the service.
+    expect(messagesCreate.mock.calls[0]?.[0]).not.toHaveProperty("from");
+  });
+
+  it("throws if TWILIO_FROM_NUMBER missing in non-stub mode without messaging service", async () => {
+    delete process.env.STEWARD_DEV_STUB_SMS;
+    delete process.env.TWILIO_MESSAGING_SERVICE_SID;
     delete process.env.TWILIO_FROM_NUMBER;
     await expect(sendSmsDirect({ to: "+15551234567", body: "hi" })).rejects.toThrow(
       /TWILIO_FROM_NUMBER/,
     );
+  });
+
+  it("does NOT require TWILIO_FROM_NUMBER when messaging service is set", async () => {
+    delete process.env.STEWARD_DEV_STUB_SMS;
+    delete process.env.TWILIO_FROM_NUMBER;
+    process.env.TWILIO_MESSAGING_SERVICE_SID = "MGabc123";
+    messagesCreate.mockResolvedValue({ sid: "SMservice" });
+    const sid = await sendSmsDirect({ to: "+15551234567", body: "hi" });
+    expect(sid).toBe("SMservice");
   });
 
   it("uses TWILIO_FROM_NUMBER_TESTING when fromMode is 'testing'", async () => {

--- a/functions/src/twilio/messaging.ts
+++ b/functions/src/twilio/messaging.ts
@@ -29,6 +29,16 @@ export async function sendSmsDirect({ to, body, fromMode }: SendSmsInput): Promi
     if (url) logger.info("[SMS stub] invite URL →", url);
     return `SM_stub_${Date.now()}`;
   }
+  // Production sends prefer the Messaging Service when configured —
+  // routes through Twilio's sender pool and lets the service-level
+  // "Disable Inbound and Outbound Message Body Logging" toggle apply.
+  // Testing-mode sends always use the raw testing number (it's not in
+  // the service's pool and is for ad-hoc maintainer smoke tests).
+  const messagingServiceSid = process.env.TWILIO_MESSAGING_SERVICE_SID;
+  if (fromMode !== "testing" && messagingServiceSid) {
+    const msg = await getTwilioClient().messages.create({ to, messagingServiceSid, body });
+    return msg.sid;
+  }
   const from = resolveFromNumber(fromMode);
   const msg = await getTwilioClient().messages.create({ to, from, body });
   return msg.sid;


### PR DESCRIPTION
## Summary

Adds an optional `TWILIO_MESSAGING_SERVICE_SID` secret. When set, production-mode `sendSmsDirect` calls route through the Messaging Service (Twilio picks the sender from the pool attached to the service) instead of the raw `TWILIO_FROM_NUMBER`. Service-level toggles — including **"Disable Inbound and Outbound Message Body Logging"** — then apply.

## Why

Twilio retains message bodies in its Console and API responses by default. The invitation SMS body carries the capability-token URL; routing through a Messaging Service with body-logging disabled bounds the lifetime of any retained URL.

This is a code-only enabler — the actual privacy improvement comes from the operator action (set the secret + toggle in Twilio Console).

## Behaviour matrix

| `fromMode` | `TWILIO_MESSAGING_SERVICE_SID` | What Twilio sees |
|---|---|---|
| `testing` | (any) | `from = TWILIO_FROM_NUMBER_TESTING` (raw) |
| `production` | set | `messagingServiceSid` |
| `production` | unset | `from = TWILIO_FROM_NUMBER` (raw, current behaviour) |

Backwards-compatible — environments that don't set the secret behave exactly as before.

## Operator runbook (after merge)

1. **Twilio Console** → Messaging → Services → **Create Messaging Service** (or reuse "Default Messaging Service for Conversations" if you'd rather not split)
2. Use case: "Notify my users"
3. **Add `TWILIO_FROM_NUMBER`** as a sender on that service
4. **Logging Configuration** → toggle **"Disable Inbound and Outbound Message Body Logging"** ON
5. Copy the service SID (`MG...`)
6. Set `TWILIO_MESSAGING_SERVICE_SID` on the deployed functions:
   ```
   firebase functions:secrets:set TWILIO_MESSAGING_SERVICE_SID
   ```
7. Redeploy functions

## Test plan

- [x] `pnpm --dir functions test` — 91/91 (2 new test cases)
- [x] `pnpm test` — 453/453
- [x] Rules tests — 108/108
- [x] `pnpm typecheck` / `format:check` / `lint` — clean
- [x] `pnpm --dir functions build` — clean
- [ ] Reviewer: confirm no other call sites pass `messagingServiceSid` directly to Twilio (grep `messages.create` — only `sendSmsDirect` does)
- [ ] Operator: complete the runbook above, then send a test invite and verify in Twilio Console that the message body shows as `<redacted>` post-delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)