### PR TITLE
security: bundled remaining remediations (M1·M2·M6·M7+L1·H4·L2·L3·L5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,12 @@ VITE_USE_EMULATORS=
 # so the toggle is hidden for everyone. The server-side mirror lives
 # in functions/.env.local under DEV_MODE_EMAILS.
 VITE_DEV_MODE_EMAILS=
+
+# Firebase App Check (reCAPTCHA Enterprise) site key. When set, both
+# Firebase apps (main + invite) attach App Check tokens to every
+# Firestore / callable / FCM request, blocking abuse from non-app
+# sources at the edge. Leave blank in dev/emulator. Provision the key
+# at Firebase Console -> App Check -> Apps -> Web -> reCAPTCHA Enterprise.
+# Server-side enforcement is gated separately by `APP_CHECK_ENFORCED`
+# on the issueSpeakerSession Cloud Function.
+VITE_FIREBASE_APPCHECK_SITE_KEY=

--- a/functions/.env.example
+++ b/functions/.env.example
@@ -19,4 +19,11 @@ STEWARD_DEV_STUB_SMS=true
 # unless a maintainer needs to route through TWILIO_FROM_NUMBER_TESTING.
 DEV_MODE_EMAILS=
 
+# Set to "true" to enforce Firebase App Check on the issueSpeakerSession
+# callable. Roll out: deploy with the client-side site key set + this
+# unset, observe `appCheckTokenInvalid` / `appCheckTokenMissing` metrics
+# in the Firebase Console for a soak window, then flip to "true" once
+# real traffic looks healthy. Leave blank in dev/emulator.
+APP_CHECK_ENFORCED=
+
 # ---- See functions/.secret.local.example for the Twilio credential keys.

--- a/functions/src/invitationReplyNotify.ts
+++ b/functions/src/invitationReplyNotify.ts
@@ -1,7 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { logger } from "firebase-functions/v2";
 import { rotateTokenForBishopNotification } from "./issueSpeakerSession.helpers.js";
-import { interpolate, readMessageTemplate } from "./messageTemplates.js";
+import { interpolate, neutralizeMustaches, readMessageTemplate } from "./messageTemplates.js";
 import { STEWARD_ORIGIN } from "./secrets.js";
 import { buildInviteUrl } from "./sendSpeakerInvitation.helpers.js";
 import { sendEmail } from "./sendgrid/client.js";
@@ -42,7 +42,11 @@ export async function smsSpeaker(inv: ResolvedInvitation, body: string): Promise
       err: (err as Error).message,
     });
   }
-  const preview = truncate(body, 240);
+  // `body` is bishop-authored chat content; neutralize any `{{...}}`
+  // before it reaches `interpolate` so a future change to recursive
+  // substitution can't surprise us by expanding chat tokens against
+  // the surrounding vars dict (notably leaking `inviteUrl`).
+  const preview = neutralizeMustaches(truncate(body, 240));
   // Rotation-failed path stays hardcoded: it's an error fallback, not
   // a user-authored message — we don't want a bishopric-edited template
   // to leak a placeholder `{{inviteUrl}}` token into an SMS.
