### PR TITLE
fix + feat(invitations): SMS binding cleanup + personalised templates

### DIFF
--- a/functions/src/emailTemplateBody.ts
+++ b/functions/src/emailTemplateBody.ts
@@ -14,7 +14,9 @@ import { interpolate } from "./messageTemplates.js";
 
 export const DEFAULT_SPEAKER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. The full invitation letter — including our suggested topic and length — is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. Suggested topic: {{topic}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 
@@ -24,7 +26,9 @@ With gratitude,
 
 export const DEFAULT_PRAYER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}. The full invitation letter is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -4,6 +4,7 @@ import {
   addChatParticipant,
   addSmsParticipant,
   createConversation,
+  freePhoneBindingConflicts,
 } from "./twilio/conversations.js";
 import {
   addBishopricParticipants,
@@ -106,17 +107,19 @@ export async function createFreshInvitation(
   // Bind the speaker's phone for SMS-to-Conversation bridging — without
   // this, a speaker's SMS reply has no participant binding to match
   // and Twilio drops it (the chat-identity participant alone covers
-  // the web-side, not SMS). Fail-soft: if Twilio rejects the binding
-  // (bad phone format, cross-border 10DLC block, etc.) we log and
-  // proceed; the chat still works on the web side and the invite SMS
-  // still gets delivered separately by `trySms` below.
+  // the web-side, not SMS). Twilio enforces uniqueness on
+  // (phone, proxy) pairs across all active conversations, so we free
+  // any existing binding for this phone first — handles family-shared
+  // phones, repeated test invites, and any stale state from prior
+  // errors. Fail-soft: if Twilio rejects after the cleanup (bad phone
+  // format, cross-border block, etc.) we log and proceed; the
+  // chat-identity participant still covers the web side and the invite
+  // SMS still gets delivered separately by `trySms` below.
   if (input.speakerPhone) {
+    const proxyAddress = resolveFromNumber(fromNumberMode);
     try {
-      await addSmsParticipant(
-        conversationSid,
-        input.speakerPhone,
-        resolveFromNumber(fromNumberMode),
-      );
+      await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
+      await addSmsParticipant(conversationSid, input.speakerPhone, proxyAddress);
     } catch (err) {
       logger.warn("failed to add SMS participant — chat will work web-only", {
         speakerId: input.speakerId,

--- a/functions/src/invitationDelivery.ts
+++ b/functions/src/invitationDelivery.ts
@@ -56,7 +56,12 @@ export async function tryEmail(
       wardName: args.wardName,
       inviterName: args.inviterName,
       inviteUrl: args.inviteUrl,
-      ...(args.topic ? { topic: args.topic } : {}),
+      // Speaker template references `{{topic}}`; coerce to the
+      // project's standard "Topic of Choice" fallback (matches the
+      // schedule + program-editor surfaces from v0.19.0) when the
+      // speaker hasn't been assigned a specific topic. Harmless for
+      // prayer emails — their template doesn't reference `{{topic}}`.
+      topic: args.topic ?? "Topic of Choice",
       ...(args.prayerType ? { prayerType: args.prayerType } : {}),
     };
     const messageId = await sendEmail({
@@ -78,13 +83,26 @@ export async function tryEmail(
 
 async function buildInitialInvitationSms(
   wardId: string,
-  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl"> & {
+  vars: Pick<
+    EmailArgs,
+    "speakerName" | "inviterName" | "wardName" | "assignedDate" | "inviteUrl"
+  > & {
     prayerType?: string;
+    topic?: string;
   },
 ): Promise<string> {
   const key = vars.prayerType ? "prayerInitialInvitationSms" : "initialInvitationSms";
   const template = await readMessageTemplate(getFirestore(), wardId, key);
-  return interpolate(template, vars);
+  // Speaker SMS template references `{{topic}}`; coerce to the
+  // project's standard "Topic of Choice" fallback so the rendered
+  // SMS reads naturally when the speaker has no specific topic. The
+  // prayer SMS template doesn't reference `{{topic}}`, so the
+  // fallback value is unused on that path.
+  const interpolationVars = {
+    ...vars,
+    topic: vars.topic ?? "Topic of Choice",
+  };
+  return interpolate(template, interpolationVars);
 }
 
 export async function trySms(
@@ -118,6 +136,11 @@ export async function sendInvitationSms(args: {
   assignedDate: string;
   speakerName: string;
   inviteUrl: string;
+  /** Speaker's assigned topic — interpolated into `{{topic}}` in the
+   *  speaker SMS template. Optional: when unset, `buildInitialInvitationSms`
+   *  applies the project's "Topic of Choice" fallback. Unused on the
+   *  prayer SMS template path (which doesn't reference `{{topic}}`). */
+  topic?: string;
   fromMode?: FromNumberMode;
 }): Promise<{ providerId: string }> {
   const body = await buildInitialInvitationSms(args.wardId, args);

--- a/functions/src/issueSpeakerSession.helpers.ts
+++ b/functions/src/issueSpeakerSession.helpers.ts
@@ -17,6 +17,7 @@ export type TokenDecision =
       newToken: string;
       speakerPhone: string | undefined;
       speakerName: string;
+      speakerTopic: string | undefined;
       inviterName: string;
       wardName: string;
       assignedDate: string;
@@ -72,6 +73,7 @@ export async function decideTokenAction(
       newToken,
       speakerPhone: data.speakerPhone,
       speakerName: data.speakerName,
+      speakerTopic: data.speakerTopic,
       inviterName: data.inviterName,
       wardName: data.wardName,
       assignedDate: data.assignedDate,

--- a/functions/src/issueSpeakerSession.ts
+++ b/functions/src/issueSpeakerSession.ts
@@ -127,6 +127,7 @@ async function handleSpeakerTokenExchange(
         assignedDate: decision.assignedDate,
         speakerName: decision.speakerName,
         inviteUrl: buildInviteUrl(origin, wardId, invitationId, decision.newToken),
+        ...(decision.speakerTopic ? { topic: decision.speakerTopic } : {}),
         ...(decision.fromNumberMode ? { fromMode: decision.fromNumberMode } : {}),
       });
     } catch (err) {

--- a/functions/src/messageTemplateDefaults.ts
+++ b/functions/src/messageTemplateDefaults.ts
@@ -12,9 +12,13 @@
  * `messageTemplates.ts`.
  */
 
-export const DEFAULT_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to speak on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to speak on {{assignedDate}}. Topic: {{topic}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 export const DEFAULT_SPEAKER_RESPONSE_ACCEPTED =
   "You accepted the invitation to speak on {{assignedDate}}. Thank you.";
@@ -38,9 +42,13 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
   "— {{wardName}}",
 ].join("\n");
 
-export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to give the {{prayerType}} on {{assignedDate}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =
   "You accepted the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you.";

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -83,6 +83,48 @@ export async function addSmsParticipant(
   return p.sid;
 }
 
+/** Frees the speaker phone's existing SMS binding(s) on this
+ *  Conversations service before a new conversation tries to claim it.
+ *  Twilio enforces uniqueness on (address, proxyAddress) pairs across
+ *  all active conversations — without this cleanup, the second
+ *  `addSmsParticipant` call for the same phone fails and inbound SMS
+ *  routes to whichever conversation already owns the binding (often
+ *  not the most recent one).
+ *
+ *  Real-world cases this catches:
+ *  - Family-shared phone: the bishop sent invite to spouse A, then to
+ *    spouse B. Most-recent-invite wins for SMS routing on that phone.
+ *  - Test/staging churn: repeated invites to the same phone with
+ *    different speakerIds (so `cleanupPriorConversations` doesn't
+ *    catch them via its speakerId+meetingDate filter).
+ *  - Stale state: any conversation orphaned by an earlier deploy
+ *    error or manual cleanup that left bindings behind.
+ *
+ *  Removes only the SMS participant, not the whole conversation —
+ *  the prior chat history (web side, bishopric identities) survives
+ *  and remains viewable by the bishop. */
+export async function freePhoneBindingConflicts(
+  speakerPhoneE164: string,
+  twilioFromNumber: string,
+): Promise<void> {
+  const svc = service();
+  const conflicts = await svc.participantConversations.list({ address: speakerPhoneE164 });
+  for (const c of conflicts) {
+    const binding = c.participantMessagingBinding as
+      | { address?: string; proxy_address?: string; type?: string }
+      | undefined;
+    if (
+      binding?.type !== "sms" ||
+      binding.address !== speakerPhoneE164 ||
+      binding.proxy_address !== twilioFromNumber
+    ) {
+      continue;
+    }
+    if (!c.conversationSid || !c.participantSid) continue;
+    await svc.conversations(c.conversationSid).participants(c.participantSid).remove();
+  }
+}
+
 export interface PostMessageInput {
   conversationSid: string;
   author: string;

--- a/src/features/templates/utils/prayerEmailDefaults.ts
+++ b/src/features/templates/utils/prayerEmailDefaults.ts
@@ -12,7 +12,9 @@
 
 export const DEFAULT_PRAYER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}. The full invitation letter is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 

--- a/src/features/templates/utils/serverTemplateDefaults.ts
+++ b/src/features/templates/utils/serverTemplateDefaults.ts
@@ -14,9 +14,13 @@ import type { MessageTemplateKey } from "@/lib/types";
  */
 
 /** Twilio SMS body sent when a bishop first invites a speaker. */
-export const DEFAULT_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to speak on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to speak on {{assignedDate}}. Topic: {{topic}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 /** Narrative header of the SendGrid email the speaker receives when
  *  they submit Yes on the invitation page. The letter excerpt and
@@ -59,9 +63,13 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
  *  Mirrors the speaker-side wording with prayer phrasing in place of
  *  "speak". `{{prayerType}}` resolves to "opening prayer" or
  *  "closing prayer" per the prayer participant's role. */
-export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to give the {{prayerType}} on {{assignedDate}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 /** Speaker-side acceptance receipt for prayer invitations. */
 export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =

--- a/src/features/templates/utils/speakerEmailDefaults.ts
+++ b/src/features/templates/utils/speakerEmailDefaults.ts
@@ -11,7 +11,9 @@
 
 export const DEFAULT_SPEAKER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. The full invitation letter — including our suggested topic and length — is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. Suggested topic: {{topic}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 


### PR DESCRIPTION
Two related changes on the same branch.

## 1. fix: free stale SMS binding before adding new one

Twilio enforces uniqueness on `(address, proxyAddress)` pairs across all active conversations. Without preemptive cleanup, a second `addSmsParticipant` call for the same speaker phone fails silently (the fail-soft handler from PR-217 eats the error), the binding stays on whichever conversation claimed it first, and inbound SMS replies route to the wrong chat.

New helper `freePhoneBindingConflicts(speakerPhone, proxyAddress)` in `twilio/conversations.ts`:

- Calls Twilio's `participantConversations.list({ address })` to find any active SMS binding matching this `(phone, proxy)` pair.
- For each match, removes only the SMS participant. Conversation + chat history + bishopric identities survive.

Wired into `freshInvitation.ts` immediately before `addSmsParticipant`. Catches family-shared phones, repeated test invites, and stale state from prior errors.

## 2. feat: personalise invitation templates + emphasise the in-app chat

The default SMS and email templates now address the recipient by name, surface the assigned Sunday + the speaker's topic (or prayer role), and direct replies into the in-app chat instead of plain SMS. Twilio per-message SMS billing makes the chat substantially cheaper for back-and-forth conversation; richer context lives in one place too.

**Template changes** (server + client mirrors kept in sync per the drift check in `messageTemplates.test.ts`):

- Speaker SMS — "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to speak on {{assignedDate}}. Topic: {{topic}}." plus a chat-first CTA.
- Prayer SMS — same shape, "give the {{prayerType}}" instead of "speak", no topic line.
- Speaker email — adds "Suggested topic: {{topic}}." and rewrites the body to point replies at the chat thread on the invite page.
- Prayer email — same chat-first rewrite, role drives copy via `{{prayerType}}`.

**Plumbing:**

- `buildInitialInvitationSms` widened to forward `speakerName` and `topic` to interpolation.
- Both SMS + email paths apply the project's standard `"Topic of Choice"` fallback (matches v0.19.0 schedule + program-editor convention) when the speaker has no topic on file. Prayer paths don't reference `{{topic}}`, so the fallback is unused there.
- `decideTokenAction`'s rotate kind carries `speakerTopic` so rotation re-sends preserve the topic. `sendInvitationSms` accepts optional `topic`.

## Out of scope — deferred

- **YES/NO-via-SMS auto-binding** — issue [#222](https://github.com/aylabyuk/steward/issues/222). User wants more design discussion before shipping (multi-word match? auto-Apply skip the bishop's review? confirmation SMS? etc.).
- **Conditional template syntax** (`{{#if topic}}...{{/if}}`) — interpolate is intentionally simple. Followup if templates ever need it.

## Test plan

- [x] `pnpm typecheck` / `format:check` / `lint` — clean
- [x] `pnpm --dir functions build` — clean
- [x] `pnpm --dir functions test` — 96/96 (drift check still green; client/server defaults match)
- [x] `pnpm test` — 453/453
- [ ] Manual prod verification after merge + deploy:
  1. Companion manual cleanup already done — stale `Test Speaker 2` binding removed via `twilio api ... participants remove` so SMS routing in prod is unblocked right now.
  2. Send fresh invite to a phone you control. Confirm SMS reads "Hi [Name] — ... Topic: [Topic]." with the chat-first CTA.
  3. Send a second fresh invite to a *different* speakerId, same phone. Confirm `freePhoneBindingConflicts` runs and the new binding wins.
  4. Reply by SMS — should land in the second invite's chat (most-recent-invite wins).
  5. (Email) When SendGrid is wired, confirm the new copy renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)