### PR TITLE
Release: v0.21.2 — countdown precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.21.2] — 2026-05-03
+
+Patch release: precision tweak to the schedule countdown labels.
+
+### Fixed
+
+- **Schedule countdown is precise instead of round-up.** `formatCountdown` previously called `Math.ceil(daysUntil / 7)`, so 8 days showed "In 2 weeks" and 17 days showed "In 3 weeks". It now floors the week count and surfaces the remainder, producing copy like "In 1 week and 1 day" and "In 2 weeks and 3 days". Both formatters anchor to local-midnight so DST shifts and late-night composition don't pull a result across a day boundary. Verbose copy on the desktop `SundayCardHeader` and `SundayTypeMenu`; a new compact form ("In 2w 3d") is wired into `MobileSundayBlock` so the tighter mobile header stays one line. (#236)
+
 ## [0.21.1] — 2026-05-02
 
 Bundled remediation release for the remaining items from the 2026-05-01 invitation-flow audit. PR #233 lands eight findings as separate commits — one High, four Medium, three Low — alongside the audit's Critical (already shipped in v0.21.0). Behaviour-preserving for normal flows; rate-limited callers and `[archived]` Twilio Conversations are the only user-observable surface changes. App Check is wired but gated on operator-side env vars so this release ships in observe-only mode.
@@ -2512,7 +2520,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.21.2...HEAD
+[0.21.2]: https://github.com/aylabyuk/steward/releases/tag/v0.21.2
 [0.21.1]: https://github.com/aylabyuk/steward/releases/tag/v0.21.1
 [0.21.0]: https://github.com/aylabyuk/steward/releases/tag/v0.21.0
 [0.20.1]: https://github.com/aylabyuk/steward/releases/tag/v0.20.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.21.1",
+  "version": "0.21.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/features/schedule/MobileSundayBlock.tsx
+++ b/src/features/schedule/MobileSundayBlock.tsx
@@ -4,7 +4,7 @@ import type { MeetingType, NonMeetingSunday, SacramentMeeting } from "@/lib/type
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { cn } from "@/lib/cn";
 import { kindLabel, type KindVariant } from "./utils/kindLabel";
-import { formatCountdown } from "./utils/dateFormat";
+import { formatCountdownCompact } from "./utils/dateFormat";
 import { MobileSundayHeader } from "./MobileSundayHeader";
 import { MobileSundayHeroSummary } from "./MobileSundayHeroSummary";
 import { SundayCardSpecial } from "./SundayCardSpecial";
