### PR TITLE
ci: cache Playwright browsers + parallelise rules job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,11 +90,6 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
-      - uses: actions/setup-java@v5
-        with:
-          distribution: "temurin"
-          java-version: "21"
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
@@ -110,14 +105,28 @@ jobs:
       - name: Unit tests (Vitest)
         run: pnpm test
 
-      - name: Rules tests (Firestore emulator)
-        run: pnpm test:rules
-
       - name: Build
         run: pnpm build
 
-      - name: Install Playwright browsers
+      # Cache the downloaded browser binaries (~150MB chromium). Key
+      # invalidates on any pnpm-lock change — coarse but the simplest
+      # signal that picks up Playwright version bumps. On cache hit the
+      # next step skips the download and only runs install-deps for the
+      # apt packages (system deps don't carry across runner images).
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright browsers + deps (cache miss)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system deps (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
 
       - name: E2E tests (Playwright)
         run: pnpm test:e2e
@@ -129,6 +138,38 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  # Rules tests live in their own job so they parallelise with the
+  # build/e2e critical path. They need Java for the Firebase emulator,
+  # which the rest of the workflow doesn't touch — keeping it isolated
+  # also avoids paying the ~10s setup-java cost on every PR that
+  # doesn't change rules.
+  rules:
+    name: rules · firestore emulator
+    needs: changes
+    if: needs.changes.outputs.app == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rules tests (Firestore emulator)
+        run: pnpm test:rules
 
   functions:
     name: functions · build · test


### PR DESCRIPTION
## Summary

Two CI optimisations targeted at the slowest paths.

### 1. Cache Playwright browsers
- Cache `~/.cache/ms-playwright` keyed on `pnpm-lock.yaml`.
- On hit → skip the ~150MB chromium download; only run `playwright install-deps chromium` for system apt packages (those don't survive runner images, but install in seconds).
- On miss → fall back to the full `--with-deps chromium` install.

Expected savings: **30–60s per run** when the cache is warm.

### 2. Split rules tests into a parallel job
- `pnpm test:rules` needs Java 21 + Firebase emulator. Previously inline in the main `ci` job, blocking build/e2e on the ~10s setup-java cost.
- Moved to its own `rules · firestore emulator` job. Runs in parallel with build/e2e.
- Bonus: PRs that don't change rules don't pay for Java in the main `ci` runner anymore (rules job is a separate runner; main runner is leaner).

Expected savings: **~10–30s on the critical path**, depending on rules-test duration.

## Other optimisations considered but not done

- **Splitting lint/format/typecheck into a separate job** — overhead (~30–60s job startup per runner) outweighs the savings since each step is already fast (oxlint + biome are sub-second; tsc is ~10–30s).
- **Caching `node_modules`** — pnpm store cache via `setup-node`'s `cache: pnpm` already covers most of this. Direct `node_modules` cache adds complexity without much win.
- **Caching Vite build output** — cache keys are tricky; gains are marginal.

Happy to revisit any of these if a profile shows a bigger long-pole.

## Branch protection note

The new `rules · firestore emulator` job won't be in any required-status-check list yet. It'll run optionally on this PR; once green, you can add it as a required check via repo settings if you want it to gate merges (recommended — otherwise rules regressions don't block).

## Test plan

- [ ] CI runs on this PR — main `ci` job + new `rules` job both pass
- [ ] First run after merge populates the Playwright cache; second run shows the "Install Playwright system deps (cache hit)" step running instead of "(cache miss)"
- [ ] Total wall-clock CI time on the next PR is shorter than the historical baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)