### PR TITLE
fix(invitations): combine speaker participant + drop redundant reply SMS

### DIFF
--- a/docs/invitation-flow.md
+++ b/docs/invitation-flow.md
@@ -142,19 +142,13 @@ sequenceDiagram
     rect rgb(255,255,235)
     Note over Bishop,SpkPhone: Phase 7 — Bishop replies in chat (later)
     Bishop->>Twilio: Conversation message
-    Twilio->>Fn: onTwilioWebhook
-    par Notify speaker
-        Fn->>Fn: Check speaker heartbeat (online?)
-        alt offline (>120s)
-            Fn->>Fn: Rotate token (no daily cap)
-            Fn->>Twilio: SMS w/ fresh invite URL
-            Twilio->>SpkPhone: SMS: bishop replied
-            Fn->>SG: Email: bishop replied
-            SG->>SpkEmail: Inbox
-        else online
-            Note over Fn: Skip SMS — speaker is reading chat live
-        end
-    and Notify other bishopric
+    par Native SMS bridge
+        Twilio->>SpkPhone: SMS to speaker's bound number
+        Note over Twilio,SpkPhone: Twilio Conversations broadcasts the<br/>chat message to the speaker's<br/>SMS-bound participant — single<br/>combined participant suppresses<br/>echo back to web sender
+    and Webhook fans out
+        Twilio->>Fn: onTwilioWebhook
+        Fn->>SG: Email: bishop replied
+        SG->>SpkEmail: Inbox
         Fn->>FCM: Push to other active bishopric
     end
     end
@@ -185,6 +179,7 @@ sequenceDiagram
 The diagrams omit a few branches that exist in the code but would clutter the picture. Pointers for when you need them:
 
 - **Quiet hours / timezone filtering on FCM pushes** — applied per-recipient inside `notifyBishopricOfResponse` and the reply-push helpers.
+- **Single combined speaker participant** — the speaker's chat identity and SMS messagingBinding live on a single Twilio Conversations participant (not two separate ones). Twilio uses this to suppress echoes back to the web-side sender when the speaker submits a Yes/No from the invite page.
 - **Per-template variable interpolation** (`{{speakerName}}`, `{{topic}}`, `{{wardName}}`, …) — handled by `messageTemplates.ts` in `functions/src/`.
 - **Speaker vs prayer template keys** — every notification lookup branches on `kind` to pick the right template (e.g. `speakerResponseAccepted` vs `prayerResponseAccepted`). Parity was finished in commit `8660a98`.
 - **Twilio Conversation cleanup on re-send** — `freshInvitation.ts` deletes any prior Conversation for the same (ward, speaker, meeting) before creating a new one.

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -1,8 +1,7 @@
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import {
-  addChatParticipant,
-  addSmsParticipant,
+  addSpeakerParticipant,
   createConversation,
   freePhoneBindingConflicts,
 } from "./twilio/conversations.js";
@@ -99,32 +98,51 @@ export async function createFreshInvitation(
     createdAt: FieldValue.serverTimestamp(),
   });
 
