### PR TITLE
security(webhook): pin Twilio signing URL + structured failure logs

### DIFF
--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -1,7 +1,6 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { onRequest, type Request } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
-import twilio from "twilio";
 import { emailSpeaker, smsSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
 import { pushToBishopric } from "./invitationReplyPush.js";
 import {
@@ -9,7 +8,9 @@ import {
   TWILIO_AUTH_TOKEN,
   TWILIO_CONVERSATIONS_SERVICE_SID,
   TWILIO_FROM_NUMBER,
+  TWILIO_WEBHOOK_URL,
 } from "./secrets.js";
+import { verifyTwilioSignature } from "./twilio/verifyTwilioSignature.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 // SendGrid secrets intentionally omitted — SMS-only v1. emailSpeaker()
@@ -21,6 +22,7 @@ const WEBHOOK_SECRETS = [
   TWILIO_AUTH_TOKEN,
   TWILIO_CONVERSATIONS_SERVICE_SID,
   TWILIO_FROM_NUMBER,
+  TWILIO_WEBHOOK_URL,
 ];
 
 /** Twilio Conversations Service webhook. Wired to this endpoint via
@@ -37,7 +39,8 @@ export const onTwilioWebhook = onRequest(
   { secrets: WEBHOOK_SECRETS },
   async (req, res): Promise<void> => {
     if (!verifySignature(req)) {
-      logger.warn("twilio webhook signature verification failed");
+      // verifyTwilioSignature emits a structured `twilio.webhook.signature_failed`
+      // log with a `reason` label — alarm-able via Cloud Logging metric.
       res.status(403).send("forbidden");
       return;
     }
@@ -84,12 +87,19 @@ export const onTwilioWebhook = onRequest(
 );
 
 function verifySignature(req: Request): boolean {
-  const sig = req.get("X-Twilio-Signature");
-  const authToken = process.env.TWILIO_AUTH_TOKEN;
-  if (!sig || !authToken) return false;
-  const url = `https://${req.get("host")}${req.originalUrl}`;
-  const params = (req.body ?? {}) as Record<string, string>;
-  return twilio.validateRequest(authToken, sig, url, params);
+  // Prefer the pinned `TWILIO_WEBHOOK_URL` when set — eliminates
+  // host-header drift as a silent failure mode (e.g. region change,
+  // custom-domain swap, unexpected `Host:` header). Falls back to
+  // constructing the URL from the request when unset, preserving the
+  // prior behaviour for environments that haven't configured pinning.
+  const pinnedUrl = process.env.TWILIO_WEBHOOK_URL;
+  const url = pinnedUrl ?? `https://${req.get("host")}${req.originalUrl}`;
+  return verifyTwilioSignature({
+    signature: req.get("X-Twilio-Signature"),
+    authToken: process.env.TWILIO_AUTH_TOKEN,
+    url,
+    params: (req.body ?? {}) as Record<string, string>,
+  });
 }
 
 async function findInvitationByConversation(

--- a/functions/src/secrets.ts
+++ b/functions/src/secrets.ts
@@ -26,6 +26,17 @@ export const TWILIO_FROM_NUMBER = defineSecret("TWILIO_FROM_NUMBER");
  *  wrong number. */
 export const TWILIO_FROM_NUMBER_TESTING = defineSecret("TWILIO_FROM_NUMBER_TESTING");
 
+/** Pinned webhook URL Twilio is configured to call. When set, the
+ *  signature-verification path uses this exact value as the signing
+ *  URL instead of constructing one from request headers. Eliminates
+ *  host-header drift as a silent-failure mode (e.g. a region change
+ *  or custom-domain swap leaving signatures perpetually invalid).
+ *  Set this to the public URL Twilio Console points at — typically
+ *  https://us-central1-<project>.cloudfunctions.net/onTwilioWebhook
+ *  or a custom-domain equivalent. Unset = fall back to constructing
+ *  the URL from `req.host` + `req.originalUrl` (prior behaviour). */
+export const TWILIO_WEBHOOK_URL = defineSecret("TWILIO_WEBHOOK_URL");
+
 /** Public origin of the web app (e.g. https://steward-app.ca) —
  *  used by Cloud Functions to build invite URLs in outbound
  *  correspondence. Runtime-configurable, not a secret. */

--- a/functions/src/twilio/verifyTwilioSignature.test.ts
+++ b/functions/src/twilio/verifyTwilioSignature.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { validateRequest, loggerWarn } = vi.hoisted(() => ({
+  validateRequest: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+vi.mock("twilio", () => ({ default: { validateRequest } }));
+vi.mock("firebase-functions/v2", () => ({ logger: { warn: loggerWarn } }));
+
+import { verifyTwilioSignature } from "./verifyTwilioSignature.js";
+
+describe("verifyTwilioSignature", () => {
+  beforeEach(() => {
+    validateRequest.mockReset();
+    loggerWarn.mockReset();
+  });
+  afterEach(() => {
+    validateRequest.mockReset();
+    loggerWarn.mockReset();
+  });
+
+  it("returns true and skips logging when Twilio's library accepts the signature", () => {
+    validateRequest.mockReturnValue(true);
+    const ok = verifyTwilioSignature({
+      signature: "sig-abc",
+      authToken: "token-xyz",
+      url: "https://example.cloudfunctions.net/onTwilioWebhook",
+      params: { ConversationSid: "CHabc" },
+    });
+    expect(ok).toBe(true);
+    expect(validateRequest).toHaveBeenCalledWith(
+      "token-xyz",
+      "sig-abc",
+      "https://example.cloudfunctions.net/onTwilioWebhook",
+      { ConversationSid: "CHabc" },
+    );
+    expect(loggerWarn).not.toHaveBeenCalled();
+  });
+
+  it("returns false and logs `missing-header` when the signature is undefined", () => {
+    const ok = verifyTwilioSignature({
+      signature: undefined,
+      authToken: "token-xyz",
+      url: "https://example/x",
+      params: {},
+    });
+    expect(ok).toBe(false);
+    expect(validateRequest).not.toHaveBeenCalled();
+    expect(loggerWarn).toHaveBeenCalledWith("twilio.webhook.signature_failed", {
+      reason: "missing-header",
+    });
+  });
+
+  it("returns false and logs `missing-auth-token` when the env var isn't injected", () => {
+    const ok = verifyTwilioSignature({
+      signature: "sig-abc",
+      authToken: undefined,
+      url: "https://example/x",
+      params: {},
+    });
+    expect(ok).toBe(false);
+    expect(validateRequest).not.toHaveBeenCalled();
+    expect(loggerWarn).toHaveBeenCalledWith("twilio.webhook.signature_failed", {
+      reason: "missing-auth-token",
+    });
+  });
+
+  it("returns false and logs `invalid` when Twilio's library rejects", () => {
+    validateRequest.mockReturnValue(false);
+    const ok = verifyTwilioSignature({
+      signature: "sig-tampered",
+      authToken: "token-xyz",
+      url: "https://example/x",
+      params: { Body: "Hello" },
+    });
+    expect(ok).toBe(false);
+    expect(loggerWarn).toHaveBeenCalledWith("twilio.webhook.signature_failed", {
+      reason: "invalid",
+    });
+  });
+
+  it("passes the URL through verbatim — no normalisation, query string preserved", () => {
+    validateRequest.mockReturnValue(true);
+    verifyTwilioSignature({
+      signature: "s",
+      authToken: "t",
+      url: "https://example/x?a=1&b=2",
+      params: {},
+    });
+    expect(validateRequest).toHaveBeenCalledWith("t", "s", "https://example/x?a=1&b=2", {});
+  });
+});

--- a/functions/src/twilio/verifyTwilioSignature.ts
+++ b/functions/src/twilio/verifyTwilioSignature.ts
@@ -1,0 +1,41 @@
+import { logger } from "firebase-functions/v2";
+import twilio from "twilio";
+
+export interface VerifyTwilioSignatureInput {
+  /** `X-Twilio-Signature` header value, or undefined when the header
+   *  isn't present. */
+  signature: string | undefined;
+  /** `TWILIO_AUTH_TOKEN` value, or undefined when the secret isn't
+   *  injected. */
+  authToken: string | undefined;
+  /** Signing URL Twilio used when computing the signature. Should be
+   *  the URL Twilio Console is configured with — `https://...` plus
+   *  any path/query — verbatim. */
+  url: string;
+  /** Form-urlencoded body parameters, deserialized. */
+  params: Record<string, string>;
+}
+
+/** Pure verification helper. Wraps `twilio.validateRequest` with
+ *  defence-in-depth checks (missing header / missing token short-circuit
+ *  to false) and structured logging on failure so a Cloud Logging
+ *  metric can alarm on rate.
+ *
+ *  Log key `twilio.webhook.signature_failed` with a `reason` label —
+ *  `missing-header`, `missing-auth-token`, or `invalid` — distinguishes
+ *  a misconfigured webhook from an actively-tampered request. */
+export function verifyTwilioSignature(input: VerifyTwilioSignatureInput): boolean {
+  if (!input.signature) {
+    logger.warn("twilio.webhook.signature_failed", { reason: "missing-header" });
+    return false;
+  }
+  if (!input.authToken) {
+    logger.warn("twilio.webhook.signature_failed", { reason: "missing-auth-token" });
+    return false;
+  }
+  const ok = twilio.validateRequest(input.authToken, input.signature, input.url, input.params);
+  if (!ok) {
+    logger.warn("twilio.webhook.signature_failed", { reason: "invalid" });
+  }
+  return ok;
+}


### PR DESCRIPTION
## Summary

Two improvements to `onTwilioWebhook`'s signature-verification path:

1. **Pinned signing URL** — adds optional `TWILIO_WEBHOOK_URL` secret. When set, the URL passed to `twilio.validateRequest` is pinned to that value instead of constructed from `req.host` + `req.originalUrl`. Eliminates the prior reliance on the attacker-controlled `Host` header and removes silent-drift failure modes (region change, custom-domain swap, unexpected headers). Backwards-compat — environments that don't set the secret keep the prior behaviour.
2. **Structured failure logs** — extracts verification into a pure helper at `functions/src/twilio/verifyTwilioSignature.ts`. The helper emits a `twilio.webhook.signature_failed` log entry with a `reason` label (`missing-header`, `missing-auth-token`, or `invalid`) on every failure. Gives Cloud Logging a stable key to alarm on and distinguishes misconfiguration from active tampering.

## Test plan

- [x] `pnpm --dir functions test` — 94/94 (5 new for verifyTwilioSignature)
- [x] `pnpm test` — 453/453
- [x] `pnpm typecheck` / `format:check` / `lint` — clean
- [x] `pnpm --dir functions build` — clean

## Operator runbook (after merge)

1. Get the deployed webhook URL — typically:
   ```
   https://us-central1-<project>.cloudfunctions.net/onTwilioWebhook
   ```
   or the custom-domain equivalent. Match exactly what Twilio Console has under **Conversations → Manage → Services → [your service] → Webhooks → Post-Event URL**.

2. Set the secret:
   ```
   firebase functions:secrets:set TWILIO_WEBHOOK_URL
   ```
   Paste the URL when prompted.

3. Redeploy functions.

4. Optional — wire up a Cloud Logging metric on `jsonPayload.message="twilio.webhook.signature_failed"` and alert when the rate exceeds a threshold (e.g. >5 in 5 minutes is suspicious; sustained means misconfig).

🤖 Generated with [Claude Code](https://claude.com/claude-code)