### PR TITLE
fix(invitations): server-side SMS relay + remove echo (#226 + #227)

### DIFF
--- a/docs/invitation-flow.md
+++ b/docs/invitation-flow.md
@@ -76,7 +76,8 @@ sequenceDiagram
     rect rgb(245,255,245)
     Note over Bishop,SG: Phase 2 — Send invitation
     Bishop->>Fn: sendSpeakerInvitation { mode: "fresh", channels }
-    Fn->>Twilio: Create Conversation, add bishopric + speaker
+    Fn->>Twilio: Create Conversation, add bishopric + speaker chat-identity
+    Note right of Twilio: Speaker is added as chat-identity ONLY<br/>(speaker:{id}). No SMS-only participant —<br/>inbound SMS is relayed server-side instead<br/>(see Phase 4). Avoids Twilio's chat→SMS<br/>auto-broadcast echo and duplicate bishop-<br/>reply SMS. (#227)
     Fn->>Fn: Generate token, hash it (SHA-256)
     Fn->>FS: Write speakerInvitations/{id}<br/>{ tokenHash, conversationSid, letter snapshot }
     Fn->>FS: Stamp participant: status="invited"
@@ -111,11 +112,18 @@ sequenceDiagram
     Note over SpkWeb,FCM: Phase 4 — Speaker responds
     alt Yes / No on web page
         SpkWeb->>FS: Write response { answer, reason, respondedAt }
+        SpkWeb->>Twilio: Conversation message (speaker:{id})
+        Twilio->>Fn: onTwilioWebhook (onMessageAdded)
+        Fn->>FCM: Push to bishopric
     else SMS reply
         SpkPhone->>Twilio: Reply SMS
-        Twilio->>Fn: onTwilioWebhook (Conversations event)
-        Fn->>FCM: Push to bishopric: "{name} replied"
-    else Web chat message
+        Twilio->>Fn: onTwilioWebhook (Programmable Messaging inbound)
+        Fn->>FS: Lookup active invitation by speakerPhone
+        Fn->>Twilio: postMessage as speaker:{id} into the conversation
+        Twilio->>Fn: onTwilioWebhook (onMessageAdded — same fn, second hit)
+        Fn->>FCM: Push to bishopric
+        Note right of Fn: Single endpoint dispatches on payload<br/>shape — Programmable Messaging inbound<br/>(MessageSid + From) vs Conversations<br/>onMessageAdded (EventType). See<br/>twilio/inboundSmsRelay.ts.
+    else Web chat message (free-form)
         SpkWeb->>Twilio: Conversation message
         Twilio->>Fn: onTwilioWebhook
         Fn->>FCM: Push to bishopric
@@ -125,10 +133,16 @@ sequenceDiagram
     rect rgb(248,240,255)
     Note over FS,SG: Phase 5 — Receipt + notify (Yes/No path)
     FS->>Fn: onInvitationWrite (response set)
-    Fn->>SG: Speaker receipt email (Yes/No template, CC bishopric)
-    SG->>SpkEmail: Receipt: "We have your Yes/No on file"
-    Fn->>FCM: Push: "{name} accepted/declined"
-    FCM->>Bishop: Notification
+    par Speaker email
+        Fn->>SG: Speaker receipt email (Yes/No template, CC bishopric)
+        SG->>SpkEmail: Receipt: "We have your Yes/No on file"
+    and Speaker SMS
+        Fn->>Twilio: sendSmsDirect (speakerResponse{Accepted,Declined}Sms template)
+        Twilio->>SpkPhone: Receipt SMS: "we've recorded your response"
+    and Bishopric notify
+        Fn->>FCM: Push: "{name} accepted/declined"
+        FCM->>Bishop: Notification
+    end
     end
 
     rect rgb(240,255,255)
@@ -142,18 +156,20 @@ sequenceDiagram
     rect rgb(255,255,235)
     Note over Bishop,SpkPhone: Phase 7 — Bishop replies in chat (later)
     Bishop->>Twilio: Conversation message
-    Twilio->>Fn: onTwilioWebhook
-    par Notify speaker
+    Twilio->>Fn: onTwilioWebhook (uid:{bishopUid})
+    par Notify speaker via SMS
         Fn->>Fn: Check speaker heartbeat (online?)
         alt offline (>120s)
             Fn->>Fn: Rotate token (no daily cap)
-            Fn->>Twilio: SMS w/ fresh invite URL
+            Fn->>Twilio: sendSmsDirect w/ fresh invite URL
             Twilio->>SpkPhone: SMS: bishop replied
-            Fn->>SG: Email: bishop replied
-            SG->>SpkEmail: Inbox
         else online
             Note over Fn: Skip SMS — speaker is reading chat live
         end
+        Note right of Fn: Server-driven via smsSpeaker — there's no<br/>SMS-only Conversations participant for the<br/>speaker, so Twilio's auto-broadcast doesn't<br/>fire. Single SMS, no duplicate. (#227)
+    and Notify speaker via email
+        Fn->>SG: Email: bishop replied
+        SG->>SpkEmail: Inbox
     and Notify other bishopric
         Fn->>FCM: Push to other active bishopric
     end
@@ -176,7 +192,8 @@ sequenceDiagram
 | Token exchange | [functions/src/issueSpeakerSession.ts](../functions/src/issueSpeakerSession.ts) |
 | Speaker writes Yes/No, bishop applies | [src/features/invitations/utils/invitationActions.ts](../src/features/invitations/utils/invitationActions.ts) |
 | Receipt emails + response push | [functions/src/onInvitationWrite.ts](../functions/src/onInvitationWrite.ts), [functions/src/invitationResponseNotify.ts](../functions/src/invitationResponseNotify.ts) |
-| Twilio reply webhook | [functions/src/onTwilioWebhook.ts](../functions/src/onTwilioWebhook.ts) |
+| Twilio reply webhook (Conversations + Messaging) | [functions/src/onTwilioWebhook.ts](../functions/src/onTwilioWebhook.ts) |
+| Inbound SMS → chat relay | [functions/src/twilio/inboundSmsRelay.ts](../functions/src/twilio/inboundSmsRelay.ts) |
 
 ---
 
@@ -188,5 +205,6 @@ The diagrams omit a few branches that exist in the code but would clutter the pi
 - **Per-template variable interpolation** (`{{speakerName}}`, `{{topic}}`, `{{wardName}}`, …) — handled by `messageTemplates.ts` in `functions/src/`.
 - **Speaker vs prayer template keys** — every notification lookup branches on `kind` to pick the right template (e.g. `speakerResponseAccepted` vs `prayerResponseAccepted`). Parity was finished in commit `8660a98`.
 - **Twilio Conversation cleanup on re-send** — `freshInvitation.ts` deletes any prior Conversation for the same (ward, speaker, meeting) before creating a new one.
+- **Why the speaker has no SMS-only Conversations participant** — Twilio's chat → SMS auto-broadcast would echo the speaker's web-side replies back to their own phone, and double-up on bishop chat replies (since `smsSpeaker` already drives outbound server-side). The relay model avoids both. The proper Twilio fix (`MessagingBinding.ProjectedAddress`) is gated by account authorization (error 50439); revisit if/when granted. See #227.
 - **Token rate-limit response** — when a speaker burns through the 3/day rotation cap, `issueSpeakerSession` returns `{ status: "rate-limited" }` and the invite page tells them to contact the bishopric.
 - **iOS WebView `mintWebSession` branch** — `issueSpeakerSession` mints an extra session shape when called with `mintWebSession: true` from the iOS app.

--- a/docs/invitation-flow.md
+++ b/docs/invitation-flow.md
@@ -142,13 +142,19 @@ sequenceDiagram
     rect rgb(255,255,235)
     Note over Bishop,SpkPhone: Phase 7 — Bishop replies in chat (later)
     Bishop->>Twilio: Conversation message
-    par Native SMS bridge
-        Twilio->>SpkPhone: SMS to speaker's bound number
-        Note over Twilio,SpkPhone: Twilio Conversations broadcasts the<br/>chat message to the speaker's<br/>SMS-bound participant — single<br/>combined participant suppresses<br/>echo back to web sender
-    and Webhook fans out
-        Twilio->>Fn: onTwilioWebhook
-        Fn->>SG: Email: bishop replied
-        SG->>SpkEmail: Inbox
+    Twilio->>Fn: onTwilioWebhook
+    par Notify speaker
+        Fn->>Fn: Check speaker heartbeat (online?)
+        alt offline (>120s)
+            Fn->>Fn: Rotate token (no daily cap)
+            Fn->>Twilio: SMS w/ fresh invite URL
+            Twilio->>SpkPhone: SMS: bishop replied
+            Fn->>SG: Email: bishop replied
+            SG->>SpkEmail: Inbox
+        else online
+            Note over Fn: Skip SMS — speaker is reading chat live
+        end
+    and Notify other bishopric
         Fn->>FCM: Push to other active bishopric
     end
     end
@@ -179,7 +185,6 @@ sequenceDiagram
 The diagrams omit a few branches that exist in the code but would clutter the picture. Pointers for when you need them:
 
 - **Quiet hours / timezone filtering on FCM pushes** — applied per-recipient inside `notifyBishopricOfResponse` and the reply-push helpers.
-- **Single combined speaker participant** — the speaker's chat identity and SMS messagingBinding live on a single Twilio Conversations participant (not two separate ones). Twilio uses this to suppress echoes back to the web-side sender when the speaker submits a Yes/No from the invite page.
 - **Per-template variable interpolation** (`{{speakerName}}`, `{{topic}}`, `{{wardName}}`, …) — handled by `messageTemplates.ts` in `functions/src/`.
 - **Speaker vs prayer template keys** — every notification lookup branches on `kind` to pick the right template (e.g. `speakerResponseAccepted` vs `prayerResponseAccepted`). Parity was finished in commit `8660a98`.
 - **Twilio Conversation cleanup on re-send** — `freshInvitation.ts` deletes any prior Conversation for the same (ward, speaker, meeting) before creating a new one.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -7,6 +7,14 @@
         { "fieldPath": "email", "order": "ASCENDING" },
         { "fieldPath": "active", "order": "ASCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "speakerInvitations",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "speakerPhone", "order": "ASCENDING" },
+        { "fieldPath": "tokenStatus", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": [

--- a/functions/package.json
+++ b/functions/package.json
@@ -13,7 +13,8 @@
     "lint": "oxlint",
     "test": "vitest run",
     "deploy": "firebase deploy --only functions",
-    "configure-conversation-roles": "tsx scripts/configure-conversation-roles.ts"
+    "configure-conversation-roles": "tsx scripts/configure-conversation-roles.ts",
+    "sweep-sms-only-participants": "tsx scripts/sweep-sms-only-participants.ts"
   },
   "dependencies": {
     "@sendgrid/mail": "^8.1.6",

--- a/functions/scripts/sweep-sms-only-participants.ts
+++ b/functions/scripts/sweep-sms-only-participants.ts
@@ -61,7 +61,12 @@ async function main(): Promise<void> {
     `Service ${serviceSid}: scanning ${conversations.length} conversation(s) for SMS-only participants...`,
   );
 
-  const targets: { conversationSid: string; conversationName: string; participantSid: string; address: string }[] = [];
+  const targets: {
+    conversationSid: string;
+    conversationName: string;
+    participantSid: string;
+    address: string;
+  }[] = [];
   for (const c of conversations) {
     const participants = (await service
       .conversations(c.sid)

--- a/functions/scripts/sweep-sms-only-participants.ts
+++ b/functions/scripts/sweep-sms-only-participants.ts
@@ -1,0 +1,116 @@
+import twilio from "twilio";
+
+/** One-time admin script: removes every SMS-only Conversations
+ *  participant in the configured Conversations service.
+ *
+ *  Why this exists: from v0.20.2 forward we no longer add an SMS-only
+ *  participant for the speaker's phone (#227). Inbound speaker SMS is
+ *  relayed server-side (twilio/inboundSmsRelay.ts) into the active
+ *  invitation's conversation, authored as `speaker:{invitationId}`.
+ *
+ *  Older invitations created on prior code paths still have SMS-only
+ *  participants attached — Twilio's auto-bridge keeps routing inbound
+ *  to those conversations *in addition to* the new MS inboundRequestUrl
+ *  → relay path, so the bishop sees double messages in two different
+ *  chatboxes (one per active invitation that shares the speaker phone).
+ *
+ *  Definition of an "SMS-only participant" for this sweep: any
+ *  participant whose `messagingBinding` is non-null AND whose
+ *  `identity` is null. Combined-binding participants (identity +
+ *  binding) shouldn't exist on this account anyway — Twilio rejects
+ *  them with error "Participants on SMS, WhatsApp or other non-chat
+ *  channels cannot have Identities" — but the filter is defensive.
+ *
+ *  Idempotent: a second run finds nothing to remove.
+ *
+ *  Run from the functions workspace:
+ *    TWILIO_ACCOUNT_SID=AC... \
+ *    TWILIO_AUTH_TOKEN=... \
+ *    TWILIO_CONVERSATIONS_SERVICE_SID=IS... \
+ *    pnpm --filter @steward/functions tsx scripts/sweep-sms-only-participants.ts
+ *
+ *  Dry-run by default. Pass `--commit` to actually remove. */
+
+interface ConversationLike {
+  sid: string;
+  friendlyName?: string | null;
+}
+
+interface ParticipantLike {
+  sid: string;
+  identity?: string | null;
+  messagingBinding?: { address?: string | null; proxy_address?: string | null } | null;
+}
+
+async function main(): Promise<void> {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID;
+  const authToken = process.env.TWILIO_AUTH_TOKEN;
+  const serviceSid = process.env.TWILIO_CONVERSATIONS_SERVICE_SID;
+  if (!accountSid || !authToken || !serviceSid) {
+    throw new Error(
+      "Missing env: TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_CONVERSATIONS_SERVICE_SID all required.",
+    );
+  }
+  const commit = process.argv.includes("--commit");
+
+  const client = twilio(accountSid, authToken);
+  const service = client.conversations.v1.services(serviceSid);
+
+  const conversations = (await service.conversations.list()) as unknown as ConversationLike[];
+  console.log(
+    `Service ${serviceSid}: scanning ${conversations.length} conversation(s) for SMS-only participants...`,
+  );
+
+  const targets: { conversationSid: string; conversationName: string; participantSid: string; address: string }[] = [];
+  for (const c of conversations) {
+    const participants = (await service
+      .conversations(c.sid)
+      .participants.list()) as unknown as ParticipantLike[];
+    for (const p of participants) {
+      if (p.identity) continue;
+      if (!p.messagingBinding?.address) continue;
+      targets.push({
+        conversationSid: c.sid,
+        conversationName: c.friendlyName ?? "(no name)",
+        participantSid: p.sid,
+        address: p.messagingBinding.address,
+      });
+    }
+  }
+
+  if (targets.length === 0) {
+    console.log("No SMS-only participants found. Nothing to do.");
+    return;
+  }
+
+  console.log(`\nFound ${targets.length} SMS-only participant(s):`);
+  for (const t of targets) {
+    console.log(
+      `  - ${t.participantSid}  conversation=${t.conversationSid} (${t.conversationName})  address=${t.address}`,
+    );
+  }
+
+  if (!commit) {
+    console.log("\nDry-run only. Re-run with --commit to remove the participant(s) above.");
+    return;
+  }
+
+  console.log(`\nRemoving ${targets.length} participant(s)...`);
+  let removed = 0;
+  for (const t of targets) {
+    try {
+      await service.conversations(t.conversationSid).participants(t.participantSid).remove();
+      removed++;
+    } catch (err) {
+      console.error(
+        `  ! failed ${t.participantSid} in ${t.conversationSid}: ${(err as Error).message}`,
+      );
+    }
+  }
+  console.log(`Done. Removed ${removed}/${targets.length}.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -1,7 +1,8 @@
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import {
-  addSpeakerParticipant,
+  addChatParticipant,
+  addSmsParticipant,
   createConversation,
   freePhoneBindingConflicts,
 } from "./twilio/conversations.js";
@@ -98,51 +99,32 @@ export async function createFreshInvitation(
     createdAt: FieldValue.serverTimestamp(),
   });
 
-  // Add the speaker as a single participant carrying BOTH the chat
-  // identity AND (when phone on file) the SMS messagingBinding.
-  // Two-participant setups echo the speaker's web-side answer back
-  // to their own phone via SMS — Twilio can't tell the chat-identity
-  // participant and the SMS-binding participant are the same human,
-  // so it broadcasts to all bindings. Combining them on one
-  // participant lets Twilio de-dup automatically.
-  //
-  // Twilio enforces uniqueness on (phone, proxyAddress) across all
-  // active conversations, so free any existing binding for this
-  // phone first. Fail-soft: if the create itself fails (bad phone
-  // format, cross-border 10DLC block, etc.), log and continue with
-  // a chat-only participant — invite SMS still delivers separately
-  // via `trySms` below.
-  const proxyAddress = input.speakerPhone ? resolveFromNumber(fromNumberMode) : undefined;
-  if (input.speakerPhone && proxyAddress) {
-    await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
-  }
-  try {
-    await addSpeakerParticipant(
-      conversationSid,
-      `speaker:${docRef.id}`,
-      { displayName: input.speakerName, role: "speaker" },
-      input.speakerPhone && proxyAddress
-        ? { speakerPhoneE164: input.speakerPhone, twilioFromNumber: proxyAddress }
-        : undefined,
-    );
-  } catch (err) {
-    logger.warn("failed to add speaker participant with SMS binding — falling back to chat-only", {
-      speakerId: input.speakerId,
-      meetingDate: input.meetingDate,
-      err: (err as Error).message,
-    });
-    // Fallback: at least make the chat side work so the bishop UI
-    // can see the speaker's identity if anything else fires.
+  await addChatParticipant(conversationSid, `speaker:${docRef.id}`, {
+    displayName: input.speakerName,
+    role: "speaker",
+  });
+
+  // Bind the speaker's phone for SMS-to-Conversation bridging — without
+  // this, a speaker's SMS reply has no participant binding to match
+  // and Twilio drops it (the chat-identity participant alone covers
+  // the web-side, not SMS). Twilio enforces uniqueness on
+  // (phone, proxy) pairs across all active conversations, so we free
+  // any existing binding for this phone first — handles family-shared
+  // phones, repeated test invites, and any stale state from prior
+  // errors. Fail-soft: if Twilio rejects after the cleanup (bad phone
+  // format, cross-border block, etc.) we log and proceed; the
+  // chat-identity participant still covers the web side and the invite
+  // SMS still gets delivered separately by `trySms` below.
+  if (input.speakerPhone) {
+    const proxyAddress = resolveFromNumber(fromNumberMode);
     try {
-      await addSpeakerParticipant(conversationSid, `speaker:${docRef.id}`, {
-        displayName: input.speakerName,
-        role: "speaker",
-      });
-    } catch (chatErr) {
-      logger.warn("chat-only fallback also failed", {
+      await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
+      await addSmsParticipant(conversationSid, input.speakerPhone, proxyAddress);
+    } catch (err) {
+      logger.warn("failed to add SMS participant — chat will work web-only", {
         speakerId: input.speakerId,
         meetingDate: input.meetingDate,
-        err: (chatErr as Error).message,
+        err: (err as Error).message,
       });
     }
   }

--- a/functions/src/freshInvitation.ts
+++ b/functions/src/freshInvitation.ts
@@ -1,11 +1,5 @@
 import { getFirestore, FieldValue } from "firebase-admin/firestore";
-import { logger } from "firebase-functions/v2";
-import {
-  addChatParticipant,
-  addSmsParticipant,
-  createConversation,
-  freePhoneBindingConflicts,
-} from "./twilio/conversations.js";
+import { addChatParticipant, createConversation } from "./twilio/conversations.js";
 import {
   addBishopricParticipants,
   buildInviteUrl,
@@ -16,7 +10,7 @@ import {
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
 import { invitationPrayerType } from "./invitationTypes.js";
 import { stampParticipantInvited } from "./stampParticipantInvited.js";
-import { resolveFromNumber, type FromNumberMode } from "./twilio/fromNumber.js";
+import type { FromNumberMode } from "./twilio/fromNumber.js";
 import type {
   DeliveryEntry,
   FreshInvitationRequest,
@@ -99,35 +93,19 @@ export async function createFreshInvitation(
     createdAt: FieldValue.serverTimestamp(),
   });
 
+  // Speaker is added as a chat-identity participant only — no SMS-only
+  // participant. Inbound speaker SMS replies arrive at the Programmable
+  // Messaging webhook and are relayed into this conversation
+  // server-side by `inboundSmsRelay` (authored as `speaker:{id}`).
+  // Outbound bishop → speaker SMS is server-driven via `smsSpeaker`
+  // ([invitationReplyNotify.ts]). Avoiding the SMS-only participant
+  // sidesteps Twilio's auto-broadcast of chat messages back to the
+  // speaker's phone (the echo behind #227) and the duplicate SMS that
+  // would arrive when both auto-broadcast and `smsSpeaker` ran.
   await addChatParticipant(conversationSid, `speaker:${docRef.id}`, {
     displayName: input.speakerName,
     role: "speaker",
   });
-
-  // Bind the speaker's phone for SMS-to-Conversation bridging — without
-  // this, a speaker's SMS reply has no participant binding to match
-  // and Twilio drops it (the chat-identity participant alone covers
-  // the web-side, not SMS). Twilio enforces uniqueness on
-  // (phone, proxy) pairs across all active conversations, so we free
-  // any existing binding for this phone first — handles family-shared
-  // phones, repeated test invites, and any stale state from prior
-  // errors. Fail-soft: if Twilio rejects after the cleanup (bad phone
-  // format, cross-border block, etc.) we log and proceed; the
-  // chat-identity participant still covers the web side and the invite
-  // SMS still gets delivered separately by `trySms` below.
-  if (input.speakerPhone) {
-    const proxyAddress = resolveFromNumber(fromNumberMode);
-    try {
-      await freePhoneBindingConflicts(input.speakerPhone, proxyAddress);
-      await addSmsParticipant(conversationSid, input.speakerPhone, proxyAddress);
-    } catch (err) {
-      logger.warn("failed to add SMS participant — chat will work web-only", {
-        speakerId: input.speakerId,
-        meetingDate: input.meetingDate,
-        err: (err as Error).message,
-      });
-    }
-  }
 
   await stampParticipantInvited({
     db,

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,12 +1,73 @@
-import { logger } from "firebase-functions/v2";
-import { interpolate, readMessageTemplate } from "./messageTemplates.js";
-import { sendEmail } from "./sendgrid/client.js";
 import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
+import { interpolate, readMessageTemplate } from "./messageTemplates.js";
+import { STEWARD_ORIGIN } from "./secrets.js";
+import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
+import { sendEmail } from "./sendgrid/client.js";
+import { sendSmsDirect } from "./twilio/messaging.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
 export interface ResolvedInvitation extends SpeakerInvitationShape {
   wardId: string;
   token: string;
+}
+
+/** Max age of the speaker's `speakerLastSeenAt` heartbeat before we
+ *  treat the chat as "closed". The invite page pings every 60s while
+ *  the tab is visible; 2× that cadence gives one missed ping of slack
+ *  before we fall back to SMS. */
+const HEARTBEAT_FRESH_MS = 120_000;
+
+/** Bishop posted → SMS the speaker with a fresh resume link (unless
+ *  the speaker's heartbeat shows they're actively viewing the chat).
+ *  Rotates the invitation's capability token (bishop-initiated, so it
+ *  does NOT count against `tokenRotationsByDay`) and appends the fresh
+ *  URL — the speaker can tap it to re-enter the chat with prior
+ *  messages preserved (same conversationSid). No-op when the invitation
+ *  has no phone on file. */
+export async function smsSpeaker(inv: ResolvedInvitation, body: string): Promise<void> {
+  if (!inv.speakerPhone) return;
+  if (isSpeakerOnline(inv)) return;
+  let inviteUrl: string | null = null;
+  try {
+    const rotated = await rotateTokenForBishopNotification(inv.wardId, inv.token);
+    if (rotated) {
+      const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
+      inviteUrl = buildInviteUrl(origin, inv.wardId, inv.token, rotated.newToken);
+    }
+  } catch (err) {
+    logger.warn("reply SMS token rotation failed — falling back to preview-only", {
+      token: inv.token,
+      err: (err as Error).message,
+    });
+  }
+  const preview = truncate(body, 240);
+  // Rotation-failed path stays hardcoded: it's an error fallback, not
+  // a user-authored message — we don't want a bishopric-edited template
+  // to leak a placeholder `{{inviteUrl}}` token into an SMS.
+  let text: string;
+  if (inviteUrl) {
+    const template = await readMessageTemplate(getFirestore(), inv.wardId, "bishopReplySms");
+    text = interpolate(template, { wardName: inv.wardName, preview, inviteUrl });
+  } else {
+    text = `${inv.inviterName} (Steward): ${preview}`;
+  }
+  try {
+    await sendSmsDirect({
+      to: inv.speakerPhone,
+      body: text,
+      ...(inv.fromNumberMode ? { fromMode: inv.fromNumberMode } : {}),
+    });
+  } catch (err) {
+    logger.error("reply SMS failed", { err: (err as Error).message, token: inv.token });
+  }
+}
+
+function isSpeakerOnline(inv: ResolvedInvitation): boolean {
+  const ts = inv.speakerLastSeenAt;
+  if (!ts) return false;
+  return Date.now() - ts.toMillis() < HEARTBEAT_FRESH_MS;
 }
 
 /** Bishop posted → SendGrid email to the speaker with a preview.

--- a/functions/src/messageTemplateDefaults.ts
+++ b/functions/src/messageTemplateDefaults.ts
@@ -59,27 +59,47 @@ export const DEFAULT_PRAYER_RESPONSE_DECLINED =
 export const DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT =
   "{{speakerName}} {{verb}} the invitation to give the {{prayerType}} on {{assignedDate}}.";
 
+export const DEFAULT_SPEAKER_RESPONSE_ACCEPTED_SMS =
+  "Thanks {{speakerName}} — your acceptance to speak on {{assignedDate}} is recorded. — {{wardName}}";
+
+export const DEFAULT_SPEAKER_RESPONSE_DECLINED_SMS =
+  "Thanks {{speakerName}} — your decline of the speaking invitation for {{assignedDate}} is recorded. — {{wardName}}";
+
+export const DEFAULT_PRAYER_RESPONSE_ACCEPTED_SMS =
+  "Thanks {{speakerName}} — your acceptance to give the {{prayerType}} on {{assignedDate}} is recorded. — {{wardName}}";
+
+export const DEFAULT_PRAYER_RESPONSE_DECLINED_SMS =
+  "Thanks {{speakerName}} — your decline of the {{prayerType}} for {{assignedDate}} is recorded. — {{wardName}}";
+
 export type MessageTemplateKey =
   | "initialInvitationSms"
   | "speakerResponseAccepted"
   | "speakerResponseDeclined"
+  | "speakerResponseAcceptedSms"
+  | "speakerResponseDeclinedSms"
   | "bishopricResponseReceipt"
   | "bishopReplySms"
   | "bishopReplyEmail"
   | "prayerInitialInvitationSms"
   | "prayerResponseAccepted"
   | "prayerResponseDeclined"
+  | "prayerResponseAcceptedSms"
+  | "prayerResponseDeclinedSms"
   | "prayerBishopricResponseReceipt";
 
 export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
   speakerResponseAccepted: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
   speakerResponseDeclined: DEFAULT_SPEAKER_RESPONSE_DECLINED,
+  speakerResponseAcceptedSms: DEFAULT_SPEAKER_RESPONSE_ACCEPTED_SMS,
+  speakerResponseDeclinedSms: DEFAULT_SPEAKER_RESPONSE_DECLINED_SMS,
   bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
   bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
   bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
   prayerInitialInvitationSms: DEFAULT_PRAYER_INITIAL_INVITATION_SMS,
   prayerResponseAccepted: DEFAULT_PRAYER_RESPONSE_ACCEPTED,
   prayerResponseDeclined: DEFAULT_PRAYER_RESPONSE_DECLINED,
+  prayerResponseAcceptedSms: DEFAULT_PRAYER_RESPONSE_ACCEPTED_SMS,
+  prayerResponseDeclinedSms: DEFAULT_PRAYER_RESPONSE_DECLINED_SMS,
   prayerBishopricResponseReceipt: DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT,
 };

--- a/functions/src/onInvitationWrite.helpers.ts
+++ b/functions/src/onInvitationWrite.helpers.ts
@@ -1,6 +1,9 @@
 import { logger } from "firebase-functions/v2";
 import { buildBishopricReceipt, buildSpeakerReceipt } from "./invitationReceiptContent.js";
+import { invitationPrayerType } from "./invitationTypes.js";
+import { interpolate, readMessageTemplate } from "./messageTemplates.js";
 import { sendEmail } from "./sendgrid/client.js";
+import { sendSmsDirect } from "./twilio/messaging.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 import type { MemberDoc } from "./types.js";
 
@@ -50,6 +53,50 @@ export async function sendSpeakerReceipt(
     html: content.html,
     ...(bishopric.length > 0 ? { cc: bishopric.map((b) => b.email) } : {}),
   });
+}
+
+/** Send a short SMS receipt to the speaker confirming their response.
+ *  Complements `sendSpeakerReceipt` (email) on the same response
+ *  transition; SMS is the primary channel since most speakers reach
+ *  the chat via the SMS link. No-ops when the invitation has no
+ *  phone on file. Failures are logged and swallowed — the email leg
+ *  is the source-of-truth notification, this is a courtesy. */
+export async function sendSpeakerReceiptSms(
+  db: FirebaseFirestore.Firestore,
+  wardId: string,
+  invitation: SpeakerInvitationShape,
+): Promise<void> {
+  if (!invitation.speakerPhone) return;
+  const answer = invitation.response?.answer;
+  if (answer !== "yes" && answer !== "no") return;
+  const isPrayer = invitation.kind === "prayer";
+  const key = isPrayer
+    ? answer === "yes"
+      ? "prayerResponseAcceptedSms"
+      : "prayerResponseDeclinedSms"
+    : answer === "yes"
+      ? "speakerResponseAcceptedSms"
+      : "speakerResponseDeclinedSms";
+  const template = await readMessageTemplate(db, wardId, key);
+  const prayerType = invitationPrayerType(invitation);
+  const body = interpolate(template, {
+    speakerName: invitation.speakerName,
+    assignedDate: invitation.assignedDate,
+    wardName: invitation.wardName,
+    ...(prayerType ? { prayerType } : {}),
+  });
+  try {
+    await sendSmsDirect({
+      to: invitation.speakerPhone,
+      body,
+      ...(invitation.fromNumberMode ? { fromMode: invitation.fromNumberMode } : {}),
+    });
+  } catch (err) {
+    logger.error("speaker receipt SMS failed", {
+      err: (err as Error).message,
+      speakerName: invitation.speakerName,
+    });
+  }
 }
 
 export async function sendBishopricReceipt(

--- a/functions/src/onInvitationWrite.ts
+++ b/functions/src/onInvitationWrite.ts
@@ -8,6 +8,7 @@ import {
   fetchActiveBishopricEmails,
   sendBishopricReceipt,
   sendSpeakerReceipt,
+  sendSpeakerReceiptSms,
 } from "./onInvitationWrite.helpers.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
@@ -58,6 +59,7 @@ export const onInvitationWrite = onDocumentWritten(
         // allSettled keeps both sides running to completion.
         const results = await Promise.allSettled([
           sendSpeakerReceipt(after, bishopric, headerTemplate),
+          sendSpeakerReceiptSms(db, wardId, after),
           notifyBishopricOfResponse(db, wardId, invitationId, before, after),
         ]);
         for (const r of results) {

--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -1,7 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { onRequest, type Request } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
-import { emailSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
+import { emailSpeaker, smsSpeaker, type ResolvedInvitation } from "./invitationReplyNotify.js";
 import { pushToBishopric } from "./invitationReplyPush.js";
 import {
   TWILIO_ACCOUNT_SID,
@@ -72,15 +72,12 @@ export const onTwilioWebhook = onRequest(
       await pushToBishopric(invitation, body);
     } else if (author.startsWith("uid:")) {
       const senderBishopUid = author.slice("uid:".length);
-      // No `smsSpeaker` here: Twilio Conversations natively
-      // broadcasts the bishop's message to the speaker's SMS-bound
-      // participant. The previous wrapped notification SMS (with a
-      // freshly-rotated invite URL) was a duplicate of that native
-      // broadcast — speakers were getting both bubbles for the same
-      // bishop reply. Email + the bishop-to-bishop FCM push still
-      // run in parallel so peers see each other's chat activity even
-      // when not actively viewing the thread.
+      // All three run in parallel. SMS is the primary channel for the
+      // speaker, email is best-effort (no-ops when SendGrid isn't
+      // wired), and the bishop-to-bishop push keeps peer bishopric
+      // members in the loop without re-notifying the sender.
       await Promise.all([
+        smsSpeaker(invitation, body),
         emailSpeaker(invitation, body),
         pushToBishopric(invitation, body, { senderBishopUid }),
       ]);

--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -10,6 +10,7 @@ import {
   TWILIO_FROM_NUMBER,
   TWILIO_WEBHOOK_URL,
 } from "./secrets.js";
+import { NO_MATCH_TWIML, relayInboundSms } from "./twilio/inboundSmsRelay.js";
 import { verifyTwilioSignature } from "./twilio/verifyTwilioSignature.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 
@@ -25,16 +26,26 @@ const WEBHOOK_SECRETS = [
   TWILIO_WEBHOOK_URL,
 ];
 
-/** Twilio Conversations Service webhook. Wired to this endpoint via
- *  the service's POST-Webhook URL. Fires for every conversation
- *  event; we filter to `onMessageAdded` and fan out:
+/** Twilio webhook endpoint — handles two kinds of inbound:
  *
- *   - `speaker:*` authored → FCM push to active bishopric members
- *   - `uid:*` (bishopric) authored → SMS + email to the speaker,
- *     AND FCM push to other active bishopric members in the ward
- *     (the sender is filtered out)
+ *  1. **Conversations Service post-webhook** (payload has `EventType`).
+ *     Fires on every conversation event; we filter to `onMessageAdded`
+ *     and fan out:
+ *      - `speaker:*` authored → FCM push to active bishopric members
+ *      - `uid:*` (bishopric) authored → SMS + email to the speaker,
+ *        AND FCM push to other active bishopric members in the ward
+ *        (the sender is filtered out)
  *
- *  Post-expiry messages are logged and ignored defensively. */
+ *  2. **Programmable Messaging inbound webhook** (payload has
+ *     `MessageSid` + `From` + `Body`, no `EventType`). Wired via the
+ *     messaging service's `inboundRequestUrl`. Routes the SMS body
+ *     into the matching active speaker invitation's conversation as
+ *     `speaker:{invitationId}` so the bishop sees a normal speaker
+ *     chat message — see [twilio/inboundSmsRelay.ts]. Replaces the
+ *     deleted SMS-only Conversations participant pattern (#227).
+ *
+ *  Post-expiry messages on the Conversations branch are logged and
+ *  ignored defensively. */
 export const onTwilioWebhook = onRequest(
   { secrets: WEBHOOK_SECRETS },
   async (req, res): Promise<void> => {
@@ -44,6 +55,13 @@ export const onTwilioWebhook = onRequest(
       res.status(403).send("forbidden");
       return;
     }
+
+    if (isInboundSmsPayload(req)) {
+      const twiml = await handleInboundSms(req);
+      res.set("Content-Type", "text/xml").status(200).send(twiml);
+      return;
+    }
+
     if (req.body?.EventType !== "onMessageAdded") {
       res.status(200).send("ignored");
       return;
@@ -85,6 +103,40 @@ export const onTwilioWebhook = onRequest(
     res.status(200).send("ok");
   },
 );
+
+/** Programmable Messaging inbound payloads carry `MessageSid` + `From`
+ *  + `Body`, with no `EventType` (that field is Conversations-only).
+ *  Distinguishing on payload shape lets a single endpoint serve both
+ *  Twilio webhook formats without expanding the Cloud Function count. */
+function isInboundSmsPayload(req: Request): boolean {
+  const b = req.body as Record<string, unknown> | undefined;
+  if (!b) return false;
+  if (b.EventType) return false;
+  return typeof b.MessageSid === "string" && typeof b.From === "string";
+}
+
+/** Run the inbound-SMS relay and return the TwiML body to send back.
+ *  Splitting the logic out of the response-emitting code keeps the
+ *  function easy to unit-test (no `Response` type plumbing required). */
+async function handleInboundSms(req: Request): Promise<string> {
+  const body = (req.body?.Body ?? "") as string;
+  const from = req.body.From as string;
+  const result = await relayInboundSms(getFirestore(), from, body);
+  if (result.matched) {
+    // Empty TwiML — handled, but no auto-reply (the bishop sees the
+    // message in chat; the speaker doesn't need a confirmation echo).
+    return "<Response/>";
+  }
+  if (result.reason === "no-active-invitation") {
+    // Genuinely unknown sender — politely tell them this isn't the way.
+    return NO_MATCH_TWIML;
+  }
+  // empty-body or no-conversation: silent empty TwiML.
+  // (We don't want to chastise a speaker for accidentally sending an
+  // empty message; we don't want to leak invitation state by
+  // responding differently when the conversation lookup fails.)
+  return "<Response/>";
+}
 
 function verifySignature(req: Request): boolean {
   // Prefer the pinned `TWILIO_WEBHOOK_URL` when set — eliminates

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -19,9 +19,7 @@ export async function assertActiveMember(wardId: string, uid: string): Promise<v
 /** Frees the speaker's phone binding from any earlier Twilio
  *  Conversation for this (wardId, speakerId, meetingDate). Twilio
  *  refuses to bind the same (phone, proxy) pair twice, so a re-send
- *  for the same speaker would otherwise fail at the participant
- *  create call. (Cross-speaker phone conflicts are handled by
- *  `freePhoneBindingConflicts` at participant-create time.) */
+ *  for the same speaker would otherwise fail at addSmsParticipant. */
 export interface BishopricSnapshot {
   uid: string;
   displayName: string;

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -16,10 +16,6 @@ export async function assertActiveMember(wardId: string, uid: string): Promise<v
   }
 }
 
-/** Frees the speaker's phone binding from any earlier Twilio
- *  Conversation for this (wardId, speakerId, meetingDate). Twilio
- *  refuses to bind the same (phone, proxy) pair twice, so a re-send
- *  for the same speaker would otherwise fail at addSmsParticipant. */
 export interface BishopricSnapshot {
   uid: string;
   displayName: string;
@@ -64,6 +60,11 @@ export async function addBishopricParticipants(
   return added;
 }
 
+/** Deletes any Twilio Conversation tied to a previous invitation for
+ *  the same (wardId, speakerId, meetingDate). Hygiene for re-sends:
+ *  prevents orphan conversations from accumulating in the Conversations
+ *  service when a bishop replaces an invitation. Failures per-SID are
+ *  logged and swallowed so one stale SID doesn't block the rest. */
 export async function cleanupPriorConversations(
   wardId: string,
   speakerId: string,

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -67,64 +67,6 @@ export async function ensureChatParticipant(
   }
 }
 
-/** Speaker-side SMS participant. Twilio bridges messages in this
- *  conversation to/from the speaker's phone automatically. Returns
- *  the participant SID; throws if Twilio rejects (bad phone format,
- *  cross-border 10DLC block, etc.). */
-export async function addSmsParticipant(
-  conversationSid: string,
-  speakerPhoneE164: string,
-  twilioFromNumber: string,
-): Promise<string> {
-  const p = await service().conversations(conversationSid).participants.create({
-    "messagingBinding.address": speakerPhoneE164,
-    "messagingBinding.proxyAddress": twilioFromNumber,
-  });
-  return p.sid;
-}
-
-/** Frees the speaker phone's existing SMS binding(s) on this
- *  Conversations service before a new conversation tries to claim it.
- *  Twilio enforces uniqueness on (address, proxyAddress) pairs across
- *  all active conversations — without this cleanup, the second
- *  `addSmsParticipant` call for the same phone fails and inbound SMS
- *  routes to whichever conversation already owns the binding (often
- *  not the most recent one).
- *
- *  Real-world cases this catches:
- *  - Family-shared phone: the bishop sent invite to spouse A, then to
- *    spouse B. Most-recent-invite wins for SMS routing on that phone.
- *  - Test/staging churn: repeated invites to the same phone with
- *    different speakerIds (so `cleanupPriorConversations` doesn't
- *    catch them via its speakerId+meetingDate filter).
- *  - Stale state: any conversation orphaned by an earlier deploy
- *    error or manual cleanup that left bindings behind.
- *
- *  Removes only the SMS participant, not the whole conversation —
- *  the prior chat history (web side, bishopric identities) survives
- *  and remains viewable by the bishop. */
-export async function freePhoneBindingConflicts(
-  speakerPhoneE164: string,
-  twilioFromNumber: string,
-): Promise<void> {
-  const svc = service();
-  const conflicts = await svc.participantConversations.list({ address: speakerPhoneE164 });
-  for (const c of conflicts) {
-    const binding = c.participantMessagingBinding as
-      | { address?: string; proxy_address?: string; type?: string }
-      | undefined;
-    if (
-      binding?.type !== "sms" ||
-      binding.address !== speakerPhoneE164 ||
-      binding.proxy_address !== twilioFromNumber
-    ) {
-      continue;
-    }
-    if (!c.conversationSid || !c.participantSid) continue;
-    await svc.conversations(c.conversationSid).participants(c.participantSid).remove();
-  }
-}
-
 export interface PostMessageInput {
   conversationSid: string;
   author: string;
@@ -132,11 +74,11 @@ export interface PostMessageInput {
   attributes?: Record<string, unknown>;
 }
 
-/** Hard-deletes a Twilio Conversation by SID. Used to free up an
- *  SMS binding (phone + proxy) before creating a new conversation for
- *  the same speaker — Twilio enforces one binding per phone per
- *  proxy and rejects `addSmsParticipant` otherwise. Safe to call on
- *  an already-deleted SID: Twilio returns 404 which we let bubble. */
+/** Hard-deletes a Twilio Conversation by SID. Used by
+ *  `cleanupPriorConversations` to remove orphan conversations from
+ *  prior re-sends for the same speaker+date so they don't accumulate
+ *  in the Conversations service. Safe to call on an already-deleted
+ *  SID: Twilio returns 404 which we let bubble. */
 export async function deleteConversation(conversationSid: string): Promise<void> {
   await service().conversations(conversationSid).remove();
 }

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -67,46 +67,19 @@ export async function ensureChatParticipant(
   }
 }
 
-/** Speaker-side participant carrying BOTH a chat identity AND (when
- *  the speaker has a phone on file) an SMS messagingBinding on a
- *  single Twilio Conversations participant.
- *
- *  Why both on one participant: Twilio Conversations broadcasts every
- *  message to all participants with delivery channels. With the
- *  chat-identity and SMS binding split across two participants, a
- *  message authored by the chat-identity participant gets broadcast
- *  to the SMS-only participant — Twilio can't tell they're the same
- *  human, and the speaker receives their own web-side answer back as
- *  SMS (the "Yes, I can speak." echo). Combining identity + binding
- *  on one participant makes the de-dup automatic: Twilio knows the
- *  sender and the binding belong to the same participant and won't
- *  fan back to that channel.
- *
- *  Bonus side effect: the binding now carries the speaker's display
- *  name + role attributes, so the bishop's chat UI no longer renders
- *  SMS-originated messages as "Unknown".
- *
- *  Pass `smsBinding: undefined` for speakers with no phone on file —
- *  the participant is created chat-only, identical to bishopric
- *  participants. */
-export async function addSpeakerParticipant(
+/** Speaker-side SMS participant. Twilio bridges messages in this
+ *  conversation to/from the speaker's phone automatically. Returns
+ *  the participant SID; throws if Twilio rejects (bad phone format,
+ *  cross-border 10DLC block, etc.). */
+export async function addSmsParticipant(
   conversationSid: string,
-  identity: string,
-  attributes: {
-    displayName: string;
-    role: "speaker";
-  },
-  smsBinding?: { speakerPhoneE164: string; twilioFromNumber: string },
+  speakerPhoneE164: string,
+  twilioFromNumber: string,
 ): Promise<string> {
-  const params: Record<string, string> = {
-    identity,
-    attributes: JSON.stringify(attributes),
-  };
-  if (smsBinding) {
-    params["messagingBinding.address"] = smsBinding.speakerPhoneE164;
-    params["messagingBinding.proxyAddress"] = smsBinding.twilioFromNumber;
-  }
-  const p = await service().conversations(conversationSid).participants.create(params);
+  const p = await service().conversations(conversationSid).participants.create({
+    "messagingBinding.address": speakerPhoneE164,
+    "messagingBinding.proxyAddress": twilioFromNumber,
+  });
   return p.sid;
 }
 
@@ -114,9 +87,9 @@ export async function addSpeakerParticipant(
  *  Conversations service before a new conversation tries to claim it.
  *  Twilio enforces uniqueness on (address, proxyAddress) pairs across
  *  all active conversations — without this cleanup, the second
- *  `addSpeakerParticipant` call for the same phone fails and inbound
- *  SMS routes to whichever conversation already owns the binding
- *  (often not the most recent one).
+ *  `addSmsParticipant` call for the same phone fails and inbound SMS
+ *  routes to whichever conversation already owns the binding (often
+ *  not the most recent one).
  *
  *  Real-world cases this catches:
  *  - Family-shared phone: the bishop sent invite to spouse A, then to
@@ -127,11 +100,9 @@ export async function addSpeakerParticipant(
  *  - Stale state: any conversation orphaned by an earlier deploy
  *    error or manual cleanup that left bindings behind.
  *
- *  Removes the matching SMS-bound participant entirely (today that's
- *  the speaker's combined chat-identity + SMS-binding participant
- *  per `addSpeakerParticipant`). The prior chat history survives
- *  conversation-side; only that participant's attribution on past
- *  messages is freed. */
+ *  Removes only the SMS participant, not the whole conversation —
+ *  the prior chat history (web side, bishopric identities) survives
+ *  and remains viewable by the bishop. */
 export async function freePhoneBindingConflicts(
   speakerPhoneE164: string,
   twilioFromNumber: string,

--- a/functions/src/twilio/inboundSmsRelay.test.ts
+++ b/functions/src/twilio/inboundSmsRelay.test.ts
@@ -1,0 +1,155 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { postMessage } = vi.hoisted(() => ({ postMessage: vi.fn() }));
+vi.mock("./conversations.js", () => ({ postMessage }));
+vi.mock("firebase-functions/v2", () => ({ logger: { warn: vi.fn() } }));
+
+import { NO_MATCH_TWIML, relayInboundSms } from "./inboundSmsRelay.js";
+
+interface DocLike {
+  id: string;
+  data: () => Record<string, unknown>;
+}
+
+function ts(ms: number): Timestamp {
+  return Timestamp.fromMillis(ms);
+}
+
+function makeDb(docs: DocLike[]): import("firebase-admin/firestore").Firestore {
+  // Minimal fake — only the methods relayInboundSms calls.
+  const get = vi.fn().mockResolvedValue({ empty: docs.length === 0, docs });
+  const where2 = vi.fn().mockReturnValue({ get });
+  const where1 = vi.fn().mockReturnValue({ where: where2 });
+  const collectionGroup = vi.fn().mockReturnValue({ where: where1 });
+  return { collectionGroup } as unknown as import("firebase-admin/firestore").Firestore;
+}
+
+describe("relayInboundSms", () => {
+  beforeEach(() => {
+    postMessage.mockReset();
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns no-active-invitation when no docs match", async () => {
+    const db = makeDb([]);
+    const r = await relayInboundSms(db, "+14155551111", "hello");
+    expect(r).toEqual({ matched: false, reason: "no-active-invitation" });
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns empty-body when the SMS body is whitespace", async () => {
+    const db = makeDb([]);
+    const r = await relayInboundSms(db, "+14155551111", "   \n  ");
+    expect(r).toEqual({ matched: false, reason: "empty-body" });
+  });
+
+  it("filters out expired invitations", async () => {
+    const past = ts(Date.now() - 60_000);
+    const docs: DocLike[] = [
+      {
+        id: "expired1",
+        data: () => ({
+          speakerPhone: "+14155551111",
+          tokenStatus: "active",
+          expiresAt: past,
+          conversationSid: "CHexpired",
+          createdAt: ts(Date.now() - 600_000),
+        }),
+      },
+    ];
+    const db = makeDb(docs);
+    const r = await relayInboundSms(db, "+14155551111", "hi");
+    expect(r).toEqual({ matched: false, reason: "no-active-invitation" });
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+
+  it("picks most-recent createdAt when multiple non-expired invitations match", async () => {
+    const future = ts(Date.now() + 60 * 60_000);
+    const docs: DocLike[] = [
+      {
+        id: "older",
+        data: () => ({
+          speakerPhone: "+14155551111",
+          tokenStatus: "active",
+          expiresAt: future,
+          conversationSid: "CHolder",
+          createdAt: ts(Date.now() - 86_400_000),
+        }),
+      },
+      {
+        id: "newer",
+        data: () => ({
+          speakerPhone: "+14155551111",
+          tokenStatus: "active",
+          expiresAt: future,
+          conversationSid: "CHnewer",
+          createdAt: ts(Date.now() - 60_000),
+        }),
+      },
+    ];
+    const db = makeDb(docs);
+    postMessage.mockResolvedValue("IM_msg_sid");
+    const r = await relayInboundSms(db, "+14155551111", "Yes I can speak");
+    expect(r).toEqual({
+      matched: true,
+      conversationSid: "CHnewer",
+      invitationId: "newer",
+      messageSid: "IM_msg_sid",
+    });
+    expect(postMessage).toHaveBeenCalledWith({
+      conversationSid: "CHnewer",
+      author: "speaker:newer",
+      body: "Yes I can speak",
+    });
+  });
+
+  it("trims whitespace from the posted body", async () => {
+    const future = ts(Date.now() + 60 * 60_000);
+    const docs: DocLike[] = [
+      {
+        id: "inv1",
+        data: () => ({
+          speakerPhone: "+14155551111",
+          tokenStatus: "active",
+          expiresAt: future,
+          conversationSid: "CHinv1",
+          createdAt: ts(Date.now()),
+        }),
+      },
+    ];
+    const db = makeDb(docs);
+    postMessage.mockResolvedValue("IM_sid");
+    await relayInboundSms(db, "+14155551111", "  hi there \n");
+    expect(postMessage).toHaveBeenCalledWith(expect.objectContaining({ body: "hi there" }));
+  });
+
+  it("returns no-conversation when matched doc lacks conversationSid", async () => {
+    const future = ts(Date.now() + 60 * 60_000);
+    const docs: DocLike[] = [
+      {
+        id: "inv1",
+        data: () => ({
+          speakerPhone: "+14155551111",
+          tokenStatus: "active",
+          expiresAt: future,
+          createdAt: ts(Date.now()),
+        }),
+      },
+    ];
+    const db = makeDb(docs);
+    const r = await relayInboundSms(db, "+14155551111", "hi");
+    expect(r).toEqual({ matched: false, reason: "no-conversation" });
+    expect(postMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe("NO_MATCH_TWIML", () => {
+  it("is a valid TwiML Response with a Message child", () => {
+    expect(NO_MATCH_TWIML).toContain("<Response>");
+    expect(NO_MATCH_TWIML).toContain("<Message>");
+    expect(NO_MATCH_TWIML).toContain("</Response>");
+  });
+});

--- a/functions/src/twilio/inboundSmsRelay.ts
+++ b/functions/src/twilio/inboundSmsRelay.ts
@@ -1,0 +1,82 @@
+import { type Firestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions/v2";
+import { postMessage } from "./conversations.js";
+import type { SpeakerInvitationShape } from "../invitationTypes.js";
+
+export type RelayResult =
+  | { matched: true; conversationSid: string; invitationId: string; messageSid: string }
+  | { matched: false; reason: "no-active-invitation" | "no-conversation" | "empty-body" };
+
+/** Server-side bridge for inbound SMS from a speaker's phone. Looks up
+ *  the most recent active invitation for the sender phone and posts
+ *  the SMS body into that conversation as `speaker:{invitationId}`,
+ *  so the bishop sees a normal speaker-authored chat message and the
+ *  rest of the existing webhook fan-out (FCM push to bishopric) runs
+ *  unchanged.
+ *
+ *  Why this exists: we removed the SMS-only Conversations participant
+ *  for the speaker (see #227) to avoid Twilio's chat → SMS auto-bridge
+ *  echoing the speaker's own web-side replies back to their phone.
+ *  With no SMS participant, inbound SMS has nowhere to land natively;
+ *  this relay restores the inbound path server-side.
+ *
+ *  Match rule: any speakerInvitation whose `speakerPhone` equals the
+ *  inbound `From`, `tokenStatus === "active"`, and `expiresAt` in the
+ *  future — most recent wins. Tie-break is `createdAt` descending so a
+ *  shared phone (e.g. spouses) routes to the most-recently-sent
+ *  invitation. Returns `matched: false` so the caller can respond with
+ *  a TwiML auto-reply for genuinely unknown senders. */
+export async function relayInboundSms(
+  db: Firestore,
+  from: string,
+  body: string,
+): Promise<RelayResult> {
+  const trimmed = body.trim();
+  if (!trimmed) return { matched: false, reason: "empty-body" };
+
+  const snap = await db
+    .collectionGroup("speakerInvitations")
+    .where("speakerPhone", "==", from)
+    .where("tokenStatus", "==", "active")
+    .get();
+  if (snap.empty) return { matched: false, reason: "no-active-invitation" };
+
+  const now = Date.now();
+  const candidates = snap.docs
+    .map((d) => ({ doc: d, data: d.data() as SpeakerInvitationShape }))
+    .filter(({ data }) => !data.expiresAt || data.expiresAt.toMillis() > now)
+    .sort((a, b) => {
+      // Sort descending by createdAt (most recent first). Admin SDK
+      // doesn't expose createdAt as a typed field on
+      // SpeakerInvitationShape (server-stamped FieldValue), so read
+      // through the raw doc data.
+      const aMs = (a.data as { createdAt?: FirebaseFirestore.Timestamp }).createdAt?.toMillis() ?? 0;
+      const bMs = (b.data as { createdAt?: FirebaseFirestore.Timestamp }).createdAt?.toMillis() ?? 0;
+      return bMs - aMs;
+    });
+  if (candidates.length === 0) return { matched: false, reason: "no-active-invitation" };
+
+  const winner = candidates[0]!;
+  const conversationSid = winner.data.conversationSid;
+  if (!conversationSid) {
+    logger.warn("matched invitation has no conversationSid", {
+      invitationId: winner.doc.id,
+    });
+    return { matched: false, reason: "no-conversation" };
+  }
+  const invitationId = winner.doc.id;
+  const messageSid = await postMessage({
+    conversationSid,
+    author: `speaker:${invitationId}`,
+    body: trimmed,
+  });
+  return { matched: true, conversationSid, invitationId, messageSid };
+}
+
+/** Static TwiML response body for the no-match case — used by the
+ *  webhook caller to politely respond to inbound SMS from a phone we
+ *  don't recognize. Uses Twilio's `<Response><Message>` shape. */
+export const NO_MATCH_TWIML = `<?xml version="1.0" encoding="UTF-8"?>
+<Response>
+  <Message>This number doesn't recognize your phone. Please contact your ward bishopric directly.</Message>
+</Response>`;

--- a/functions/src/twilio/inboundSmsRelay.ts
+++ b/functions/src/twilio/inboundSmsRelay.ts
@@ -45,13 +45,15 @@ export async function relayInboundSms(
   const candidates = snap.docs
     .map((d) => ({ doc: d, data: d.data() as SpeakerInvitationShape }))
     .filter(({ data }) => !data.expiresAt || data.expiresAt.toMillis() > now)
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       // Sort descending by createdAt (most recent first). Admin SDK
       // doesn't expose createdAt as a typed field on
       // SpeakerInvitationShape (server-stamped FieldValue), so read
       // through the raw doc data.
-      const aMs = (a.data as { createdAt?: FirebaseFirestore.Timestamp }).createdAt?.toMillis() ?? 0;
-      const bMs = (b.data as { createdAt?: FirebaseFirestore.Timestamp }).createdAt?.toMillis() ?? 0;
+      const aMs =
+        (a.data as { createdAt?: FirebaseFirestore.Timestamp }).createdAt?.toMillis() ?? 0;
+      const bMs =
+        (b.data as { createdAt?: FirebaseFirestore.Timestamp }).createdAt?.toMillis() ?? 0;
       return bMs - aMs;
     });
   if (candidates.length === 0) return { matched: false, reason: "no-active-invitation" };

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2023"],
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -126,3 +126,34 @@ pnpm --filter @steward/functions configure-conversation-roles
 
 Idempotent. Run once per Twilio service (dev + prod each have their own
 Conversations service SID).
+
+## sweep-sms-only-participants (functions workspace)
+
+One-time migration: removes every SMS-only participant
+(`messagingBinding` set, `identity` null) from every conversation in
+the configured Conversations service. Required at the v0.20.2 deploy
+step — older invitations (pre-c9dc4a9) still carry SMS-only participants
+that Twilio's auto-bridge keeps routing inbound to. After v0.20.2 the
+inbound path is the messaging-service `inboundRequestUrl` →
+`onTwilioWebhook` → `inboundSmsRelay`. Without this sweep, Twilio
+double-routes inbound SMS (auto-bridge to the old conversation AND
+the relay to the new one), so the bishop sees the same message in
+two different chatboxes.
+
+Dry-run by default. Pass `--commit` to actually remove.
+
+```sh
+# Dry-run against prod
+TWILIO_ACCOUNT_SID=AC... \
+TWILIO_AUTH_TOKEN=... \
+TWILIO_CONVERSATIONS_SERVICE_SID=IS4f27eebffb094603938ad543cfb280d8 \
+pnpm --filter @steward/functions sweep-sms-only-participants
+
+# Commit
+TWILIO_ACCOUNT_SID=AC... \
+TWILIO_AUTH_TOKEN=... \
+TWILIO_CONVERSATIONS_SERVICE_SID=IS4f27eebffb094603938ad543cfb280d8 \
+pnpm --filter @steward/functions sweep-sms-only-participants --commit
+```
+
+Idempotent: a second run finds nothing to remove.

--- a/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
+++ b/src/app/routes/invite-speaker/SpeakerChatFloatingDrawer.tsx
@@ -30,12 +30,12 @@ export function SpeakerChatFloatingDrawer({
 }: Props): React.ReactElement {
   const isMobile = useIsMobile();
   const contentRef = useRef<HTMLDivElement | null>(null);
-  // Keyboard-aware sizing only applies on the mobile bottom sheet.
+  // Keyboard-aware sizing only applies on the mobile fullscreen sheet.
   // Desktop is `inset-y-0 right-0` and never collides with the soft
   // keyboard.
   useKeyboardAwareViewport(contentRef, isMobile && open);
   const contentClass = isMobile
-    ? "fixed bottom-0 left-0 right-0 z-20 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
+    ? "fixed inset-0 z-20 flex flex-col bg-chalk shadow-elev-3 outline-none"
     : "fixed inset-y-0 right-0 z-20 flex w-[min(26.25rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
   return (
     <>

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -52,12 +52,12 @@ export function BishopInvitationDialog({
 }: Props): React.ReactElement | null {
   const isMobile = useIsMobile();
   const contentRef = useRef<HTMLDivElement | null>(null);
-  // Keyboard-aware sizing only applies on the mobile bottom sheet.
+  // Keyboard-aware sizing only applies on the mobile fullscreen sheet.
   // Desktop is `inset-y-0 right-0` and never collides with the soft
   // keyboard.
   useKeyboardAwareViewport(contentRef, isMobile && open);
   const contentClass = isMobile
-    ? "fixed bottom-0 left-0 right-0 z-60 mt-24 flex h-[85dvh] flex-col rounded-t-[18px] border-t border-x border-border-strong bg-chalk shadow-elev-3 outline-none"
+    ? "fixed inset-0 z-60 flex flex-col bg-chalk shadow-elev-3 outline-none"
     : "fixed inset-y-0 right-0 z-60 flex w-[min(28rem,100vw)] flex-col bg-chalk shadow-elev-3 border-l border-border-strong outline-none";
   return (
     <Drawer.Root

--- a/src/features/templates/utils/serverTemplateDefaults.ts
+++ b/src/features/templates/utils/serverTemplateDefaults.ts
@@ -83,15 +83,35 @@ export const DEFAULT_PRAYER_RESPONSE_DECLINED =
 export const DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT =
   "{{speakerName}} {{verb}} the invitation to give the {{prayerType}} on {{assignedDate}}.";
 
+/** Speaker-side SMS confirmation when the speaker accepts on the web invite page. */
+export const DEFAULT_SPEAKER_RESPONSE_ACCEPTED_SMS =
+  "Thanks {{speakerName}} — your acceptance to speak on {{assignedDate}} is recorded. — {{wardName}}";
+
+/** Speaker-side SMS confirmation when the speaker declines on the web invite page. */
+export const DEFAULT_SPEAKER_RESPONSE_DECLINED_SMS =
+  "Thanks {{speakerName}} — your decline of the speaking invitation for {{assignedDate}} is recorded. — {{wardName}}";
+
+/** Prayer-side SMS confirmation when the speaker accepts. */
+export const DEFAULT_PRAYER_RESPONSE_ACCEPTED_SMS =
+  "Thanks {{speakerName}} — your acceptance to give the {{prayerType}} on {{assignedDate}} is recorded. — {{wardName}}";
+
+/** Prayer-side SMS confirmation when the speaker declines. */
+export const DEFAULT_PRAYER_RESPONSE_DECLINED_SMS =
+  "Thanks {{speakerName}} — your decline of the {{prayerType}} for {{assignedDate}} is recorded. — {{wardName}}";
+
 export const DEFAULT_MESSAGE_TEMPLATES: Record<MessageTemplateKey, string> = {
   initialInvitationSms: DEFAULT_INITIAL_INVITATION_SMS,
   speakerResponseAccepted: DEFAULT_SPEAKER_RESPONSE_ACCEPTED,
   speakerResponseDeclined: DEFAULT_SPEAKER_RESPONSE_DECLINED,
+  speakerResponseAcceptedSms: DEFAULT_SPEAKER_RESPONSE_ACCEPTED_SMS,
+  speakerResponseDeclinedSms: DEFAULT_SPEAKER_RESPONSE_DECLINED_SMS,
   bishopricResponseReceipt: DEFAULT_BISHOPRIC_RESPONSE_RECEIPT,
   bishopReplySms: DEFAULT_BISHOP_REPLY_SMS,
   bishopReplyEmail: DEFAULT_BISHOP_REPLY_EMAIL,
   prayerInitialInvitationSms: DEFAULT_PRAYER_INITIAL_INVITATION_SMS,
   prayerResponseAccepted: DEFAULT_PRAYER_RESPONSE_ACCEPTED,
   prayerResponseDeclined: DEFAULT_PRAYER_RESPONSE_DECLINED,
+  prayerResponseAcceptedSms: DEFAULT_PRAYER_RESPONSE_ACCEPTED_SMS,
+  prayerResponseDeclinedSms: DEFAULT_PRAYER_RESPONSE_DECLINED_SMS,
   prayerBishopricResponseReceipt: DEFAULT_PRAYER_BISHOPRIC_RESPONSE_RECEIPT,
 };

--- a/src/lib/types/template.ts
+++ b/src/lib/types/template.ts
@@ -181,12 +181,16 @@ export const MESSAGE_TEMPLATE_KEYS = [
   "initialInvitationSms",
   "speakerResponseAccepted",
   "speakerResponseDeclined",
+  "speakerResponseAcceptedSms",
+  "speakerResponseDeclinedSms",
   "bishopricResponseReceipt",
   "bishopReplySms",
   "bishopReplyEmail",
   "prayerInitialInvitationSms",
   "prayerResponseAccepted",
   "prayerResponseDeclined",
+  "prayerResponseAcceptedSms",
+  "prayerResponseDeclinedSms",
   "prayerBishopricResponseReceipt",
 ] as const;
 export type MessageTemplateKey = (typeof MESSAGE_TEMPLATE_KEYS)[number];


### PR DESCRIPTION
## Summary

- Restores inbound speaker SMS replies (`Fixes #226`) and removes the speaker-side echo SMS (`Fixes #227`) by replacing Twilio's chat → SMS auto-bridge with a server-driven relay.
- Speaker is added to a Conversations conversation as **chat-identity only**; no SMS-only participant. Outbound bishop → speaker SMS keeps using the existing `smsSpeaker` server helper. Inbound speaker SMS arrives at the messaging service's new `inboundRequestUrl`, dispatches inside `onTwilioWebhook` to a new `inboundSmsRelay`, looks up the active invitation by phone, and posts the body into the conversation as `speaker:{invitationId}` — bishop sees a normal speaker chat message, the existing `pushToBishopric` fan-out fires.
- Speaker now also gets a short SMS receipt on Yes/No transitions (4 new template keys mirrored across server + client + drift-test). Mobile chatbox is fullscreen on both bishop and speaker sides.

## Why this shape

The c9dc4a9 attempt to combine identity + SMS messagingBinding on one Conversations participant always fails Twilio's API constraint ("Participants on SMS, WhatsApp or other non-chat channels cannot have Identities"); the `catch` left the speaker with no SMS binding so inbound replies were dropped by the Conversations service. The proper Twilio-supported fix (`MessagingBinding.ProjectedAddress`) is account-gated (error 50439) — tracked as a follow-up in #227. This PR sidesteps both issues by moving both directions of SMS bridging server-side.

## Files

- **Code**: `freshInvitation.ts`, `twilio/conversations.ts`, `onTwilioWebhook.ts`, `twilio/inboundSmsRelay.ts` (new), `onInvitationWrite.{ts,helpers.ts}`, `messageTemplateDefaults.ts` + client mirror + `lib/types/template.ts`.
- **Mobile UI**: `BishopInvitationDialog.tsx`, `SpeakerChatFloatingDrawer.tsx` — fullscreen on mobile.
- **Infra**: `firestore.indexes.json` (new collectionGroup composite for `speakerPhone + tokenStatus`).
- **Docs**: `docs/invitation-flow.md` updated to reflect the new model.
- **Migration**: `functions/scripts/sweep-sms-only-participants.ts` (new) — one-time admin sweep needed at deploy.

## Twilio side (already done in this session)

- New dev messaging service `MG09a6…` "Steward Dev Inbound" (contains only `+12295473216`), `inboundRequestUrl` → ngrok tunnel.
- Existing prod messaging service `MG0566…` (contains only `+15873184624`), `inboundRequestUrl` set to the prod function URL.
- Existing dev/prod Conversations services and address-configs unchanged.

## Deploy runbook (required, in this order)

1. `firebase deploy --only firestore:indexes --project steward-prod-65a36` — wait for the new collectionGroup index to finish building.
2. `firebase deploy --only functions --project steward-prod-65a36`.
3. Run the sweep to remove pre-c9dc4a9 SMS-only participants from prod conversations:
   ```sh
   TWILIO_ACCOUNT_SID=... \
   TWILIO_AUTH_TOKEN=... \
   TWILIO_CONVERSATIONS_SERVICE_SID=IS4f27eebffb094603938ad543cfb280d8 \
   pnpm --filter @steward/functions sweep-sms-only-participants            # dry-run
   pnpm --filter @steward/functions sweep-sms-only-participants --commit
   ```

## Test plan

- [x] Functions tests green (103/103, +7 new for `inboundSmsRelay`).
- [x] Web tests green (453/453).
- [x] Typecheck (web + functions) clean.
- [x] Local e2e — speaker SMS reply lands once in the most-recent active invitation's chatbox; bishop chat reply reaches speaker phone exactly once.
- [x] Mobile chatbox is fullscreen on both bishop and speaker views.
- [ ] After deploy: smoke-test prod with one real invitation (replies via SMS + replies via web) and run the sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)