### PR TITLE
fix(invitations): wire speaker SMS participant binding

### DIFF
--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -1,5 +1,10 @@
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
-import { addChatParticipant, createConversation } from "./twilio/conversations.js";
+import { logger } from "firebase-functions/v2";
+import {
+  addChatParticipant,
+  addSmsParticipant,
+  createConversation,
+} from "./twilio/conversations.js";
 import {
   addBishopricParticipants,
   buildInviteUrl,
@@ -10,7 +15,7 @@ import {
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
 import { invitationPrayerType } from "./invitationTypes.js";
 import { stampParticipantInvited } from "./stampParticipantInvited.js";
-import type { FromNumberMode } from "./twilio/fromNumber.js";
+import { resolveFromNumber, type FromNumberMode } from "./twilio/fromNumber.js";
 import type {
   DeliveryEntry,
   FreshInvitationRequest,
@@ -97,6 +102,29 @@ export async function createFreshInvitation(
     displayName: input.speakerName,
     role: "speaker",
   });
+
+  // Bind the speaker's phone for SMS-to-Conversation bridging — without
+  // this, a speaker's SMS reply has no participant binding to match
+  // and Twilio drops it (the chat-identity participant alone covers
+  // the web-side, not SMS). Fail-soft: if Twilio rejects the binding
+  // (bad phone format, cross-border 10DLC block, etc.) we log and
+  // proceed; the chat still works on the web side and the invite SMS
+  // still gets delivered separately by `trySms` below.
+  if (input.speakerPhone) {
+    try {
+      await addSmsParticipant(
+        conversationSid,
+        input.speakerPhone,
+        resolveFromNumber(fromNumberMode),
+      );
+    } catch (err) {
+      logger.warn("failed to add SMS participant — chat will work web-only", {
+        speakerId: input.speakerId,
+        meetingDate: input.meetingDate,
+        err: (err as Error).message,
+      });
+    }
+  }
 
   await stampParticipantInvited({
     db,


### PR DESCRIPTION
## Summary

Restores SMS-to-Conversation bridging for speakers. `freshInvitation` was creating the speaker's chat-identity participant but never the SMS-binding participant — every inbound SMS reply had no participant to match against and Twilio dropped it. The bishop's chat went silent for the SMS path even though web chat worked.

## Root cause

`functions/src/twilio/conversations.ts` defines two participant types:
- `addChatParticipant(conversationSid, identity, attrs)` — chat identity only (web SDK uses this)
- `addSmsParticipant(conversationSid, speakerPhoneE164, twilioFromNumber)` — phone↔proxy binding (Twilio uses this to route inbound SMS into the conversation)

`freshInvitation.ts` called the first but not the second. The function definition + supporting comments remained ("two consecutive sends for the same speaker would otherwise fail at addSmsParticipant" — past-tense reference to a missing call), so this looks like a wiring that was lost in an earlier refactor.

## Fix

After the chat-identity participant is created for the speaker, call `addSmsParticipant` with their phone number and the resolved Twilio FROM proxy. Fail-soft on Twilio errors — bad phone format / cross-border 10DLC block etc. logs a warning but lets the chat-identity participant + the invite SMS continue to work.

## Important — pre-existing invitations are not auto-fixed

Conversations created before this PR have speakers without `messagingBinding`. They'll never bridge SMS replies regardless of how Twilio is configured. After this PR ships:
- For each in-flight invitation that needs SMS bridging, send a fresh invitation via Steward UI.
- Or, if there are many, write a one-time backfill script that calls `addSmsParticipant` for each existing conversation. Out of scope for this PR.

## Test plan

- [x] `pnpm typecheck` / `format:check` / `lint` — clean
- [x] `pnpm --dir functions build` — clean
- [x] `pnpm --dir functions test` — 89/89 pass (no new tests; `freshInvitation` lacks a Firestore-Admin mock harness — extracting one for a 30-line fix is over-engineering)
- [ ] Reviewer + operator: after merge + redeploy, send a fresh invite → reply by SMS → confirm the reply appears in the bishop's chat. Inspect via `twilio api conversations v1 services conversations participants list --chat-service-sid IS... --conversation-sid CH...` — speaker participant should now have `messagingBinding: { address: <speakerPhone>, proxyAddress: <TWILIO_FROM_NUMBER> }` instead of `null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)