@@ -46,7 +46,7 @@ export function MobileSundayBlock({
   const { data: speakers } = useSpeakers(date);
   const urgent = leadTimeSeverity(new Date(), date, leadTimeDays) === "urgent";
   const hasConfirmedSpeaker = speakers.some((s) => s.data.status === "confirmed");
-  const countdown = cancelled ? "Cancelled" : formatCountdown(date);
+  const countdown = cancelled ? "Cancelled" : formatCountdownCompact(date);
 
   return (
     <article

--- a/src/features/schedule/utils/__tests__/dateFormat.test.ts
+++ b/src/features/schedule/utils/__tests__/dateFormat.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { formatCountdown, formatCountdownCompact } from "../dateFormat";
+
+// Anchor "today" to a fixed local-midnight Sunday so the date-math
+// branches are deterministic regardless of when CI runs.
+const TODAY = new Date(2026, 4, 3); // 2026-05-03, Sunday
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(TODAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("formatCountdown (verbose)", () => {
+  it.each([
+    ["2026-05-02", "Past"],
+    ["2026-05-03", "Today"],
+    ["2026-05-04", "In 1 day"],
+    ["2026-05-09", "In 6 days"],
+    ["2026-05-10", "In 1 week"],
+    ["2026-05-11", "In 1 week and 1 day"],
+    ["2026-05-17", "In 2 weeks"],
+    ["2026-05-20", "In 2 weeks and 3 days"],
+    ["2026-05-24", "In 3 weeks"],
+    ["2026-05-25", "In 3 weeks and 1 day"],
+  ])("%s -> %s", (iso, expected) => {
+    expect(formatCountdown(iso)).toBe(expected);
+  });
+
+  it("returns the raw string for unparseable input", () => {
+    expect(formatCountdown("not-a-date")).toBe("not-a-date");
+  });
+});
+
+describe("formatCountdownCompact", () => {
+  it.each([
+    ["2026-05-02", "Past"],
+    ["2026-05-03", "Today"],
+    ["2026-05-04", "In 1d"],
+    ["2026-05-09", "In 6d"],
+    ["2026-05-10", "In 1w"],
+    ["2026-05-11", "In 1w 1d"],
+    ["2026-05-17", "In 2w"],
+    ["2026-05-20", "In 2w 3d"],
+    ["2026-05-24", "In 3w"],
+  ])("%s -> %s", (iso, expected) => {
+    expect(formatCountdownCompact(iso)).toBe(expected);
+  });
+});

--- a/src/features/schedule/utils/dateFormat.ts
+++ b/src/features/schedule/utils/dateFormat.ts
@@ -37,16 +37,47 @@ export function formatSundayOrdinal(iso: string): string {
   return `${ordinal}${suffix} Sunday`;
 }
 
-export function formatCountdown(iso: string): string {
+/** Whole-day delta from today's midnight to the event's midnight.
+ *  Both sides anchor to local-midnight so DST shifts and "started
+ *  composing at 11:59pm" don't pull a result across day boundaries.
+ *  Returns null if the ISO string can't be parsed. */
+function daysUntil(iso: string): number | null {
   const [y, m, d] = iso.split("-").map(Number);
-  if (!y || !m || !d) return iso;
-  const eventDate = new Date(y, m - 1, d);
-  const today = new Date();
-  const daysUntil = Math.ceil((eventDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
-  if (daysUntil < 0) return "Past";
-  if (daysUntil === 0) return "Today";
-  if (daysUntil === 1) return "In 1 day";
-  if (daysUntil <= 7) return `In ${daysUntil} days`;
-  const weeks = Math.ceil(daysUntil / 7);
-  return `In ${weeks} week${weeks > 1 ? "s" : ""}`;
+  if (!y || !m || !d) return null;
+  const event = new Date(y, m - 1, d).getTime();
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  return Math.round((event - today) / (1000 * 60 * 60 * 24));
+}
+
+/** Verbose countdown for desktop card headers + the type menu, where
+ *  precision earns its keep ("In 2 weeks and 3 days" vs. the old ceil-
+ *  rounded "In 3 weeks"). For tighter mobile chrome use
+ *  `formatCountdownCompact`. */
+export function formatCountdown(iso: string): string {
+  const days = daysUntil(iso);
+  if (days === null) return iso;
+  if (days < 0) return "Past";
+  if (days === 0) return "Today";
+  if (days === 1) return "In 1 day";
+  if (days < 7) return `In ${days} days`;
+  const weeks = Math.floor(days / 7);
+  const extra = days % 7;
+  const weekPart = `${weeks} week${weeks > 1 ? "s" : ""}`;
+  if (extra === 0) return `In ${weekPart}`;
+  return `In ${weekPart} and ${extra} day${extra > 1 ? "s" : ""}`;
+}
+
+/** Compact countdown ("2w 3d") for mobile, where the verbose form
+ *  would wrap the header. Same precision, fewer pixels. */
+export function formatCountdownCompact(iso: string): string {
+  const days = daysUntil(iso);
+  if (days === null) return iso;
+  if (days < 0) return "Past";
+  if (days === 0) return "Today";
+  if (days < 7) return `In ${days}d`;
+  const weeks = Math.floor(days / 7);
+  const extra = days % 7;
+  if (extra === 0) return `In ${weeks}w`;
+  return `In ${weeks}w ${extra}d`;
 }


### PR DESCRIPTION
## Summary
Patch release. Schedule countdown labels are now precise (floor + remainder) instead of rounded up to whole weeks.

## Highlights

### Fixed
- **Schedule countdown is precise.** "In 1 week and 1 day" / "In 2 weeks and 3 days" instead of the old `Math.ceil` round-up that turned 8 days into "In 2 weeks". Verbose copy on desktop card headers + the type menu; new compact form ("In 2w 3d") on the mobile block. Both formatters anchor to local-midnight so DST and late-night composition can't pull a result across day boundaries. (#236)

## Test plan
- [x] CI green on the release-prep merge into `develop` (#237)
- [x] Pre-flight: only #236 sat between `main` and `develop`; clean patch surface
- [ ] After merge: `Release` workflow tags `v0.21.2`, publishes the GitHub Release, and deploys Firestore rules + Cloud Functions to `steward-prod-65a36`
- [ ] Vercel prod build picks up the new commit
- [ ] Smoke: open `/schedule` on prod desktop + mobile, confirm a Sunday roughly 2.5 weeks out reads "In 2 weeks and 3 days" (desktop) / "In 2w 3d" (mobile)

---
_Auto-merge handled by `.github/workflows/auto-merge-release.yml` (matches the `Release:` title prefix)._

---
_Generated by [Claude Code](https://claude.ai/code/session_013AuubKx3zS51PCohLMLPGB)_