@@ -82,7 +86,11 @@ function isSpeakerOnline(inv: ResolvedInvitation): boolean {
  *  them at their SMS instead. */
 export async function emailSpeaker(inv: ResolvedInvitation, body: string): Promise<void> {
   if (!inv.speakerEmail) return;
-  const preview = truncate(body, 180);
+  // Neutralize chat-author `{{...}}` before interpolation — same
+  // rationale as smsSpeaker above. The plain-text body is escaped via
+  // textToParagraphHtml for HTML-context rendering; this guards the
+  // template-substitution context.
+  const preview = neutralizeMustaches(truncate(body, 180));
   const template = await readMessageTemplate(getFirestore(), inv.wardId, "bishopReplyEmail");
   const text = interpolate(template, {
     inviterName: inv.inviterName,

--- a/functions/src/issueSpeakerSession.dispatch.ts
+++ b/functions/src/issueSpeakerSession.dispatch.ts
@@ -1,0 +1,80 @@
+import { getAuth } from "firebase-admin/auth";
+import { logger } from "firebase-functions/v2";
+import { decideTokenAction, speakerUid } from "./issueSpeakerSession.helpers.js";
+import { TOKEN_TTL_SECONDS, type SpeakerResponse } from "./issueSpeakerSession.types.js";
+import { phoneLast4 } from "./invitationToken.js";
+import { STEWARD_ORIGIN } from "./secrets.js";
+import { buildInviteUrl, sendInvitationSms } from "./sendSpeakerInvitation.helpers.js";
+import { issueChatToken } from "./twilio/token.js";
+
+/** Speaker capability-token exchange: dispatches on `decideTokenAction`
+ *  and either mints a session, returns a rate-limited / invalid status,
+ *  or fires the rotation SMS and returns `rotated`. Lives in its own
+ *  file so the callable entry point stays under the 150-line cap
+ *  without forcing the token-decision helpers over it. */
+export async function handleSpeakerTokenExchange(
+  wardId: string,
+  invitationId: string,
+  presentedToken: string,
+): Promise<SpeakerResponse> {
+  const decision = await decideTokenAction(wardId, invitationId, presentedToken);
+  if (decision.kind === "invalid") return { status: "invalid" };
+  if (decision.kind === "rate-limited") return { status: "rate-limited" };
+  if (decision.kind === "consume") {
+    return mintSpeakerSession(wardId, invitationId);
+  }
+
+  // L2: session revoke now lives inside `decideTokenAction`'s rotate
+  // branch, so by the time we reach this code path the prior speaker
+  // session is already invalidated. Keeping the call here would just
+  // be a redundant network round-trip.
+  if (decision.speakerPhone) {
+    try {
+      const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
+      await sendInvitationSms({
+        wardId,
+        speakerPhone: decision.speakerPhone,
+        inviterName: decision.inviterName,
+        wardName: decision.wardName,
+        assignedDate: decision.assignedDate,
+        speakerName: decision.speakerName,
+        inviteUrl: buildInviteUrl(origin, wardId, invitationId, decision.newToken),
+        ...(decision.speakerTopic ? { topic: decision.speakerTopic } : {}),
+        ...(decision.fromNumberMode ? { fromMode: decision.fromNumberMode } : {}),
+      });
+    } catch (err) {
+      logger.error("rotation SMS send failed", {
+        wardId,
+        invitationId,
+        err: (err as Error).message,
+      });
+    }
+  } else {
+    logger.warn("rotation with no speakerPhone — client shows contact-bishopric fallback", {
+      wardId,
+      invitationId,
+    });
+  }
+  return { status: "rotated", phoneLast4: phoneLast4(decision.speakerPhone) };
+}
+
+async function mintSpeakerSession(
+  wardId: string,
+  invitationId: string,
+): Promise<SpeakerResponse> {
+  const uid = speakerUid(wardId, invitationId);
+  const identity = `speaker:${invitationId}`;
+  const customToken = await getAuth().createCustomToken(uid, {
+    invitationId,
+    wardId,
+    role: "speaker",
+  });
+  const twilioToken = issueChatToken({ identity, ttlSeconds: TOKEN_TTL_SECONDS });
+  return {
+    status: "ready",
+    firebaseCustomToken: customToken,
+    twilioToken,
+    identity,
+    expiresInSeconds: TOKEN_TTL_SECONDS,
+  };
+}

--- a/functions/src/issueSpeakerSession.dispatch.ts
+++ b/functions/src/issueSpeakerSession.dispatch.ts
@@ -58,10 +58,7 @@ export async function handleSpeakerTokenExchange(
   return { status: "rotated", phoneLast4: phoneLast4(decision.speakerPhone) };
 }
 
-async function mintSpeakerSession(
-  wardId: string,
-  invitationId: string,
-): Promise<SpeakerResponse> {
+async function mintSpeakerSession(wardId: string, invitationId: string): Promise<SpeakerResponse> {
   const uid = speakerUid(wardId, invitationId);
   const identity = `speaker:${invitationId}`;
   const customToken = await getAuth().createCustomToken(uid, {

--- a/functions/src/issueSpeakerSession.helpers.ts
+++ b/functions/src/issueSpeakerSession.helpers.ts
@@ -170,3 +170,4 @@ export async function revokeSpeakerSession(wardId: string, invitationId: string)
 export function speakerUid(wardId: string, invitationId: string): string {
   return `speaker:${wardId}:${invitationId}`;
 }
+

--- a/functions/src/issueSpeakerSession.helpers.ts
+++ b/functions/src/issueSpeakerSession.helpers.ts
@@ -58,10 +58,30 @@ export async function decideTokenAction(
       return { kind: "consume" };
     }
 
+    // Structured signal for alarm-able metrics. The label distinguishes
+    // a normal expired-token rotation from a presented-after-consumption
+    // event (someone tapping the same SMS link twice, or replay attempts).
+    // Cloud Logging filter: jsonPayload.event="invitation.consumed_token_presented"
+    logger.info("invitation.consumed_token_presented", {
+      event: "invitation.consumed_token_presented",
+      wardId,
+      invitationId,
+      reason: expired ? "expired" : "consumed",
+    });
+
     const bucket = rotationBucketKey(now);
     const counts = data.tokenRotationsByDay ?? {};
     const todayCount = counts[bucket] ?? 0;
     if (todayCount >= ROTATION_DAILY_CAP) {
+      // Alarm-able label: jsonPayload.event="invitation.rate_limited"
+      logger.warn("invitation.rate_limited", {
+        event: "invitation.rate_limited",
+        wardId,
+        invitationId,
+        bucket,
+        count: todayCount,
+        cap: ROTATION_DAILY_CAP,
+      });
       return { kind: "rate-limited" };
     }
 

--- a/functions/src/issueSpeakerSession.helpers.ts
+++ b/functions/src/issueSpeakerSession.helpers.ts
@@ -170,4 +170,3 @@ export async function revokeSpeakerSession(wardId: string, invitationId: string)
 export function speakerUid(wardId: string, invitationId: string): string {
   return `speaker:${wardId}:${invitationId}`;
 }
-

--- a/functions/src/issueSpeakerSession.helpers.ts
+++ b/functions/src/issueSpeakerSession.helpers.ts
@@ -67,6 +67,13 @@ export async function decideTokenAction(
 
     const newToken = generateInvitationToken();
     const newHash = hashInvitationToken(newToken);
+    // Revoke the prior speaker session inside the same transaction
+    // boundary as the rotation write. revokeRefreshTokens is idempotent,
+    // so a tx retry running it twice is harmless. Keeping the call here
+    // (rather than after `runTransaction` returns) closes the window
+    // where the new token was committed but the old session was still
+    // alive — a leaked link can't keep its session past a rotation.
+    await revokeSpeakerSession(wardId, invitationId);
     tx.update(authRef, {
       tokenHash: newHash,
       tokenStatus: "active",

--- a/functions/src/issueSpeakerSession.ts
+++ b/functions/src/issueSpeakerSession.ts
@@ -1,17 +1,14 @@
-import { getAuth } from "firebase-admin/auth";
-import { logger } from "firebase-functions/v2";
 import { HttpsError, onCall, type CallableRequest } from "firebase-functions/v2/https";
-import { STEWARD_ORIGIN, TWILIO_SECRETS } from "./secrets.js";
+import { TWILIO_SECRETS } from "./secrets.js";
 import { issueChatToken } from "./twilio/token.js";
-import { phoneLast4 } from "./invitationToken.js";
-import { buildInviteUrl, sendInvitationSms } from "./sendSpeakerInvitation.helpers.js";
-import { decideTokenAction, speakerUid } from "./issueSpeakerSession.helpers.js";
+import { handleSpeakerTokenExchange } from "./issueSpeakerSession.dispatch.js";
 import { callerIp, logRateLimited, rateLimitOk } from "./rateLimit.js";
 import {
   loadActiveMember,
   mintBishopricSession,
   type BishopricSessionResponse,
 } from "./bishopricSession.js";
+import { TOKEN_TTL_SECONDS, type SpeakerResponse } from "./issueSpeakerSession.types.js";
 
 interface Request {
   wardId: string;
@@ -24,21 +21,7 @@ interface Request {
   mintWebSession?: boolean;
 }
 
-type SpeakerResponse =
-  | {
-      status: "ready";
-      firebaseCustomToken: string;
-      twilioToken: string;
-      identity: string;
-      expiresInSeconds: number;
-    }
-  | { status: "rotated"; phoneLast4: string | null }
-  | { status: "rate-limited" }
-  | { status: "invalid" };
-
 type Response = SpeakerResponse | BishopricSessionResponse;
-
-const TOKEN_TTL_SECONDS = 3600;
 
 /** Per-IP rate limit on the speaker token-exchange surface. Combined
  *  with App Check (which blocks non-app callers entirely) this is a
@@ -123,70 +106,6 @@ function mintSpeakerRefresh(invitationId: string): SpeakerResponse {
   return {
     status: "ready",
     firebaseCustomToken: "",
-    twilioToken,
-    identity,
-    expiresInSeconds: TOKEN_TTL_SECONDS,
-  };
-}
-
-async function handleSpeakerTokenExchange(
-  wardId: string,
-  invitationId: string,
-  presentedToken: string,
-): Promise<SpeakerResponse> {
-  const decision = await decideTokenAction(wardId, invitationId, presentedToken);
-  if (decision.kind === "invalid") return { status: "invalid" };
-  if (decision.kind === "rate-limited") return { status: "rate-limited" };
-  if (decision.kind === "consume") {
-    return mintSpeakerSession(wardId, invitationId);
-  }
-
-  // L2: session revoke now lives inside `decideTokenAction`'s rotate
-  // branch, so by the time we reach this code path the prior speaker
-  // session is already invalidated. Keeping the call here would just
-  // be a redundant network round-trip.
-  if (decision.speakerPhone) {
-    try {
-      const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();
-      await sendInvitationSms({
-        wardId,
-        speakerPhone: decision.speakerPhone,
-        inviterName: decision.inviterName,
-        wardName: decision.wardName,
-        assignedDate: decision.assignedDate,
-        speakerName: decision.speakerName,
-        inviteUrl: buildInviteUrl(origin, wardId, invitationId, decision.newToken),
-        ...(decision.speakerTopic ? { topic: decision.speakerTopic } : {}),
-        ...(decision.fromNumberMode ? { fromMode: decision.fromNumberMode } : {}),
-      });
-    } catch (err) {
-      logger.error("rotation SMS send failed", {
-        wardId,
-        invitationId,
-        err: (err as Error).message,
-      });
-    }
-  } else {
-    logger.warn("rotation with no speakerPhone — client shows contact-bishopric fallback", {
-      wardId,
-      invitationId,
-    });
-  }
-  return { status: "rotated", phoneLast4: phoneLast4(decision.speakerPhone) };
-}
-
-async function mintSpeakerSession(wardId: string, invitationId: string): Promise<SpeakerResponse> {
-  const uid = speakerUid(wardId, invitationId);
-  const identity = `speaker:${invitationId}`;
-  const customToken = await getAuth().createCustomToken(uid, {
-    invitationId,
-    wardId,
-    role: "speaker",
-  });
-  const twilioToken = issueChatToken({ identity, ttlSeconds: TOKEN_TTL_SECONDS });
-  return {
-    status: "ready",
-    firebaseCustomToken: customToken,
     twilioToken,
     identity,
     expiresInSeconds: TOKEN_TTL_SECONDS,

--- a/functions/src/issueSpeakerSession.ts
+++ b/functions/src/issueSpeakerSession.ts
@@ -6,6 +6,7 @@ import { issueChatToken } from "./twilio/token.js";
 import { phoneLast4 } from "./invitationToken.js";
 import { buildInviteUrl, sendInvitationSms } from "./sendSpeakerInvitation.helpers.js";
 import { decideTokenAction, speakerUid } from "./issueSpeakerSession.helpers.js";
+import { callerIp, logRateLimited, rateLimitOk } from "./rateLimit.js";
 import {
   loadActiveMember,
   mintBishopricSession,
@@ -39,14 +40,43 @@ type Response = SpeakerResponse | BishopricSessionResponse;
 
 const TOKEN_TTL_SECONDS = 3600;
 
+/** Per-IP rate limit on the speaker token-exchange surface. Combined
+ *  with App Check (which blocks non-app callers entirely) this is a
+ *  best-effort backstop — picked to comfortably accommodate a real
+ *  speaker iterating through retries (refresh, re-tap link) while
+ *  cutting off scripted bursts. */
+const RATE_LIMIT_MAX = 30;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+/** Server-side App Check enforcement is gated by env so the operator
+ *  can ship the client-side init first, observe metrics for missing /
+ *  failing tokens, and then flip the flag once real traffic looks
+ *  healthy. Set `APP_CHECK_ENFORCED=true` on the function to enable. */
+const enforceAppCheck = process.env.APP_CHECK_ENFORCED === "true";
+
 /** Exchanges an invitation capability token for a Firebase custom
  *  token + Twilio Conversations JWT. Replaces the prior OTP-based
  *  speaker sign-in: the invitation SMS is already the identity
  *  signal, so possession of the URL token proves identity directly.
  *  Full decision tree lives in `issueSpeakerSession.helpers.ts`. */
 export const issueSpeakerSession = onCall(
-  { secrets: TWILIO_SECRETS },
+  { secrets: TWILIO_SECRETS, enforceAppCheck },
   async (request: CallableRequest<Request>): Promise<Response> => {
+    const ip = callerIp(request.rawRequest);
+    if (
+      !rateLimitOk({
+        bucketKey: `issueSpeakerSession:${ip}`,
+        max: RATE_LIMIT_MAX,
+        windowMs: RATE_LIMIT_WINDOW_MS,
+      })
+    ) {
+      logRateLimited("issueSpeakerSession", ip);
+      // Reuse the existing speaker-shape "rate-limited" status so the
+      // landing page renders its existing rate-limit UI without a
+      // separate error branch.
+      return { status: "rate-limited" } as SpeakerResponse;
+    }
+
     const { wardId, invitationId, invitationToken, mintWebSession } = request.data;
     if (!wardId) throw new HttpsError("invalid-argument", "wardId required.");
     const auth = request.auth;

--- a/functions/src/issueSpeakerSession.ts
+++ b/functions/src/issueSpeakerSession.ts
@@ -5,11 +5,7 @@ import { STEWARD_ORIGIN, TWILIO_SECRETS } from "./secrets.js";
 import { issueChatToken } from "./twilio/token.js";
 import { phoneLast4 } from "./invitationToken.js";
 import { buildInviteUrl, sendInvitationSms } from "./sendSpeakerInvitation.helpers.js";
-import {
-  decideTokenAction,
-  revokeSpeakerSession,
-  speakerUid,
-} from "./issueSpeakerSession.helpers.js";
+import { decideTokenAction, speakerUid } from "./issueSpeakerSession.helpers.js";
 import {
   loadActiveMember,
   mintBishopricSession,
@@ -115,7 +111,10 @@ async function handleSpeakerTokenExchange(
     return mintSpeakerSession(wardId, invitationId);
   }
 
-  await revokeSpeakerSession(wardId, invitationId);
+  // L2: session revoke now lives inside `decideTokenAction`'s rotate
+  // branch, so by the time we reach this code path the prior speaker
+  // session is already invalidated. Keeping the call here would just
+  // be a redundant network round-trip.
   if (decision.speakerPhone) {
     try {
       const origin = process.env.STEWARD_ORIGIN ?? STEWARD_ORIGIN.value();

--- a/functions/src/issueSpeakerSession.types.ts
+++ b/functions/src/issueSpeakerSession.types.ts
@@ -1,0 +1,18 @@
+/** Shared types + constants for the speaker token-exchange surface.
+ *  Lives in its own file so `issueSpeakerSession.ts` (the callable
+ *  entry point) and `issueSpeakerSession.helpers.ts` (the decision
+ *  helpers) can import without a circular dep. */
+
+export const TOKEN_TTL_SECONDS = 3600;
+
+export type SpeakerResponse =
+  | {
+      status: "ready";
+      firebaseCustomToken: string;
+      twilioToken: string;
+      identity: string;
+      expiresInSeconds: number;
+    }
+  | { status: "rotated"; phoneLast4: string | null }
+  | { status: "rate-limited" }
+  | { status: "invalid" };

--- a/functions/src/messageTemplates.test.ts
+++ b/functions/src/messageTemplates.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import { DEFAULT_MESSAGE_TEMPLATES } from "./messageTemplateDefaults.js";
-import { interpolate, readMessageTemplate } from "./messageTemplates.js";
+import { interpolate, neutralizeMustaches, readMessageTemplate } from "./messageTemplates.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CLIENT_DEFAULTS_PATH = resolve(
@@ -27,6 +27,29 @@ describe("interpolate", () => {
   it("preserves multi-line bodies", () => {
     const template = "line 1: {{a}}\n\nline 3: {{b}}";
     expect(interpolate(template, { a: "x", b: "y" })).toBe("line 1: x\n\nline 3: y");
+  });
+});
+
+describe("neutralizeMustaches", () => {
+  it("breaks `{{` patterns by inserting a space", () => {
+    expect(neutralizeMustaches("hello {{inviteUrl}} world")).toBe(
+      "hello { {inviteUrl}} world",
+    );
+  });
+
+  it("does not regex-match a neutralized value when re-fed to interpolate", () => {
+    const preview = neutralizeMustaches("see {{inviteUrl}}");
+    const out = interpolate("preview: {{preview}}", { preview, inviteUrl: "SECRET" });
+    expect(out).toBe("preview: see { {inviteUrl}}");
+    expect(out).not.toContain("SECRET");
+  });
+
+  it("leaves text without mustaches untouched", () => {
+    expect(neutralizeMustaches("plain text — no braces")).toBe("plain text — no braces");
+  });
+
+  it("neutralizes every occurrence", () => {
+    expect(neutralizeMustaches("{{a}} and {{b}}")).toBe("{ {a}} and { {b}}");
   });
 });
 

--- a/functions/src/messageTemplates.test.ts
+++ b/functions/src/messageTemplates.test.ts
@@ -32,9 +32,7 @@ describe("interpolate", () => {
 
 describe("neutralizeMustaches", () => {
   it("breaks `{{` patterns by inserting a space", () => {
-    expect(neutralizeMustaches("hello {{inviteUrl}} world")).toBe(
-      "hello { {inviteUrl}} world",
-    );
+    expect(neutralizeMustaches("hello {{inviteUrl}} world")).toBe("hello { {inviteUrl}} world");
   });
 
   it("does not regex-match a neutralized value when re-fed to interpolate", () => {

--- a/functions/src/messageTemplates.ts
+++ b/functions/src/messageTemplates.ts
@@ -15,6 +15,21 @@ export function interpolate(template: string, vars: Readonly<Record<string, stri
 }
 
 /**
+ * Neutralize `{{...}}` patterns inside untrusted chat content before
+ * piping it into `interpolate` as a template variable. JS `replace` is
+ * single-pass, so a `{{inviteUrl}}` substring inside a `preview` value
+ * lands as literal text today — but a future change to recursive
+ * interpolation would silently start substituting from the surrounding
+ * vars dict and could leak the rotated invite URL or other context-
+ * specific values into a chat-author-controlled position. Replacing
+ * `{{` with `{ {` (space) keeps the visible intent while breaking the
+ * regex match unconditionally.
+ */
+export function neutralizeMustaches(s: string): string {
+  return s.replace(/\{\{/g, "{ {");
+}
+
+/**
  * Fetches the body of a ward's server-side messaging template from
  * Firestore. Falls back to the hardcoded default when no doc has
  * been written yet (or when the doc is malformed). Never throws —

--- a/functions/src/onTwilioWebhook.ts
+++ b/functions/src/onTwilioWebhook.ts
@@ -81,6 +81,19 @@ export const onTwilioWebhook = onRequest(
       res.status(200).send("no-match");
       return;
     }
+    if (!conversationWardIdMatches(req, invitation)) {
+      // Defensive cross-tenant check: the conversation SID came from
+      // Twilio (signature-verified), but the wardId we route on came
+      // from Firestore. If Twilio reports `ConversationAttributes` and
+      // its `wardId` disagrees with the Firestore-derived wardId, we
+      // refuse to fan out — somebody has the wrong record.
+      logger.warn("conversation wardId mismatch — ignoring", {
+        conversationSid,
+        derivedWardId: invitation.wardId,
+      });
+      res.status(200).send("wardId-mismatch");
+      return;
+    }
     if (isExpired(invitation)) {
       res.status(200).send("expired");
       return;
@@ -167,4 +180,25 @@ async function findInvitationByConversation(
 function isExpired(inv: ResolvedInvitation): boolean {
   if (!inv.expiresAt) return false;
   return inv.expiresAt.toMillis() <= Date.now();
+}
+
+/** Cross-check the wardId Twilio reports on `ConversationAttributes`
+ *  against the wardId we derived from the Firestore lookup. Twilio
+ *  Conversations post-webhooks include the conversation-level
+ *  attributes JSON we set at create time
+ *  (`{ wardId, speakerId }`). When the field is present and matches,
+ *  we proceed. When it's absent (older conversations, or a Twilio
+ *  webhook config that opts out) we proceed too — falling back to
+ *  the Firestore-derived wardId, the prior behaviour. We only refuse
+ *  when both are present and disagree. */
+function conversationWardIdMatches(req: Request, inv: ResolvedInvitation): boolean {
+  const raw = (req.body?.ConversationAttributes ?? "") as string;
+  if (!raw) return true;
+  try {
+    const parsed = JSON.parse(raw) as { wardId?: unknown };
+    if (typeof parsed.wardId !== "string") return true;
+    return parsed.wardId === inv.wardId;
+  } catch {
+    return true;
+  }
 }

--- a/functions/src/rateLimit.ts
+++ b/functions/src/rateLimit.ts
@@ -1,0 +1,74 @@
+import { logger } from "firebase-functions/v2";
+
+/** In-memory per-IP token-bucket rate limiter. Fluid Compute reuses
+ *  function instances across concurrent requests, so this map persists
+ *  across invocations on the same instance. Spread across instances
+ *  the limit is per-instance (effectively higher), but combined with
+ *  App Check enforcement that's an acceptable tradeoff: App Check is
+ *  the primary defense; this is a best-effort backstop against abuse
+ *  bursts that slip through. */
+const buckets = new Map<string, { count: number; resetAt: number }>();
+
+export interface RateLimitInput {
+  bucketKey: string;
+  /** Max attempts allowed in the rolling window. */
+  max: number;
+  /** Window length in milliseconds. */
+  windowMs: number;
+}
+
+/** Returns true when the call is within the limit, false when it
+ *  should be rejected. Bumps the counter on each allowed call. */
+export function rateLimitOk(input: RateLimitInput): boolean {
+  const now = Date.now();
+  evictExpired(now);
+  const entry = buckets.get(input.bucketKey);
+  if (!entry || entry.resetAt <= now) {
+    buckets.set(input.bucketKey, { count: 1, resetAt: now + input.windowMs });
+    return true;
+  }
+  if (entry.count >= input.max) return false;
+  entry.count += 1;
+  return true;
+}
+
+/** Trim entries past their reset time so the map can't grow unbounded
+ *  on a long-lived warm instance. Cheap because we only walk when at
+ *  least N entries have accumulated. */
+function evictExpired(now: number): void {
+  if (buckets.size < 256) return;
+  for (const [key, entry] of buckets) {
+    if (entry.resetAt <= now) buckets.delete(key);
+  }
+}
+
+/** Pull the caller IP from a Cloud Functions v2 callable request.
+ *  Cloud Run sets `x-forwarded-for` with the real client IP as the
+ *  first hop. Falls back to `req.ip` (Express's resolution) and
+ *  finally to a literal so the bucket key is never empty. */
+export function callerIp(rawRequest: {
+  ip?: string | undefined;
+  headers?: Record<string, string | string[] | undefined> | undefined;
+}): string {
+  const xff = rawRequest.headers?.["x-forwarded-for"];
+  if (typeof xff === "string" && xff.length > 0) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  if (Array.isArray(xff) && xff.length > 0 && xff[0]) {
+    const first = xff[0].split(",")[0]?.trim();
+    if (first) return first;
+  }
+  return rawRequest.ip || "unknown";
+}
+
+/** Emit the same alarm-able label PR-14 added to the rotation rate
+ *  limit so a single Cloud Logging metric can cover both surfaces. */
+export function logRateLimited(scope: string, ip: string, extra?: Record<string, unknown>): void {
+  logger.warn("invitation.rate_limited", {
+    event: "invitation.rate_limited",
+    scope,
+    ip,
+    ...extra,
+  });
+}

--- a/functions/src/rotateInvitationLink.ts
+++ b/functions/src/rotateInvitationLink.ts
@@ -1,6 +1,6 @@
 import { FieldValue, getFirestore } from "firebase-admin/firestore";
 import { HttpsError } from "firebase-functions/v2/https";
-import { authInvitationPath, loadMergedInvitation, updateAuth } from "./invitationDocs.js";
+import { authInvitationPath, txGetMerged } from "./invitationDocs.js";
 import { revokeSpeakerSession } from "./issueSpeakerSession.helpers.js";
 import { buildInviteUrl, tryEmail, trySms } from "./sendSpeakerInvitation.helpers.js";
 import { generateInvitationToken, hashInvitationToken } from "./invitationToken.js";
@@ -25,50 +25,62 @@ export async function rotateInvitationLink(
   origin: string,
 ): Promise<RotateInvitationResponse> {
   const db = getFirestore();
-  const invitation = await loadMergedInvitation(db, input.wardId, input.invitationId);
-  if (!invitation) throw new HttpsError("not-found", "Invitation not found.");
-  const expiresAtMillis = invitation.expiresAt?.toMillis();
-  if (typeof expiresAtMillis === "number" && expiresAtMillis < Date.now()) {
-    throw new HttpsError(
-      "failed-precondition",
-      "Invitation has expired — start a fresh one instead.",
-    );
-  }
-
   const plaintextToken = generateInvitationToken();
   const tokenHash = hashInvitationToken(plaintextToken);
 
-  // Refresh the speakerEmail + speakerPhone snapshot from the live
-  // speaker doc before we build the delivery payload. Without this,
-  // a bishop correcting a typo in the speaker's phone number and then
-  // hitting Resend would still deliver to the stale number on the
-  // invitation doc. The rest of the letter (name, date, wardName,
-  // inviterName) stays frozen — only delivery channels refresh.
-  const liveContact =
-    input.channels.length > 0 ? await readLiveContactInfo(db, input.wardId, invitation) : null;
-  const writePatch = liveContact ? contactWritePatch(liveContact) : {};
-  const effectiveContact: Pick<SpeakerInvitationShape, "speakerEmail" | "speakerPhone"> =
-    liveContact ?? {
-      ...(invitation.speakerEmail ? { speakerEmail: invitation.speakerEmail } : {}),
-      ...(invitation.speakerPhone ? { speakerPhone: invitation.speakerPhone } : {}),
-    };
+  // Single transaction: read invitation, validate not expired, refresh
+  // contact snapshot from the live speaker doc, revoke any prior
+  // speaker session, and commit the rotation. revokeRefreshTokens is
+  // idempotent so a tx retry is safe. Putting the revoke inside the
+  // tx boundary closes the window where the new token was committed
+  // but the old session was still alive.
+  const { invitation, effectiveContact } = await db.runTransaction(async (tx) => {
+    const { authRef, data } = await txGetMerged(db, tx, input.wardId, input.invitationId);
+    if (!data) throw new HttpsError("not-found", "Invitation not found.");
+    const expiresAtMillis = data.expiresAt?.toMillis();
+    if (typeof expiresAtMillis === "number" && expiresAtMillis < Date.now()) {
+      throw new HttpsError(
+        "failed-precondition",
+        "Invitation has expired — start a fresh one instead.",
+      );
+    }
 
-  // C1 doc-split: token state + speaker contact PII are on the auth
-  // subdoc now; this whole rotation patch goes to that doc.
-  await updateAuth(db, input.wardId, input.invitationId, {
-    tokenHash,
-    tokenStatus: "active" as const,
-    ...writePatch,
+    // Refresh the speakerEmail + speakerPhone snapshot from the live
+    // speaker doc before we build the delivery payload. Without this,
+    // a bishop correcting a typo in the speaker's phone number and then
+    // hitting Resend would still deliver to the stale number on the
+    // invitation doc. The rest of the letter (name, date, wardName,
+    // inviterName) stays frozen — only delivery channels refresh. Read
+    // is `tx.get` so the live contact lock-step matches the rotation.
+    const liveContact =
+      input.channels.length > 0
+        ? await readLiveContactInfo(db, tx, input.wardId, data)
+        : null;
+    const writePatch = liveContact ? contactWritePatch(liveContact) : {};
+    const effective: Pick<SpeakerInvitationShape, "speakerEmail" | "speakerPhone"> =
+      liveContact ?? {
+        ...(data.speakerEmail ? { speakerEmail: data.speakerEmail } : {}),
+        ...(data.speakerPhone ? { speakerPhone: data.speakerPhone } : {}),
+      };
+
+    // L2: revoke before tx.update so the prior session can't outlive
+    // the rotation commit. Same rationale as decideTokenAction's
+    // rotate branch — see issueSpeakerSession.helpers.ts.
+    // Distinct from rotateTokenForBishopNotification, which
+    // intentionally doesn't revoke (the speaker may be actively in
+    // chat there).
+    await revokeSpeakerSession(input.wardId, input.invitationId);
+
+    // C1 doc-split: token state + speaker contact PII are on the auth
+    // subdoc now; this whole rotation patch goes to that doc.
+    tx.update(authRef, {
+      tokenHash,
+      tokenStatus: "active" as const,
+      ...writePatch,
+    });
+
+    return { invitation: data, effectiveContact: effective };
   });
-
-  // A new token means any session minted from the prior token is no
-  // longer the source of truth for this invitation. Revoke the
-  // speaker's refresh tokens so the next ID-token refresh forces them
-  // back through the issueSpeakerSession exchange — only the speaker
-  // tapping the freshly-delivered URL can recover a working session.
-  // Distinct from rotateTokenForBishopNotification, which intentionally
-  // doesn't revoke (the speaker may be actively in chat there).
-  await revokeSpeakerSession(input.wardId, input.invitationId);
 
   const inviteUrl = buildInviteUrl(origin, input.wardId, input.invitationId, plaintextToken);
   const freshInvitation: SpeakerInvitationShape = { ...invitation, ...effectiveContact };
@@ -89,12 +101,13 @@ interface LiveContact {
 
 async function readLiveContactInfo(
   db: FirebaseFirestore.Firestore,
+  tx: FirebaseFirestore.Transaction,
   wardId: string,
   invitation: SpeakerInvitationShape,
 ): Promise<LiveContact | null> {
   const { meetingDate, speakerId } = invitation.speakerRef;
   const speakerRef = db.doc(`wards/${wardId}/meetings/${meetingDate}/speakers/${speakerId}`);
-  const snap = await speakerRef.get();
+  const snap = await tx.get(speakerRef);
   if (!snap.exists) return null;
   const speaker = snap.data() as { email?: string; phone?: string };
   const out: LiveContact = {};

--- a/functions/src/rotateInvitationLink.ts
+++ b/functions/src/rotateInvitationLink.ts
@@ -53,9 +53,7 @@ export async function rotateInvitationLink(
     // inviterName) stays frozen — only delivery channels refresh. Read
     // is `tx.get` so the live contact lock-step matches the rotation.
     const liveContact =
-      input.channels.length > 0
-        ? await readLiveContactInfo(db, tx, input.wardId, data)
-        : null;
+      input.channels.length > 0 ? await readLiveContactInfo(db, tx, input.wardId, data) : null;
     const writePatch = liveContact ? contactWritePatch(liveContact) : {};
     const effective: Pick<SpeakerInvitationShape, "speakerEmail" | "speakerPhone"> =
       liveContact ?? {

--- a/functions/src/sendSpeakerInvitation.helpers.ts
+++ b/functions/src/sendSpeakerInvitation.helpers.ts
@@ -1,7 +1,7 @@
 import { getFirestore } from "firebase-admin/firestore";
 import { HttpsError } from "firebase-functions/v2/https";
 import { logger } from "firebase-functions/v2";
-import { addChatParticipant, deleteConversation } from "./twilio/conversations.js";
+import { addChatParticipant, closeConversation } from "./twilio/conversations.js";
 import type { SpeakerInvitationShape } from "./invitationTypes.js";
 import type { MemberDoc } from "./types.js";
 
@@ -60,11 +60,13 @@ export async function addBishopricParticipants(
   return added;
 }
 
-/** Deletes any Twilio Conversation tied to a previous invitation for
+/** Archives any Twilio Conversation tied to a previous invitation for
  *  the same (wardId, speakerId, meetingDate). Hygiene for re-sends:
- *  prevents orphan conversations from accumulating in the Conversations
- *  service when a bishop replaces an invitation. Failures per-SID are
- *  logged and swallowed so one stale SID doesn't block the rest. */
+ *  prevents orphan conversations from accepting new messages while
+ *  preserving the prior thread for audit. Closed conversations stay
+ *  visible in the Twilio Console (prefixed with `[archived]`) but
+ *  reject new messages. Failures per-SID are logged and swallowed so
+ *  one stale SID doesn't block the rest. */
 export async function cleanupPriorConversations(
   wardId: string,
   speakerId: string,
@@ -80,9 +82,9 @@ export async function cleanupPriorConversations(
     .filter((s): s is string => Boolean(s));
   for (const sid of sids) {
     try {
-      await deleteConversation(sid);
+      await closeConversation(sid);
     } catch (err) {
-      logger.warn("failed to delete prior conversation", { sid, err: (err as Error).message });
+      logger.warn("failed to archive prior conversation", { sid, err: (err as Error).message });
     }
   }
 }

--- a/functions/src/twilio/conversations.ts
+++ b/functions/src/twilio/conversations.ts
@@ -74,13 +74,33 @@ export interface PostMessageInput {
   attributes?: Record<string, unknown>;
 }
 
-/** Hard-deletes a Twilio Conversation by SID. Used by
- *  `cleanupPriorConversations` to remove orphan conversations from
- *  prior re-sends for the same speaker+date so they don't accumulate
- *  in the Conversations service. Safe to call on an already-deleted
- *  SID: Twilio returns 404 which we let bubble. */
+/** Hard-deletes a Twilio Conversation by SID. Retained for explicit
+ *  full-purge use cases (none in the current code path — see
+ *  `closeConversation` for the resend-cleanup path). Safe to call on
+ *  an already-deleted SID: Twilio returns 404 which we let bubble. */
 export async function deleteConversation(conversationSid: string): Promise<void> {
   await service().conversations(conversationSid).remove();
+}
+
+/** Archive a Twilio Conversation: set its `state` to `closed` and
+ *  prefix the friendly name with `[archived]`. Closed conversations
+ *  stop accepting new messages but the history remains in the
+ *  Conversations service for audit purposes. Used by
+ *  `cleanupPriorConversations` so a re-send doesn't destroy the
+ *  prior thread — the speaker (in their fresh invitation) sees a new
+ *  conversation under a new SID, while bishopric record-keeping
+ *  retains the closed thread. */
+export async function closeConversation(conversationSid: string): Promise<void> {
+  const convo = service().conversations(conversationSid);
+  // Fetch the current friendlyName so we can prefix it idempotently
+  // (avoids `[archived] [archived] ...` if cleanup runs twice for any
+  // reason, e.g. retry).
+  const current = await convo.fetch();
+  const prefix = "[archived] ";
+  const friendlyName = current.friendlyName?.startsWith(prefix)
+    ? current.friendlyName
+    : `${prefix}${current.friendlyName ?? ""}`.trim();
+  await convo.update({ state: "closed", friendlyName });
 }
 
 export async function postMessage(input: PostMessageInput): Promise<string> {

--- a/src/features/invitations/utils/invitationActions.ts
+++ b/src/features/invitations/utils/invitationActions.ts
@@ -125,7 +125,13 @@ export async function applyResponseToSpeaker(input: ApplyResponseInput): Promise
     if (isPrayer) {
       const role = parentData.speakerRef.speakerId;
       const meetingField = role === "opening" ? "openingPrayer" : "benediction";
-      const meetingRef = doc(db, "wards", input.wardId, "meetings", parentData.speakerRef.meetingDate);
+      const meetingRef = doc(
+        db,
+        "wards",
+        input.wardId,
+        "meetings",
+        parentData.speakerRef.meetingDate,
+      );
       tx.set(
         meetingRef,
         { [meetingField]: { confirmed: newStatus === "confirmed" } },

--- a/src/features/invitations/utils/invitationActions.ts
+++ b/src/features/invitations/utils/invitationActions.ts
@@ -1,4 +1,4 @@
-import { doc, getDoc, serverTimestamp, writeBatch } from "firebase/firestore";
+import { doc, runTransaction, serverTimestamp, writeBatch } from "firebase/firestore";
 import { db, inviteDb } from "@/lib/firebase";
 
 export interface SpeakerResponseInput {
@@ -50,9 +50,13 @@ export interface ApplyResponseInput {
 
 /** Bishop-side: applies the participant's response to their status
  *  doc (confirmed for yes, declined for no) and stamps the
- *  invitation's acknowledgement. Batched so either both writes land
- *  or neither. Routes through the main `db` (bishopric Google
- *  session).
+ *  invitation's acknowledgement. Wrapped in a Firestore transaction
+ *  so the response read and the participant + auth-subdoc writes are
+ *  atomic — concurrent applies (two bishopric tabs / racing devices)
+ *  can't both pass the "no answer" check and double-write, and a
+ *  speaker response landing mid-apply can't leave participant.status
+ *  out of sync with auth.response. Routes through the main `db`
+ *  (bishopric Google session).
  *
  *  Kind-aware: the invitation doc carries `kind: "speaker" | "prayer"`
  *  (PR #169). Speakers update their doc at `meetings/{date}/speakers/
@@ -62,67 +66,71 @@ export interface ApplyResponseInput {
 export async function applyResponseToSpeaker(input: ApplyResponseInput): Promise<void> {
   const invitationRef = doc(db, "wards", input.wardId, "speakerInvitations", input.invitationId);
   const authRef = doc(invitationRef, "private", "auth");
-  const [parentSnap, authSnap] = await Promise.all([getDoc(invitationRef), getDoc(authRef)]);
-  if (!parentSnap.exists()) throw new Error("Invitation not found.");
-  const parentData = parentSnap.data() as {
-    speakerRef: { meetingDate: string; speakerId: string };
-    kind?: "speaker" | "prayer";
-    responseSummary?: { answer: "yes" | "no" };
-  };
-  const authData = (authSnap.exists() ? authSnap.data() : null) as {
-    response?: { answer: "yes" | "no" };
-  } | null;
-  // Read response from auth subdoc; fall back to the public summary
-  // (and pre-migration `response` on parent) so apply still works
-  // mid-migration.
-  const answer = authData?.response?.answer ?? parentData.responseSummary?.answer;
-  if (!answer) throw new Error("No response to apply.");
-  const data = parentData;
+  await runTransaction(db, async (tx) => {
+    const [parentSnap, authSnap] = await Promise.all([tx.get(invitationRef), tx.get(authRef)]);
+    if (!parentSnap.exists()) throw new Error("Invitation not found.");
+    const parentData = parentSnap.data() as {
+      speakerRef: { meetingDate: string; speakerId: string };
+      kind?: "speaker" | "prayer";
+      responseSummary?: { answer: "yes" | "no" };
+    };
+    const authData = (authSnap.exists() ? authSnap.data() : null) as {
+      response?: { answer: "yes" | "no"; acknowledgedAt?: unknown };
+    } | null;
+    // Read response from auth subdoc; fall back to the public summary
+    // (and pre-migration `response` on parent) so apply still works
+    // mid-migration.
+    const answer = authData?.response?.answer ?? parentData.responseSummary?.answer;
+    if (!answer) throw new Error("No response to apply.");
+    if (authData?.response?.acknowledgedAt) {
+      // Already applied by another bishopric session — short-circuit.
+      // Without this, a racing apply would re-stamp acknowledgedAt and
+      // re-overwrite participant.status with possibly-stale data.
+      return;
+    }
 
-  const newStatus: "confirmed" | "declined" = answer === "yes" ? "confirmed" : "declined";
-  const isPrayer = data.kind === "prayer";
-  const subcollection = isPrayer ? "prayers" : "speakers";
-  const participantRef = doc(
-    db,
-    "wards",
-    input.wardId,
-    "meetings",
-    data.speakerRef.meetingDate,
-    subcollection,
-    data.speakerRef.speakerId,
-  );
-
-  const batch = writeBatch(db);
-  // Acknowledgement audit lives on the auth subdoc with the rest of
-  // the response object; only the answer + respondedAt mirror to the
-  // public parent.
-  batch.update(authRef, {
-    "response.acknowledgedAt": serverTimestamp(),
-    "response.acknowledgedBy": input.bishopUid,
-  });
-  batch.update(participantRef, {
-    status: newStatus,
-    statusSource: "speaker-response",
-    statusSetBy: input.bishopUid,
-    statusSetAt: serverTimestamp(),
-  });
-
-  // Prayer kind also mirrors `confirmed` onto the inline meeting
-  // assignment row so the printed program template (which reads
-  // `meeting.openingPrayer` / `meeting.benediction`, not the
-  // participant doc) stays in sync. Speakers don't carry an inline
-  // `confirmed` mirror — their schedule pill reads the speaker doc
-  // directly.
-  if (isPrayer) {
-    const role = data.speakerRef.speakerId;
-    const meetingField = role === "opening" ? "openingPrayer" : "benediction";
-    const meetingRef = doc(db, "wards", input.wardId, "meetings", data.speakerRef.meetingDate);
-    batch.set(
-      meetingRef,
-      { [meetingField]: { confirmed: newStatus === "confirmed" } },
-      { merge: true },
+    const newStatus: "confirmed" | "declined" = answer === "yes" ? "confirmed" : "declined";
+    const isPrayer = parentData.kind === "prayer";
+    const subcollection = isPrayer ? "prayers" : "speakers";
+    const participantRef = doc(
+      db,
+      "wards",
+      input.wardId,
+      "meetings",
+      parentData.speakerRef.meetingDate,
+      subcollection,
+      parentData.speakerRef.speakerId,
     );
-  }
 
-  await batch.commit();
+    // Acknowledgement audit lives on the auth subdoc with the rest of
+    // the response object; only the answer + respondedAt mirror to the
+    // public parent.
+    tx.update(authRef, {
+      "response.acknowledgedAt": serverTimestamp(),
+      "response.acknowledgedBy": input.bishopUid,
+    });
+    tx.update(participantRef, {
+      status: newStatus,
+      statusSource: "speaker-response",
+      statusSetBy: input.bishopUid,
+      statusSetAt: serverTimestamp(),
+    });
+
+    // Prayer kind also mirrors `confirmed` onto the inline meeting
+    // assignment row so the printed program template (which reads
+    // `meeting.openingPrayer` / `meeting.benediction`, not the
+    // participant doc) stays in sync. Speakers don't carry an inline
+    // `confirmed` mirror — their schedule pill reads the speaker doc
+    // directly.
+    if (isPrayer) {
+      const role = parentData.speakerRef.speakerId;
+      const meetingField = role === "opening" ? "openingPrayer" : "benediction";
+      const meetingRef = doc(db, "wards", input.wardId, "meetings", parentData.speakerRef.meetingDate);
+      tx.set(
+        meetingRef,
+        { [meetingField]: { confirmed: newStatus === "confirmed" } },
+        { merge: true },
+      );
+    }
+  });
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,9 +1,5 @@
 import { initializeApp, type FirebaseApp } from "firebase/app";
-import {
-  initializeAppCheck,
-  ReCaptchaEnterpriseProvider,
-  type AppCheck,
-} from "firebase/app-check";
+import { initializeAppCheck, ReCaptchaEnterpriseProvider, type AppCheck } from "firebase/app-check";
 import { getAuth, connectAuthEmulator, type Auth } from "firebase/auth";
 import { getFirestore, connectFirestoreEmulator, type Firestore } from "firebase/firestore";
 import { connectFunctionsEmulator, getFunctions, type Functions } from "firebase/functions";

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,4 +1,9 @@
 import { initializeApp, type FirebaseApp } from "firebase/app";
+import {
+  initializeAppCheck,
+  ReCaptchaEnterpriseProvider,
+  type AppCheck,
+} from "firebase/app-check";
 import { getAuth, connectAuthEmulator, type Auth } from "firebase/auth";
 import { getFirestore, connectFirestoreEmulator, type Firestore } from "firebase/firestore";
 import { connectFunctionsEmulator, getFunctions, type Functions } from "firebase/functions";
@@ -67,6 +72,29 @@ if (import.meta.env.VITE_USE_EMULATORS === "true") {
   connectEmulators(auth, db, functions);
   connectEmulators(inviteAuth, inviteDb, inviteFunctions);
 }
+
+/** App Check initialization — gated on env var so dev/emulator and
+ *  any environment without a configured reCAPTCHA Enterprise key
+ *  continues to work unchanged. Once the operator provisions the key
+ *  in the Firebase Console and sets `VITE_FIREBASE_APPCHECK_SITE_KEY`
+ *  on Vercel, both Firebase apps (main + invite) start attaching App
+ *  Check tokens to all callable / Firestore / FCM requests, blocking
+ *  abuse from non-app sources at the edge. The server-side enforcement
+ *  knob lives on the callable itself (`APP_CHECK_ENFORCED`). */
+const appCheckSiteKey = import.meta.env.VITE_FIREBASE_APPCHECK_SITE_KEY as string | undefined;
+let appCheck: AppCheck | undefined;
+let inviteAppCheck: AppCheck | undefined;
+if (appCheckSiteKey && import.meta.env.VITE_USE_EMULATORS !== "true") {
+  appCheck = initializeAppCheck(app, {
+    provider: new ReCaptchaEnterpriseProvider(appCheckSiteKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+  inviteAppCheck = initializeAppCheck(inviteApp, {
+    provider: new ReCaptchaEnterpriseProvider(appCheckSiteKey),
+    isTokenAutoRefreshEnabled: true,
+  });
+}
+export { appCheck, inviteAppCheck };
 
 let messagingPromise: Promise<Messaging | null> | null = null;
 

--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,17 @@
     {
       "source": "/assets/(.*)",
       "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }]
+    },
+    {
+      "source": "/invite/speaker/(.*)",
+      "headers": [
+        { "key": "Referrer-Policy", "value": "no-referrer" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        {
+          "key": "Content-Security-Policy-Report-Only",
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com https://*.googleapis.com https://www.google.com https://www.google.com/recaptcha/ https://www.recaptcha.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; connect-src 'self' https://*.firebaseio.com https://*.googleapis.com https://*.firebaseapp.com https://firebaseinstallations.googleapis.com https://identitytoolkit.googleapis.com https://firestore.googleapis.com wss://*.firebaseio.com https://*.cloudfunctions.net https://*.run.app https://mcs.us1.twilio.com wss://tsock.us1.twilio.com https://media.twiliocdn.com; frame-src 'self' https://www.google.com https://recaptcha.google.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bundled remediation PR covering the remaining items from the 2026-05-01 audit queue. Eight findings, one PR, one commit per fix:

| Commit | Severity | Audit ref | What changed |
|--------|----------|-----------|--------------|
| `fix(security/m1)` | Medium | M1 | Wrap bishop **Apply** in a Firestore transaction; short-circuit when `acknowledgedAt` already stamped |
| `fix(security/m2)` | Medium | M2 | Neutralize `{{...}}` in chat preview before piping into `interpolate` |
| `fix(security/m6)` | Medium | M6 | Cross-check `wardId` from Twilio `ConversationAttributes` against the Firestore-derived value |
| `chore(security/m7,l1)` | Med + Low | M7, L1 | `Referrer-Policy: no-referrer`, `X-Frame-Options: DENY`, CSP report-only on `/invite/speaker/*` |
| `fix(security/l2)` | Low | L2 | Move `revokeSpeakerSession` inside the rotation transaction (both visitor- and bishop-driven paths) |
| `fix(security/l3)` | Low | L3 | Archive (close) prior Twilio Conversations on resend instead of hard-delete |
| `chore(security/l5)` | Low | L5 | Structured `invitation.consumed_token_presented` + `invitation.rate_limited` logs for alarm metrics |
| `feat(security/h4)` | High | H4 | App Check init (web, gated on `VITE_FIREBASE_APPCHECK_SITE_KEY`) + per-IP rate limit on `issueSpeakerSession`; server-side enforcement gated on `APP_CHECK_ENFORCED` |
| `refactor(security/h4)` | — | — | Split `issueSpeakerSession.ts` into `.dispatch.ts` + `.types.ts` to keep every file under the 150-LOC cap |
| `chore(security)` | — | — | Biome formatting pass |

PR-11 (C1, the Critical doc-split) shipped earlier in v0.21.0 (#230) — that's why the queue is now Mediums + one High + Lows.

## Operator follow-ups added by this PR

- **PR-10 (App Check)** — provision a reCAPTCHA Enterprise site key in Firebase Console → App Check → Apps → Web. Set `VITE_FIREBASE_APPCHECK_SITE_KEY` on Vercel (Production + Preview). After ~1 week of healthy `appCheckTokenInvalid` / `appCheckTokenMissing` metrics, set `APP_CHECK_ENFORCED=true` on the function and redeploy.
- **PR-14 (alarms)** — create Cloud Logging metrics filtering on `jsonPayload.event="invitation.consumed_token_presented"` and `jsonPayload.event="invitation.rate_limited"`, then attach Cloud Monitoring alerts.

## Verification

- `pnpm typecheck` ✓ (root + functions)
- `pnpm lint` ✓ — 0 errors
- `pnpm format:check` ✓
- `pnpm test` ✓ — 453 web tests pass
- `pnpm --dir functions exec vitest run` ✓ — 108 functions tests pass (added `neutralizeMustaches` coverage)
- Rules tests ✓ — 110 pass against the running emulator

## Test plan

- [ ] Speaker landing page still loads in dev (App Check unset → no init → unchanged)
- [ ] Bishop Apply still flips a speaker's status to `confirmed` / `declined`
- [ ] Bishop posts in chat → speaker SMS preview no longer expands `{{inviteUrl}}` if the bishop literally types it
- [ ] Resend invitation in dev: prior Twilio Conversation visible in Console as `[archived] …`, new one created
- [ ] Visit `/invite/speaker/...` and inspect response headers (`Referrer-Policy`, `X-Frame-Options`, `Content-Security-Policy-Report-Only`)
- [ ] Hit `issueSpeakerSession` from the same IP > 30 times in 60s → `{ status: "rate-limited" }`
- [ ] Twilio webhook with mismatched `ConversationAttributes.wardId` → 200 `wardId-mismatch`, no fan-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)