### PR TITLE
Release: v0.20.1 — SMS bridging cleanup + template polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,79 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.20.1] — 2026-05-01
+
+Same-day follow-up to v0.20.0. Restores SMS bridging that broke under
+prod retest after PR #217 — a participant-model bug where the
+speaker's chat identity and SMS messagingBinding lived on two
+separate Twilio Conversations participants. The split caused the
+speaker's web-side Yes/No answer to echo back to their own phone as
+SMS, and made every bishop chat reply arrive twice (Twilio native
+broadcast plus Steward's wrapped notification SMS). Combined into a
+single participant per speaker so Twilio de-dupes correctly. Same
+release also refreshes the invitation SMS + email copy to address
+the recipient by name and direct replies into the in-app chat
+instead of plain SMS.
+
+### Changed
+
+- **Invitation SMS + email copy refreshed** — speakers and prayer
+  participants are now greeted by name (`{{speakerName}}`),
+  speakers see their topic on the body line (with the project's
+  standard "Topic of Choice" fallback when no topic is set), and
+  the CTA leads recipients into the in-app chat instead of replying
+  via SMS. Lower per-message Twilio cost on back-and-forth replies
+  + richer context for the bishopric. Defaults updated server-side
+  + on the client mirror in `src/features/templates/utils/`; the
+  drift check in `messageTemplates.test.ts` still asserts the two
+  sides match.
+
+### Fixed
+
+- **Speaker SMS reply landing in the wrong chat** — Twilio enforces
+  uniqueness on `(phone, proxyAddress)` pairs across all active
+  conversations, but `cleanupPriorConversations` only cleared
+  bindings scoped to the same `(speakerId, meetingDate)`. Repeated
+  invites to the same phone with different speakers (family-shared
+  phones, test churn) left a stale binding owning the routing —
+  inbound SMS replies arrived in the wrong (older) conversation.
+  New `freePhoneBindingConflicts` helper walks
+  `participantConversations.list({ address })` and removes any
+  conflicting binding before the new participant is created.
+- **"Yes, I can speak." echoed back to speakers via SMS** — when
+  the speaker submitted Yes/No on the web invite page, the chat
+  message authored by their chat-identity participant got broadcast
+  by Twilio to the SMS-only participant — Twilio couldn't tell
+  they were the same human. Speakers received their own answer
+  back on their phone. Combined the chat identity and SMS binding
+  onto a single participant via the new `addSpeakerParticipant`
+  helper; Twilio now suppresses the echo automatically.
+- **"Unknown" displayName on SMS-originated messages in the bishop
+  chat** — the SMS-only participant carried no `attributes`, so
+  the bishop's chat UI couldn't resolve a name for the speaker on
+  inbound SMS. The combined participant now carries the
+  `displayName` + `role` attributes alongside the binding.
+- **Duplicate bishop-reply SMS arriving on the speaker's phone** —
+  pre-PR-217 the speaker had no SMS binding, so Steward's
+  `smsSpeaker` was the only path for bishop chat messages to reach
+  the speaker via SMS. PR-217 changed that — Twilio Conversations
+  now natively broadcasts bishop messages to the speaker's
+  SMS-bound participant. `smsSpeaker` became a duplicate.
+  Removed it from the bishop-reply branch in `onTwilioWebhook`;
+  `emailSpeaker` and `pushToBishopric` still run.
+  Side effect: Steward no longer rotates the token + sends a
+  fresh URL on each bishop reply. Speakers re-enter the chat via
+  their original invite URL or the existing rotation self-heal
+  (presenting a consumed token triggers a fresh-URL SMS).
+
+### Infrastructure
+
+- **`docs/invitation-flow.md` Phase 7 updated** to reflect the
+  Twilio-native SMS bridge (in parallel with the webhook fan-out)
+  rather than Steward's prior wrapped-SMS step. Added a note in
+  the simplified-out callout describing the combined-participant
+  rationale.
+
 ## [0.20.0] — 2026-05-01
 
 Security + reliability cycle. Speaker SMS replies now actually bridge
@@ -2387,7 +2460,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.20.0...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.20.1...HEAD
+[0.20.1]: https://github.com/aylabyuk/steward/releases/tag/v0.20.1
 [0.20.0]: https://github.com/aylabyuk/steward/releases/tag/v0.20.0
 [0.19.0]: https://github.com/aylabyuk/steward/releases/tag/v0.19.0
 [0.18.0]: https://github.com/aylabyuk/steward/releases/tag/v0.18.0

--- a/docs/invitation-flow.md
+++ b/docs/invitation-flow.md
@@ -142,19 +142,13 @@ sequenceDiagram
     rect rgb(255,255,235)
     Note over Bishop,SpkPhone: Phase 7 — Bishop replies in chat (later)
     Bishop->>Twilio: Conversation message
-    Twilio->>Fn: onTwilioWebhook
-    par Notify speaker
-        Fn->>Fn: Check speaker heartbeat (online?)
-        alt offline (>120s)
-            Fn->>Fn: Rotate token (no daily cap)
-            Fn->>Twilio: SMS w/ fresh invite URL
-            Twilio->>SpkPhone: SMS: bishop replied
-            Fn->>SG: Email: bishop replied
-            SG->>SpkEmail: Inbox
-        else online
-            Note over Fn: Skip SMS — speaker is reading chat live
-        end
-    and Notify other bishopric
+    par Native SMS bridge
+        Twilio->>SpkPhone: SMS to speaker's bound number
+        Note over Twilio,SpkPhone: Twilio Conversations broadcasts the<br/>chat message to the speaker's<br/>SMS-bound participant — single<br/>combined participant suppresses<br/>echo back to web sender
+    and Webhook fans out
+        Twilio->>Fn: onTwilioWebhook
+        Fn->>SG: Email: bishop replied
+        SG->>SpkEmail: Inbox
         Fn->>FCM: Push to other active bishopric
     end
     end
@@ -185,6 +179,7 @@ sequenceDiagram
 The diagrams omit a few branches that exist in the code but would clutter the picture. Pointers for when you need them:
 
 - **Quiet hours / timezone filtering on FCM pushes** — applied per-recipient inside `notifyBishopricOfResponse` and the reply-push helpers.
+- **Single combined speaker participant** — the speaker's chat identity and SMS messagingBinding live on a single Twilio Conversations participant (not two separate ones). Twilio uses this to suppress echoes back to the web-side sender when the speaker submits a Yes/No from the invite page.
 - **Per-template variable interpolation** (`{{speakerName}}`, `{{topic}}`, `{{wardName}}`, …) — handled by `messageTemplates.ts` in `functions/src/`.
 - **Speaker vs prayer template keys** — every notification lookup branches on `kind` to pick the right template (e.g. `speakerResponseAccepted` vs `prayerResponseAccepted`). Parity was finished in commit `8660a98`.
 - **Twilio Conversation cleanup on re-send** — `freshInvitation.ts` deletes any prior Conversation for the same (ward, speaker, meeting) before creating a new one.

--- a/functions/src/emailTemplateBody.ts
+++ b/functions/src/emailTemplateBody.ts
@@ -14,7 +14,9 @@ import { interpolate } from "./messageTemplates.js";
 
 export const DEFAULT_SPEAKER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. The full invitation letter — including our suggested topic and length — is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. Suggested topic: {{topic}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 
@@ -24,7 +26,9 @@ With gratitude,
 
 export const DEFAULT_PRAYER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}. The full invitation letter is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -4,6 +4,7 @@ import {
   addChatParticipant,
   addSmsParticipant,
   createConversation,
+  freePhoneBindingConflicts,
 } from "./twilio/conversations.js";
 import {
   addBishopricParticipants,
@@ -106,17 +107,19 @@ export async function createFreshInvitation(
   // Bind the speaker's phone for SMS-to-Conversation bridging — without
   // this, a speaker's SMS reply has no participant binding to match
   // and Twilio drops it (the chat-identity participant alone covers
-  // the web-side, not SMS). Fail-soft: if Twilio rejects the binding
-  // (bad phone format, cross-border 10DLC block, etc.) we log and
-  // proceed; the chat still works on the web side and the invite SMS
-  // still gets delivered separately by `trySms` below.
+  // the web-side, not SMS). Twilio enforces uniqueness on
+  // (phone, proxy) pairs across all active conversations, so we free
+  // any existing binding for this phone first — handles family-shared
+  // phones, repeated test invites, and any stale state from prior
+  // errors. Fail-soft: if Twilio rejects after the cleanup (bad phone
+  // format, cross-border block, etc.) we log and proceed; the
+  // chat-identity participant still covers the web side and the invite
+  // SMS still gets delivered separately by `trySms` below.
   if (input.speakerPhone) {
+    const proxyAddress = resolveFromNumber(fromNumberMode);
     try {
-      await addSmsParticipant(
-        conversationSid,
-        input.speakerPhone,
-        resolveFromNumber(fromNumberMode),
-      );
+      await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
+      await addSmsParticipant(conversationSid, input.speakerPhone, proxyAddress);
     } catch (err) {
       logger.warn("failed to add SMS participant — chat will work web-only", {
         speakerId: input.speakerId,

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -1,8 +1,7 @@
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import {
-  addChatParticipant,
-  addSmsParticipant,
+  addSpeakerParticipant,
   createConversation,
   freePhoneBindingConflicts,
 } from "./twilio/conversations.js";
@@ -99,32 +98,51 @@ export async function createFreshInvitation(
     createdAt: FieldValue.serverTimestamp(),
   });
 
-  await addChatParticipant(conversationSid, `speaker:${docRef.id}`, {
-    displayName: input.speakerName,
-    role: "speaker",
-  });
-
-  // Bind the speaker's phone for SMS-to-Conversation bridging — without
-  // this, a speaker's SMS reply has no participant binding to match
-  // and Twilio drops it (the chat-identity participant alone covers
-  // the web-side, not SMS). Twilio enforces uniqueness on
-  // (phone, proxy) pairs across all active conversations, so we free
-  // any existing binding for this phone first — handles family-shared
-  // phones, repeated test invites, and any stale state from prior
-  // errors. Fail-soft: if Twilio rejects after the cleanup (bad phone
-  // format, cross-border block, etc.) we log and proceed; the
-  // chat-identity participant still covers the web side and the invite
-  // SMS still gets delivered separately by `trySms` below.
-  if (input.speakerPhone) {
-    const proxyAddress = resolveFromNumber(fromNumberMode);
+  // Add the speaker as a single participant carrying BOTH the chat
+  // identity AND (when phone on file) the SMS messagingBinding.
+  // Two-participant setups echo the speaker's web-side answer back
+  // to their own phone via SMS — Twilio can't tell the chat-identity
+  // participant and the SMS-binding participant are the same human,
+  // so it broadcasts to all bindings. Combining them on one
+  // participant lets Twilio de-dup automatically.
+  //
+  // Twilio enforces uniqueness on (phone, proxyAddress) across all
+  // active conversations, so free any existing binding for this
+  // phone first. Fail-soft: if the create itself fails (bad phone
+  // format, cross-border 10DLC block, etc.), log and continue with
+  // a chat-only participant — invite SMS still delivers separately
+  // via `trySms` below.
+  const proxyAddress = input.speakerPhone ? resolveFromNumber(fromNumberMode) : undefined;
+  if (input.speakerPhone && proxyAddress) {
+    await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
+  }
+  try {
+    await addSpeakerParticipant(
+      conversationSid,
+      `speaker:${docRef.id}`,
+      { displayName: input.speakerName, role: "speaker" },
+      input.speakerPhone && proxyAddress
+        ? { speakerPhoneE164: input.speakerPhone, twilioFromNumber: proxyAddress }
+        : undefined,
+    );
+  } catch (err) {
+    logger.warn("failed to add speaker participant with SMS binding — falling back to chat-only", {
+      speakerId: input.speakerId,
+      meetingDate: input.meetingDate,
+      err: (err as Error).message,
+    });
+    // Fallback: at least make the chat side work so the bishop UI
+    // can see the speaker's identity if anything else fires.
     try {
-      await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
-      await addSmsParticipant(conversationSid, input.speakerPhone, proxyAddress);
-    } catch (err) {
-      logger.warn("failed to add SMS participant — chat will work web-only", {
+      await addSpeakerParticipant(conversationSid, `speaker:${docRef.id}`, {
+        displayName: input.speakerName,
+        role: "speaker",
+      });
+    } catch (chatErr) {
+      logger.warn("chat-only fallback also failed", {
         speakerId: input.speakerId,
         meetingDate: input.meetingDate,
-        err: (err as Error).message,
+        err: (chatErr as Error).message,
       });
     }
   }

--- a/functions/src/invitationDelivery.ts
+++ b/functions/src/invitationDelivery.ts
@@ -56,7 +56,12 @@ export async function tryEmail(
       wardName: args.wardName,
       inviterName: args.inviterName,
       inviteUrl: args.inviteUrl,
-      ...(args.topic ? { topic: args.topic } : {}),
+      // Speaker template references `{{topic}}`; coerce to the
+      // project's standard "Topic of Choice" fallback (matches the
+      // schedule + program-editor surfaces from v0.19.0) when the
+      // speaker hasn't been assigned a specific topic. Harmless for
+      // prayer emails — their template doesn't reference `{{topic}}`.
+      topic: args.topic ?? "Topic of Choice",
       ...(args.prayerType ? { prayerType: args.prayerType } : {}),
     };
     const messageId = await sendEmail({
@@ -78,13 +83,26 @@ export async function tryEmail(
 
 async function buildInitialInvitationSms(
   wardId: string,
-  vars: Pick<EmailArgs, "inviterName" | "wardName" | "assignedDate" | "inviteUrl"> & {
+  vars: Pick<
+    EmailArgs,
+    "speakerName" | "inviterName" | "wardName" | "assignedDate" | "inviteUrl"
+  > & {
     prayerType?: string;
+    topic?: string;
   },
 ): Promise<string> {
   const key = vars.prayerType ? "prayerInitialInvitationSms" : "initialInvitationSms";
   const template = await readMessageTemplate(getFirestore(), wardId, key);
-  return interpolate(template, vars);
+  // Speaker SMS template references `{{topic}}`; coerce to the
+  // project's standard "Topic of Choice" fallback so the rendered
+  // SMS reads naturally when the speaker has no specific topic. The
+  // prayer SMS template doesn't reference `{{topic}}`, so the
+  // fallback value is unused on that path.
+  const interpolationVars = {
+    ...vars,
+    topic: vars.topic ?? "Topic of Choice",
+  };
+  return interpolate(template, interpolationVars);
 }
 
 export async function trySms(
@@ -118,6 +136,11 @@ export async function sendInvitationSms(args: {
   assignedDate: string;
   speakerName: string;
   inviteUrl: string;
+  /** Speaker's assigned topic — interpolated into `{{topic}}` in the
+   *  speaker SMS template. Optional: when unset, `buildInitialInvitationSms`
+   *  applies the project's "Topic of Choice" fallback. Unused on the
+   *  prayer SMS template path (which doesn't reference `{{topic}}`). */
+  topic?: string;
   fromMode?: FromNumberMode;
 }): Promise<{ providerId: string }> {
   const body = await buildInitialInvitationSms(args.wardId, args);

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,73 +1,12 @@
-import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
-import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
 import { interpolate, readMessageTemplate } from "./messageTemplates.js";
-import { STEWARD_ORIGIN } from "./secrets.js";
-import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
 import { sendEmail } from "./sendgrid/client.js";
-import { sendSmsDirect } from "./twilio/messaging.js";
+import { getFirestore } from "firebase-admin/firestore";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ResolvedInvitation extends SpeakerInvitationShape {
   wardId: string;
   token: string;
-}
-
-/** Max age of the speaker's `speakerLastSeenAt` heartbeat before we
- *  treat the chat as "closed". The invite page pings every 60s while
- *  the tab is visible; 2× that cadence gives one missed ping of slack
- *  before we fall back to SMS. */
-const HEARTBEAT_FRESH_MS = 120_000;
-
-/** Bishop posted → SMS the speaker with a fresh resume link (unless
- *  the speaker's heartbeat shows they're actively viewing the chat).
- *  Rotates the invitation's capability token (bishop-initiated, so it
- *  does NOT count against `tokenRotationsByDay`) and appends the fresh
- *  URL — the speaker can tap it to re-enter the chat with prior
- *  messages preserved (same conversationSid). No-op when the invitation
- *  has no phone on file. */
-export async function smsSpeaker(inv: ResolvedInvitation, body: string): Promise<void> {
-  if (!inv.speakerPhone) return;
-  if (isSpeakerOnline(inv)) return;
-  let inviteUrl: string | null = null;
-  try {
-    const rotated = await rotateTokenForBishopNotification(inv.wardId, inv.token);
-    if (rotated) {
-      const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
-      inviteUrl = buildInviteUrl(origin, inv.wardId, inv.token, rotated.newToken);
-    }
-  } catch (err) {
-    logger.warn("reply SMS token rotation failed — falling back to preview-only", {
-      token: inv.token,
-      err: (err as Error).message,
-    });
-  }
-  const preview = truncate(body, 240);
-  // Rotation-failed path stays hardcoded: it's an error fallback, not
-  // a user-authored message — we don't want a bishopric-edited template
-  // to leak a placeholder `{{inviteUrl}}` token into an SMS.
-  let text: string;
-  if (inviteUrl) {
-    const template = await readMessageTemplate(getFirestore(), inv.wardId, "bishopReplySms");
-    text = interpolate(template, { wardName: inv.wardName, preview, inviteUrl });
-  } else {
-    text = `${inv.inviterName} (Steward): ${preview}`;
-  }
-  try {
-    await sendSmsDirect({
-      to: inv.speakerPhone,
-      body: text,
-      ...(inv.fromNumberMode ? { fromMode: inv.fromNumberMode } : {}),
-    });
-  } catch (err) {
-    logger.error("reply SMS failed", { err: (err as Error).message, token: inv.token });
-  }
-}
-
-function isSpeakerOnline(inv: ResolvedInvitation): boolean {
-  const ts = inv.speakerLastSeenAt;
-  if (!ts) return false;
-  return Date.now() - ts.toMillis() < HEARTBEAT_FRESH_MS;
 }
 
 /** Bishop posted → SendGrid email to the speaker with a preview.

--- a/functions/src/issueSpeakerSession.helpers.ts
+++ b/functions/src/issueSpeakerSession.helpers.ts
@@ -17,6 +17,7 @@ export type TokenDecision =
       newToken: string;
       speakerPhone: string | undefined;
       speakerName: string;
+      speakerTopic: string | undefined;
       inviterName: string;
       wardName: string;
       assignedDate: string;
@@ -72,6 +73,7 @@ export async function decideTokenAction(
       newToken,
       speakerPhone: data.speakerPhone,
       speakerName: data.speakerName,
+      speakerTopic: data.speakerTopic,
       inviterName: data.inviterName,
       wardName: data.wardName,
       assignedDate: data.assignedDate,

--- a/functions/src/issueSpeakerSession.ts
+++ b/functions/src/issueSpeakerSession.ts
@@ -127,6 +127,7 @@ async function handleSpeakerTokenExchange(
         assignedDate: decision.assignedDate,
         speakerName: decision.speakerName,
         inviteUrl: buildInviteUrl(origin, wardId, invitationId, decision.newToken),
+        ...(decision.speakerTopic ? { topic: decision.speakerTopic } : {}),
         ...(decision.fromNumberMode ? { fromMode: decision.fromNumberMode } : {}),
       });
     } catch (err) {

--- a/functions/src/messageTemplateDefaults.ts
+++ b/functions/src/messageTemplateDefaults.ts
@@ -12,9 +12,13 @@
  * `messageTemplates.ts`.
  */
 
-export const DEFAULT_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to speak on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to speak on {{assignedDate}}. Topic: {{topic}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 export const DEFAULT_SPEAKER_RESPONSE_ACCEPTED =
   "You accepted the invitation to speak on {{assignedDate}}. Thank you.";
@@ -38,9 +42,13 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
   "— {{wardName}}",
 ].join("\n");
 
-export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to give the {{prayerType}} on {{assignedDate}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =
   "You accepted the invitation to give the {{prayerType}} on {{assignedDate}}. Thank you.";

--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -1,7 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { onRequest, type Request } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
-import { emailSpeaker, smsSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
+import { emailSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
 import { pushToBishopric } from "./invitationReplyPush.js";
 import {
   TWILIO_ACCOUNT_SID,
@@ -72,12 +72,15 @@ export const onTwilioWebhook = onRequest(
       await pushToBishopric(invitation, body);
     } else if (author.startsWith("uid:")) {
       const senderBishopUid = author.slice("uid:".length);
-      // All three run in parallel. SMS is the primary channel for the
-      // speaker, email is best-effort (no-ops when SendGrid isn't
-      // wired), and the bishop-to-bishop push keeps peer bishopric
-      // members in the loop without re-notifying the sender.
+      // No `smsSpeaker` here: Twilio Conversations natively
+      // broadcasts the bishop's message to the speaker's SMS-bound
+      // participant. The previous wrapped notification SMS (with a
+      // freshly-rotated invite URL) was a duplicate of that native
+      // broadcast — speakers were getting both bubbles for the same
+      // bishop reply. Email + the bishop-to-bishop FCM push still
+      // run in parallel so peers see each other's chat activity even
+      // when not actively viewing the thread.
       await Promise.all([
-        smsSpeaker(invitation, body),
         emailSpeaker(invitation, body),
         pushToBishopric(invitation, body, { senderBishopUid }),
       ]);

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -19,7 +19,9 @@ export async function assertActiveMember(wardId: string, uid: string): Promise<v
 /** Frees the speaker's phone binding from any earlier Twilio
  *  Conversation for this (wardId, speakerId, meetingDate). Twilio
  *  refuses to bind the same (phone, proxy) pair twice, so a re-send
- *  for the same speaker would otherwise fail at addSmsParticipant. */
+ *  for the same speaker would otherwise fail at the participant
+ *  create call. (Cross-speaker phone conflicts are handled by
+ *  `freePhoneBindingConflicts` at participant-create time.) */
 export interface BishopricSnapshot {
   uid: string;
   displayName: string;

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -83,6 +83,48 @@ export async function addSmsParticipant(
   return p.sid;
 }
 
+/** Frees the speaker phone's existing SMS binding(s) on this
+ *  Conversations service before a new conversation tries to claim it.
+ *  Twilio enforces uniqueness on (address, proxyAddress) pairs across
+ *  all active conversations — without this cleanup, the second
+ *  `addSmsParticipant` call for the same phone fails and inbound SMS
+ *  routes to whichever conversation already owns the binding (often
+ *  not the most recent one).
+ *
+ *  Real-world cases this catches:
+ *  - Family-shared phone: the bishop sent invite to spouse A, then to
+ *    spouse B. Most-recent-invite wins for SMS routing on that phone.
+ *  - Test/staging churn: repeated invites to the same phone with
+ *    different speakerIds (so `cleanupPriorConversations` doesn't
+ *    catch them via its speakerId+meetingDate filter).
+ *  - Stale state: any conversation orphaned by an earlier deploy
+ *    error or manual cleanup that left bindings behind.
+ *
+ *  Removes only the SMS participant, not the whole conversation —
+ *  the prior chat history (web side, bishopric identities) survives
+ *  and remains viewable by the bishop. */
+export async function freePhoneBindingConflicts(
+  speakerPhoneE164: string,
+  twilioFromNumber: string,
+): Promise<void> {
+  const svc = service();
+  const conflicts = await svc.participantConversations.list({ address: speakerPhoneE164 });
+  for (const c of conflicts) {
+    const binding = c.participantMessagingBinding as
+      | { address?: string; proxy_address?: string; type?: string }
+      | undefined;
+    if (
+      binding?.type !== "sms" ||
+      binding.address !== speakerPhoneE164 ||
+      binding.proxy_address !== twilioFromNumber
+    ) {
+      continue;
+    }
+    if (!c.conversationSid || !c.participantSid) continue;
+    await svc.conversations(c.conversationSid).participants(c.participantSid).remove();
+  }
+}
+
 export interface PostMessageInput {
   conversationSid: string;
   author: string;

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -67,19 +67,46 @@ export async function ensureChatParticipant(
   }
 }
 
-/** Speaker-side SMS participant. Twilio bridges messages in this
- *  conversation to/from the speaker's phone automatically. Returns
- *  the participant SID; throws if Twilio rejects (bad phone format,
- *  cross-border 10DLC block, etc.). */
-export async function addSmsParticipant(
+/** Speaker-side participant carrying BOTH a chat identity AND (when
+ *  the speaker has a phone on file) an SMS messagingBinding on a
+ *  single Twilio Conversations participant.
+ *
+ *  Why both on one participant: Twilio Conversations broadcasts every
+ *  message to all participants with delivery channels. With the
+ *  chat-identity and SMS binding split across two participants, a
+ *  message authored by the chat-identity participant gets broadcast
+ *  to the SMS-only participant — Twilio can't tell they're the same
+ *  human, and the speaker receives their own web-side answer back as
+ *  SMS (the "Yes, I can speak." echo). Combining identity + binding
+ *  on one participant makes the de-dup automatic: Twilio knows the
+ *  sender and the binding belong to the same participant and won't
+ *  fan back to that channel.
+ *
+ *  Bonus side effect: the binding now carries the speaker's display
+ *  name + role attributes, so the bishop's chat UI no longer renders
+ *  SMS-originated messages as "Unknown".
+ *
+ *  Pass `smsBinding: undefined` for speakers with no phone on file —
+ *  the participant is created chat-only, identical to bishopric
+ *  participants. */
+export async function addSpeakerParticipant(
   conversationSid: string,
-  speakerPhoneE164: string,
-  twilioFromNumber: string,
+  identity: string,
+  attributes: {
+    displayName: string;
+    role: "speaker";
+  },
+  smsBinding?: { speakerPhoneE164: string; twilioFromNumber: string },
 ): Promise<string> {
-  const p = await service().conversations(conversationSid).participants.create({
-    "messagingBinding.address": speakerPhoneE164,
-    "messagingBinding.proxyAddress": twilioFromNumber,
-  });
+  const params: Record<string, string> = {
+    identity,
+    attributes: JSON.stringify(attributes),
+  };
+  if (smsBinding) {
+    params["messagingBinding.address"] = smsBinding.speakerPhoneE164;
+    params["messagingBinding.proxyAddress"] = smsBinding.twilioFromNumber;
+  }
+  const p = await service().conversations(conversationSid).participants.create(params);
   return p.sid;
 }
 
@@ -87,9 +114,9 @@ export async function addSmsParticipant(
  *  Conversations service before a new conversation tries to claim it.
  *  Twilio enforces uniqueness on (address, proxyAddress) pairs across
  *  all active conversations — without this cleanup, the second
- *  `addSmsParticipant` call for the same phone fails and inbound SMS
- *  routes to whichever conversation already owns the binding (often
- *  not the most recent one).
+ *  `addSpeakerParticipant` call for the same phone fails and inbound
+ *  SMS routes to whichever conversation already owns the binding
+ *  (often not the most recent one).
  *
  *  Real-world cases this catches:
  *  - Family-shared phone: the bishop sent invite to spouse A, then to
@@ -100,9 +127,11 @@ export async function addSmsParticipant(
  *  - Stale state: any conversation orphaned by an earlier deploy
  *    error or manual cleanup that left bindings behind.
  *
- *  Removes only the SMS participant, not the whole conversation —
- *  the prior chat history (web side, bishopric identities) survives
- *  and remains viewable by the bishop. */
+ *  Removes the matching SMS-bound participant entirely (today that's
+ *  the speaker's combined chat-identity + SMS-binding participant
+ *  per `addSpeakerParticipant`). The prior chat history survives
+ *  conversation-side; only that participant's attribution on past
+ *  messages is freed. */
 export async function freePhoneBindingConflicts(
   speakerPhoneE164: string,
   twilioFromNumber: string,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/features/templates/utils/prayerEmailDefaults.ts
+++ b/src/features/templates/utils/prayerEmailDefaults.ts
@@ -12,7 +12,9 @@
 
 export const DEFAULT_PRAYER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}. The full invitation letter is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to give the {{prayerType}} in sacrament meeting on {{date}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 

--- a/src/features/templates/utils/serverTemplateDefaults.ts
+++ b/src/features/templates/utils/serverTemplateDefaults.ts
@@ -14,9 +14,13 @@ import type { MessageTemplateKey } from "@/lib/types";
  */
 
 /** Twilio SMS body sent when a bishop first invites a speaker. */
-export const DEFAULT_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to speak on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to speak on {{assignedDate}}. Topic: {{topic}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 /** Narrative header of the SendGrid email the speaker receives when
  *  they submit Yes on the invitation page. The letter excerpt and
@@ -59,9 +63,13 @@ export const DEFAULT_BISHOP_REPLY_EMAIL = [
  *  Mirrors the speaker-side wording with prayer phrasing in place of
  *  "speak". `{{prayerType}}` resolves to "opening prayer" or
  *  "closing prayer" per the prayer participant's role. */
-export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS =
-  "{{inviterName}} ({{wardName}}) has invited you to give the {{prayerType}} on {{assignedDate}}. " +
-  "Read the full invitation: {{inviteUrl}}. Reply STOP to unsubscribe.";
+export const DEFAULT_PRAYER_INITIAL_INVITATION_SMS = [
+  "Hi {{speakerName}} — {{inviterName}} ({{wardName}}) invites you to give the {{prayerType}} on {{assignedDate}}.",
+  "",
+  "Tap to read the full letter and reply via chat (richer than SMS, and the bishopric prefers to keep the conversation in one place): {{inviteUrl}}",
+  "",
+  "Reply STOP to opt out.",
+].join("\n");
 
 /** Speaker-side acceptance receipt for prayer invitations. */
 export const DEFAULT_PRAYER_RESPONSE_ACCEPTED =

--- a/src/features/templates/utils/speakerEmailDefaults.ts
+++ b/src/features/templates/utils/speakerEmailDefaults.ts
@@ -11,7 +11,9 @@
 
 export const DEFAULT_SPEAKER_EMAIL_BODY = `Dear {{speakerName}},
 
-We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. The full invitation letter — including our suggested topic and length — is at the link below. Please let a member of the bishopric know if this Sunday works for you, or if you would prefer a different date.
+We have prayerfully considered the needs of our ward and feel inspired to invite you to speak in sacrament meeting on {{date}}. Suggested topic: {{topic}}.
+
+The full invitation letter is at the link below. Please use the chat on that page to reply directly to the bishopric — it keeps everything in one thread and is the most reliable way for us to follow up.
 
 {{inviteUrl}}
 


### PR DESCRIPTION
## Summary

Same-day follow-up to v0.20.0. Restores SMS bridging that broke under prod retesting after PR #217 (the `addSmsParticipant` wire-in), and refreshes the invitation copy to address recipients by name + lead them into the in-app chat.

Full release notes: [CHANGELOG.md § 0.20.1](CHANGELOG.md).

## What's in this release

| PR | Type | Headline |
|---|---|---|
| #221 | fix + feat | Free stale SMS bindings before adding new ones; personalise SMS + email templates |
| #223 | fix | Combine speaker chat-identity + SMS binding on one participant; drop redundant `smsSpeaker` |

## Operator runbook (post-deploy)

After `release.yml` finishes deploying functions, switch the active outbound number from \`+15873184624\` (ending 24) to \`+12295473216\` (ending 16):

\`\`\`bash
firebase functions:secrets:set TWILIO_FROM_NUMBER --project steward-prod-65a36
# Paste: +12295473216
firebase deploy --only functions --project steward-prod-65a36
\`\`\`

Releasing the +24 number from Twilio Console (to stop the monthly fee) is a separate manual step.

## Test plan

- [ ] Watch \`release.yml\` on main: tag \`v0.20.1\`, GitHub Release, Firestore + Cloud Functions deploy to \`steward-prod-65a36\`.
- [ ] Apply operator runbook above (swap to +16 number).
- [ ] Send fresh test invite to a phone you control. Verify:
  - SMS comes from \`+1...3216\` and reads "Hi [Name] — ... Topic: [Topic]." with chat-first CTA
  - Tap link, submit Yes — **no** "Yes, I can speak." echo back to phone
  - Bishop replies in chat — **one** SMS arrives on speaker phone (not two)
  - Bishop chat shows speaker name (not "Unknown") on SMS-originated messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)