-  await addChatParticipant(conversationSid, `speaker:${docRef.id}`, {
-    displayName: input.speakerName,
-    role: "speaker",
-  });
-
-  // Bind the speaker's phone for SMS-to-Conversation bridging — without
-  // this, a speaker's SMS reply has no participant binding to match
-  // and Twilio drops it (the chat-identity participant alone covers
-  // the web-side, not SMS). Twilio enforces uniqueness on
-  // (phone, proxy) pairs across all active conversations, so we free
-  // any existing binding for this phone first — handles family-shared
-  // phones, repeated test invites, and any stale state from prior
-  // errors. Fail-soft: if Twilio rejects after the cleanup (bad phone
-  // format, cross-border block, etc.) we log and proceed; the
-  // chat-identity participant still covers the web side and the invite
-  // SMS still gets delivered separately by `trySms` below.
-  if (input.speakerPhone) {
-    const proxyAddress = resolveFromNumber(fromNumberMode);
+  // Add the speaker as a single participant carrying BOTH the chat
+  // identity AND (when phone on file) the SMS messagingBinding.
+  // Two-participant setups echo the speaker's web-side answer back
+  // to their own phone via SMS — Twilio can't tell the chat-identity
+  // participant and the SMS-binding participant are the same human,
+  // so it broadcasts to all bindings. Combining them on one
+  // participant lets Twilio de-dup automatically.
+  //
+  // Twilio enforces uniqueness on (phone, proxyAddress) across all
+  // active conversations, so free any existing binding for this
+  // phone first. Fail-soft: if the create itself fails (bad phone
+  // format, cross-border 10DLC block, etc.), log and continue with
+  // a chat-only participant — invite SMS still delivers separately
+  // via `trySms` below.
+  const proxyAddress = input.speakerPhone ? resolveFromNumber(fromNumberMode) : undefined;
+  if (input.speakerPhone && proxyAddress) {
+    await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
+  }
+  try {
+    await addSpeakerParticipant(
+      conversationSid,
+      `speaker:${docRef.id}`,
+      { displayName: input.speakerName, role: "speaker" },
+      input.speakerPhone && proxyAddress
+        ? { speakerPhoneE164: input.speakerPhone, twilioFromNumber: proxyAddress }
+        : undefined,
+    );
+  } catch (err) {
+    logger.warn("failed to add speaker participant with SMS binding — falling back to chat-only", {
+      speakerId: input.speakerId,
+      meetingDate: input.meetingDate,
+      err: (err as Error).message,
+    });
+    // Fallback: at least make the chat side work so the bishop UI
+    // can see the speaker's identity if anything else fires.
     try {
-      await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
-      await addSmsParticipant(conversationSid, input.speakerPhone, proxyAddress);
-    } catch (err) {
-      logger.warn("failed to add SMS participant — chat will work web-only", {
+      await addSpeakerParticipant(conversationSid, `speaker:${docRef.id}`, {
+        displayName: input.speakerName,
+        role: "speaker",
+      });
+    } catch (chatErr) {
+      logger.warn("chat-only fallback also failed", {
         speakerId: input.speakerId,
         meetingDate: input.meetingDate,
-        err: (err as Error).message,
+        err: (chatErr as Error).message,
       });
     }
   }

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,73 +1,12 @@
-import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
-import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
 import { interpolate, readMessageTemplate } from "./messageTemplates.js";
-import { STEWARD_ORIGIN } from "./secrets.js";
-import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
 import { sendEmail } from "./sendgrid/client.js";
-import { sendSmsDirect } from "./twilio/messaging.js";
+import { getFirestore } from "firebase-admin/firestore";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ResolvedInvitation extends SpeakerInvitationShape {
   wardId: string;
   token: string;
-}
-
-/** Max age of the speaker's `speakerLastSeenAt` heartbeat before we
- *  treat the chat as "closed". The invite page pings every 60s while
- *  the tab is visible; 2× that cadence gives one missed ping of slack
- *  before we fall back to SMS. */
-const HEARTBEAT_FRESH_MS = 120_000;
-
-/** Bishop posted → SMS the speaker with a fresh resume link (unless
- *  the speaker's heartbeat shows they're actively viewing the chat).
- *  Rotates the invitation's capability token (bishop-initiated, so it
- *  does NOT count against `tokenRotationsByDay`) and appends the fresh
- *  URL — the speaker can tap it to re-enter the chat with prior
- *  messages preserved (same conversationSid). No-op when the invitation
- *  has no phone on file. */
-export async function smsSpeaker(inv: ResolvedInvitation, body: string): Promise<void> {
-  if (!inv.speakerPhone) return;
-  if (isSpeakerOnline(inv)) return;
-  let inviteUrl: string | null = null;
-  try {
-    const rotated = await rotateTokenForBishopNotification(inv.wardId, inv.token);
-    if (rotated) {
-      const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
-      inviteUrl = buildInviteUrl(origin, inv.wardId, inv.token, rotated.newToken);
-    }
-  } catch (err) {
-    logger.warn("reply SMS token rotation failed — falling back to preview-only", {
-      token: inv.token,
-      err: (err as Error).message,
-    });
-  }
-  const preview = truncate(body, 240);
-  // Rotation-failed path stays hardcoded: it's an error fallback, not
-  // a user-authored message — we don't want a bishopric-edited template
-  // to leak a placeholder `{{inviteUrl}}` token into an SMS.
-  let text: string;
-  if (inviteUrl) {
-    const template = await readMessageTemplate(getFirestore(), inv.wardId, "bishopReplySms");
-    text = interpolate(template, { wardName: inv.wardName, preview, inviteUrl });
-  } else {
-    text = `${inv.inviterName} (Steward): ${preview}`;
-  }
-  try {
-    await sendSmsDirect({
-      to: inv.speakerPhone,
-      body: text,
-      ...(inv.fromNumberMode ? { fromMode: inv.fromNumberMode } : {}),
-    });
-  } catch (err) {
-    logger.error("reply SMS failed", { err: (err as Error).message, token: inv.token });
-  }
-}
-
-function isSpeakerOnline(inv: ResolvedInvitation): boolean {
-  const ts = inv.speakerLastSeenAt;
-  if (!ts) return false;
-  return Date.now() - ts.toMillis() < HEARTBEAT_FRESH_MS;
 }
 
 /** Bishop posted → SendGrid email to the speaker with a preview.

--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -1,7 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { onRequest, type Request } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
-import { emailSpeaker, smsSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
+import { emailSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
 import { pushToBishopric } from "./invitationReplyPush.js";
 import {
   TWILIO_ACCOUNT_SID,
@@ -72,12 +72,15 @@ export const onTwilioWebhook = onRequest(
       await pushToBishopric(invitation, body);
     } else if (author.startsWith("uid:")) {
       const senderBishopUid = author.slice("uid:".length);
-      // All three run in parallel. SMS is the primary channel for the
-      // speaker, email is best-effort (no-ops when SendGrid isn't
-      // wired), and the bishop-to-bishop push keeps peer bishopric
-      // members in the loop without re-notifying the sender.
+      // No `smsSpeaker` here: Twilio Conversations natively
+      // broadcasts the bishop's message to the speaker's SMS-bound
+      // participant. The previous wrapped notification SMS (with a
+      // freshly-rotated invite URL) was a duplicate of that native
+      // broadcast — speakers were getting both bubbles for the same
+      // bishop reply. Email + the bishop-to-bishop FCM push still
+      // run in parallel so peers see each other's chat activity even
+      // when not actively viewing the thread.
       await Promise.all([
-        smsSpeaker(invitation, body),
         emailSpeaker(invitation, body),
         pushToBishopric(invitation, body, { senderBishopUid }),
       ]);

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -19,7 +19,9 @@ export async function assertActiveMember(wardId: string, uid: string): Promise<v
 /** Frees the speaker's phone binding from any earlier Twilio
  *  Conversation for this (wardId, speakerId, meetingDate). Twilio
  *  refuses to bind the same (phone, proxy) pair twice, so a re-send
- *  for the same speaker would otherwise fail at addSmsParticipant. */
+ *  for the same speaker would otherwise fail at the participant
+ *  create call. (Cross-speaker phone conflicts are handled by
+ *  `freePhoneBindingConflicts` at participant-create time.) */
 export interface BishopricSnapshot {
   uid: string;
   displayName: string;

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -67,19 +67,46 @@ export async function ensureChatParticipant(
   }
 }
 
-/** Speaker-side SMS participant. Twilio bridges messages in this
- *  conversation to/from the speaker's phone automatically. Returns
- *  the participant SID; throws if Twilio rejects (bad phone format,
- *  cross-border 10DLC block, etc.). */
-export async function addSmsParticipant(
+/** Speaker-side participant carrying BOTH a chat identity AND (when
+ *  the speaker has a phone on file) an SMS messagingBinding on a
+ *  single Twilio Conversations participant.
+ *
+ *  Why both on one participant: Twilio Conversations broadcasts every
+ *  message to all participants with delivery channels. With the
+ *  chat-identity and SMS binding split across two participants, a
+ *  message authored by the chat-identity participant gets broadcast
+ *  to the SMS-only participant — Twilio can't tell they're the same
+ *  human, and the speaker receives their own web-side answer back as
+ *  SMS (the "Yes, I can speak." echo). Combining identity + binding
+ *  on one participant makes the de-dup automatic: Twilio knows the
+ *  sender and the binding belong to the same participant and won't
+ *  fan back to that channel.
+ *
+ *  Bonus side effect: the binding now carries the speaker's display
+ *  name + role attributes, so the bishop's chat UI no longer renders
+ *  SMS-originated messages as "Unknown".
+ *
+ *  Pass `smsBinding: undefined` for speakers with no phone on file —
+ *  the participant is created chat-only, identical to bishopric
+ *  participants. */
+export async function addSpeakerParticipant(
   conversationSid: string,
-  speakerPhoneE164: string,
-  twilioFromNumber: string,
+  identity: string,
+  attributes: {
+    displayName: string;
+    role: "speaker";
+  },
+  smsBinding?: { speakerPhoneE164: string; twilioFromNumber: string },
 ): Promise<string> {
-  const p = await service().conversations(conversationSid).participants.create({
-    "messagingBinding.address": speakerPhoneE164,
-    "messagingBinding.proxyAddress": twilioFromNumber,
-  });
+  const params: Record<string, string> = {
+    identity,
+    attributes: JSON.stringify(attributes),
+  };
+  if (smsBinding) {
+    params["messagingBinding.address"] = smsBinding.speakerPhoneE164;
+    params["messagingBinding.proxyAddress"] = smsBinding.twilioFromNumber;
+  }
+  const p = await service().conversations(conversationSid).participants.create(params);
   return p.sid;
 }
 
@@ -87,9 +114,9 @@ export async function addSmsParticipant(
  *  Conversations service before a new conversation tries to claim it.
  *  Twilio enforces uniqueness on (address, proxyAddress) pairs across
  *  all active conversations — without this cleanup, the second
- *  `addSmsParticipant` call for the same phone fails and inbound SMS
- *  routes to whichever conversation already owns the binding (often
- *  not the most recent one).
+ *  `addSpeakerParticipant` call for the same phone fails and inbound
+ *  SMS routes to whichever conversation already owns the binding
+ *  (often not the most recent one).
  *
  *  Real-world cases this catches:
  *  - Family-shared phone: the bishop sent invite to spouse A, then to
@@ -100,9 +127,11 @@ export async function addSmsParticipant(
  *  - Stale state: any conversation orphaned by an earlier deploy
  *    error or manual cleanup that left bindings behind.
  *
- *  Removes only the SMS participant, not the whole conversation —
- *  the prior chat history (web side, bishopric identities) survives
- *  and remains viewable by the bishop. */
+ *  Removes the matching SMS-bound participant entirely (today that's
+ *  the speaker's combined chat-identity + SMS-binding participant
+ *  per `addSpeakerParticipant`). The prior chat history survives
+ *  conversation-side; only that participant's attribution on past
+ *  messages is freed. */
 export async function freePhoneBindingConflicts(
   speakerPhoneE164: string,
   twilioFromNumber: string,


### PR DESCRIPTION
## Summary

Two related fixes from yesterday's prod retest after PR #221.

### 1. Stop echoing the speaker's web answer back to their own phone

Pre-fix, `freshInvitation` created **two separate participants** for the speaker — chat-identity-only via `addChatParticipant`, SMS-binding-only via `addSmsParticipant`. Twilio Conversations broadcasts every message to all participants with channels; with the two split, Twilio couldn't tell they were the same human. When the speaker submitted Yes/No on the web invite page, the chat message authored by their chat identity got broadcast to the SMS-only participant — speaker received their own answer back as SMS ("Yes, I can speak." echo).

Combined onto one participant via the new `addSpeakerParticipant` helper, Twilio recognises the sender + binding belong to the same participant and suppresses the echo automatically.

**Bonus**: the SMS binding now carries `displayName` + `role` attributes (vs. nothing on the old SMS-only participant), so the bishop's chat UI no longer renders SMS-originated messages as "Unknown".

### 2. Drop the redundant `smsSpeaker` call on bishop-reply

Pre-PR-217, the speaker had no SMS binding, so `smsSpeaker` was the only way to get bishop chat messages to the speaker's phone. After PR-217, **Twilio Conversations natively broadcasts** bishop messages to the speaker's SMS-bound participant. `smsSpeaker` became a duplicate — speakers received both:
- A plain SMS via Twilio native broadcast: \`"Assignment confirmed — thank you for speaking on Sun, May 17."\`
- A wrapped SMS via Steward's `smsSpeaker`: \`"Eglinton Ward: new message — '...'. Open: <URL>"\`

Removed `smsSpeaker` from `onTwilioWebhook`'s bishop-reply branch. Twilio's native broadcast handles delivery; `emailSpeaker` and `pushToBishopric` still run.

**Side effect**: Steward no longer rotates the token + sends a fresh URL on each bishop reply. Speakers re-enter the chat via their original invite URL, or via the existing rotation self-heal when they present a consumed token. Acceptable for the cost + UX win.

## Documentation

Phase 7 in [docs/invitation-flow.md](docs/invitation-flow.md) updated — shows Twilio's native SMS bridge in parallel with the webhook fan-out (email + bishopric FCM), no Steward-side wrapped SMS step. Added a note in the "captured" callout list explaining the combined-participant model.

## Operator runbook (post-merge)

After deploy, **switch the active outbound number** from \`+15873184624\` (ending 24) to \`+12295473216\` (ending 16) per your request:

\`\`\`bash
firebase functions:secrets:set TWILIO_FROM_NUMBER --project steward-prod-65a36
# When prompted, paste: +12295473216
firebase deploy --only functions --project steward-prod-65a36
\`\`\`

⚠️ Note: switching the secret stops *new* sends from using \`+15873184624\`, but the number's monthly Twilio fee continues until you release it (Twilio Console → Phone Numbers → Active numbers → click number → Release). Existing in-flight conversations bound to \`+15873184624\` keep working until they expire — re-send those if you want them on the new number.

## Test plan

- [x] \`pnpm typecheck\` / \`format:check\` / \`lint\` — clean
- [x] \`pnpm --dir functions build\` — clean
- [x] \`pnpm --dir functions test\` — 96/96
- [x] \`pnpm test\` — 453/453
- [ ] Manual prod verification after merge + deploy + secret swap:
  1. Send fresh invite to a phone you control. SMS should come from \`+1...3216\`.
  2. Tap the link, submit Yes from the web invite page. **Should NOT see "Yes, I can speak." echoed back as SMS.** Bishop's chat shows the answer.
  3. Bishop replies in chat. **Should see ONE SMS arrive on speaker phone**, not two — Twilio's native broadcast only.
  4. Bishop's chat UI: SMS-originated messages from the speaker should show their name (not "Unknown").
  5. Inspect via \`twilio api conversations v1 services conversations participants list ...\` — the speaker participant should have BOTH \`identity\` and \`messagingBinding\` set.

## Cleanup in this PR

Removed the now-unused \`smsSpeaker\` function + its imports (\`rotateTokenForBishopNotification\`, \`STEWARD_ORIGIN\`, \`buildInviteUrl\`, \`sendSmsDirect\`, the \`isSpeakerOnline\` helper). Stale comment references to \`addSmsParticipant\` updated to \`addSpeakerParticipant\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)