### PR TITLE
feat(assign-slot): obvious close affordance + unsaved-changes guard

### DIFF
--- a/src/app/routes/assign-prayer/AssignPrayerPage.tsx
+++ b/src/app/routes/assign-prayer/AssignPrayerPage.tsx
@@ -5,7 +5,6 @@ import {
   type AssignAction,
   type AssignSeed,
 } from "@/features/assign-slot/AssignSlotForm";
-import { AssignSlotHeader } from "@/features/assign-slot/AssignSlotHeader";
 import { persistAssignPrayer } from "@/features/assign-slot/utils/persistAssignPrayer";
 import {
   clearPrayerParticipant,
@@ -130,15 +129,13 @@ export function AssignPrayerPage() {
 
   return (
     <main className="min-h-dvh bg-parchment flex flex-col">
-      <AssignSlotHeader
-        eyebrow={`Assign ${role === "opening" ? "opening prayer" : "closing prayer"}`}
-        title={seedName.trim() ? seedName : ROLE_TITLE[role]}
-        subtitle={date ? formatShortSunday(date) : undefined}
-      />
       <AssignSlotForm
         seed={seed}
         busy={busy}
         error={error}
+        eyebrow={`Assign ${role === "opening" ? "opening prayer" : "closing prayer"}`}
+        title={seedName.trim() ? seedName : ROLE_TITLE[role]}
+        subtitle={date ? formatShortSunday(date) : undefined}
         onSubmit={onSubmit}
         {...(hasExistingPrayer
           ? {

--- a/src/app/routes/assign-speaker/AssignSpeakerPage.tsx
+++ b/src/app/routes/assign-speaker/AssignSpeakerPage.tsx
@@ -122,15 +122,13 @@ export function AssignSpeakerPage() {
 
   return (
     <main className="min-h-dvh bg-parchment flex flex-col">
-      <AssignSlotHeader
-        eyebrow={isNew ? "Assign speaker" : "Edit speaker"}
-        title={isNew ? "New speaker" : (existing?.data.name ?? "Speaker")}
-        subtitle={date ? formatShortSunday(date) : undefined}
-      />
       <AssignSlotForm
         seed={seed}
         busy={busy}
         error={error}
+        eyebrow={isNew ? "Assign speaker" : "Edit speaker"}
+        title={isNew ? "New speaker" : (existing?.data.name ?? "Speaker")}
+        subtitle={date ? formatShortSunday(date) : undefined}
         onSubmit={onSubmit}
         {...(existing
           ? {

--- a/src/features/assign-slot/AssignFields.tsx
+++ b/src/features/assign-slot/AssignFields.tsx
@@ -1,0 +1,42 @@
+import { AssignPrayerFields, AssignSpeakerFields } from "./AssignSlotFields";
+import type { AssignSeed } from "./types";
+
+interface Props {
+  draft: AssignSeed;
+  emailInvalid: boolean;
+  phoneInvalid: boolean;
+  disabled: boolean;
+  onChange: (patch: Partial<AssignSeed>) => void;
+}
+
+/** Dispatch wrapper — picks the speaker or prayer field set off the
+ *  draft's kind. Kept in its own file so the parent form stays under
+ *  the 150-LOC cap. */
+export function AssignFields({ draft, emailInvalid, phoneInvalid, disabled, onChange }: Props) {
+  if (draft.kind === "speaker") {
+    return (
+      <AssignSpeakerFields
+        name={draft.name}
+        topic={draft.topic}
+        role={draft.role}
+        email={draft.email}
+        phone={draft.phone}
+        emailInvalid={emailInvalid}
+        phoneInvalid={phoneInvalid}
+        disabled={disabled}
+        onChange={onChange}
+      />
+    );
+  }
+  return (
+    <AssignPrayerFields
+      name={draft.name}
+      email={draft.email}
+      phone={draft.phone}
+      emailInvalid={emailInvalid}
+      phoneInvalid={phoneInvalid}
+      disabled={disabled}
+      onChange={onChange}
+    />
+  );
+}

--- a/src/features/assign-slot/AssignSlotForm.tsx
+++ b/src/features/assign-slot/AssignSlotForm.tsx
@@ -3,44 +3,31 @@ import type { SubState } from "@/hooks/_sub";
 import { DeleteSpeakerConfirm } from "@/features/speakers/DeleteSpeakerConfirm";
 import { isValidEmail } from "@/lib/email";
 import { isE164 } from "@/features/templates/utils/smsInvitation";
-import type { Member, SpeakerRole, SpeakerStatus, WithId } from "@/lib/types";
+import type { Member, SpeakerStatus, WithId } from "@/lib/types";
 import type { StatusSource } from "@/lib/types/meeting";
 import { AssignSlotFooter } from "./AssignSlotFooter";
-import { AssignPrayerFields, AssignSpeakerFields } from "./AssignSlotFields";
+import { AssignSlotHeader } from "./AssignSlotHeader";
+import { AssignFields } from "./AssignFields";
 import { AssignSlotStatusRow } from "./AssignSlotStatusRow";
+import { DiscardChangesConfirm } from "./DiscardChangesConfirm";
+import { useDiscardableExit } from "./hooks/useDiscardableExit";
+import type { AssignAction, AssignSeed } from "./types";
+import { isDirty } from "./utils/isDirty";
 
-export type AssignAction = "save-and-continue" | "save-as-planned";
-
-export interface AssignSpeakerSeed {
-  kind: "speaker";
-  /** Existing speaker doc id when editing. `null` for new. */
-  speakerId: string | null;
-  name: string;
-  topic: string;
-  role: SpeakerRole;
-  email: string;
-  phone: string;
-  /** Status of an existing speaker — drives the delete confirm
-   *  dialog's invited/confirmed warning. */
-  status: SpeakerStatus;
-}
-
-export interface AssignPrayerSeed {
-  kind: "prayer";
-  name: string;
-  email: string;
-  phone: string;
-  /** Status of the prayer-giver — drives the field-locking rule
-   *  (anything other than "planned" locks all inputs). */
-  status: SpeakerStatus;
-}
-
-export type AssignSeed = AssignSpeakerSeed | AssignPrayerSeed;
+export type { AssignAction, AssignPrayerSeed, AssignSeed, AssignSpeakerSeed } from "./types";
 
 interface Props {
   seed: AssignSeed;
   busy: boolean;
   error: string | null;
+  /** Header copy — eyebrow ("Assign speaker"), title (speaker / prayer
+   *  name or "New speaker"), and the Sunday-date subtitle. The page
+   *  used to render the header itself; pulling it inside the form so
+   *  the cancel control can consult dirty-form state for the discard
+   *  confirm. */
+  eyebrow: string;
+  title: string;
+  subtitle?: string | undefined;
   /** Called with the action and the current draft values. */
   onSubmit: (action: AssignAction, draft: AssignSeed) => void;
   /** Edit-mode only — both speaker and prayer pages can pass a delete
@@ -70,6 +57,9 @@ export function AssignSlotForm({
   seed,
   busy,
   error,
+  eyebrow,
+  title,
+  subtitle,
   onSubmit,
   onDelete,
   deleting,
@@ -88,6 +78,8 @@ export function AssignSlotForm({
   // this rather than draft.status (status isn't editable here, so
   // they're identical, but seeding from seed makes intent obvious).
   const locked = seed.status !== "planned";
+  const dirty = !locked && isDirty(draft, seed);
+  const exit = useDiscardableExit({ dirty });
 
   const emailInvalid = draft.email.trim().length > 0 && !isValidEmail(draft.email.trim());
   const phoneInvalid = draft.phone.trim().length > 0 && !isE164(draft.phone.trim());
@@ -109,83 +101,80 @@ export function AssignSlotForm({
   const showDelete = Boolean(onDelete) && (isExistingSpeaker || isExistingPrayer);
 
   return (
-    <div className="flex-1 px-4 py-6 sm:px-8 sm:py-10">
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit("save-and-continue");
-        }}
-        className="flex flex-col gap-5 w-full max-w-xl mx-auto sm:bg-chalk sm:border sm:border-border-strong sm:rounded-[14px] sm:shadow-elev-2 sm:p-7"
-      >
-        {onStatusChange && (isExistingSpeaker || isExistingPrayer) && (
-          <AssignSlotStatusRow
-            status={seed.status}
-            kind={draft.kind === "speaker" ? "speaker" : "prayer"}
-            locked={locked}
-            onChange={onStatusChange}
-            {...(currentStatusSource ? { currentStatusSource } : {})}
-            {...(currentStatusSetBy ? { currentStatusSetBy } : {})}
-            {...(members ? { members } : {})}
-            {...(currentUserUid !== undefined ? { currentUserUid } : {})}
-          />
-        )}
+    <>
+      <AssignSlotHeader
+        eyebrow={eyebrow}
+        title={title}
+        subtitle={subtitle}
+        onCancel={exit.requestCancel}
+      />
+      <div className="flex-1 px-4 py-6 sm:px-8 sm:py-10">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit("save-and-continue");
+          }}
+          className="flex flex-col gap-5 w-full max-w-xl mx-auto sm:bg-chalk sm:border sm:border-border-strong sm:rounded-[14px] sm:shadow-elev-2 sm:p-7"
+        >
+          {onStatusChange && (isExistingSpeaker || isExistingPrayer) && (
+            <AssignSlotStatusRow
+              status={seed.status}
+              kind={draft.kind === "speaker" ? "speaker" : "prayer"}
+              locked={locked}
+              onChange={onStatusChange}
+              {...(currentStatusSource ? { currentStatusSource } : {})}
+              {...(currentStatusSetBy ? { currentStatusSetBy } : {})}
+              {...(members ? { members } : {})}
+              {...(currentUserUid !== undefined ? { currentUserUid } : {})}
+            />
+          )}
 
-        {draft.kind === "speaker" ? (
-          <AssignSpeakerFields
-            name={draft.name}
-            topic={draft.topic}
-            role={draft.role}
-            email={draft.email}
-            phone={draft.phone}
+          <AssignFields
+            draft={draft}
             emailInvalid={emailInvalid}
             phoneInvalid={phoneInvalid}
             disabled={locked}
-            onChange={(p) => patch(p)}
+            onChange={patch}
           />
-        ) : (
-          <AssignPrayerFields
-            name={draft.name}
-            email={draft.email}
-            phone={draft.phone}
-            emailInvalid={emailInvalid}
-            phoneInvalid={phoneInvalid}
-            disabled={locked}
-            onChange={(p) => patch(p)}
+
+          {error && (
+            <p className="font-sans text-[12.5px] text-bordeaux border border-bordeaux/40 bg-bordeaux/5 rounded-md px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <AssignSlotFooter
+            canSubmit={canSubmit}
+            busy={busy}
+            showDelete={showDelete}
+            deleteLabel={draft.kind === "prayer" ? "Remove" : "Delete"}
+            showSaveActions={!locked}
+            onDelete={() => setConfirmDelete(true)}
+            onContinue={() => submit("save-and-continue")}
+            onSavePlanned={() => submit("save-as-planned")}
           />
-        )}
 
-        {error && (
-          <p className="font-sans text-[12.5px] text-bordeaux border border-bordeaux/40 bg-bordeaux/5 rounded-md px-3 py-2">
-            {error}
-          </p>
-        )}
-
-        <AssignSlotFooter
-          canSubmit={canSubmit}
-          busy={busy}
-          showDelete={showDelete}
-          deleteLabel={draft.kind === "prayer" ? "Remove" : "Delete"}
-          showSaveActions={!locked}
-          onDelete={() => setConfirmDelete(true)}
-          onContinue={() => submit("save-and-continue")}
-          onSavePlanned={() => submit("save-as-planned")}
-        />
-
-        {showDelete && onDelete && (
-          <DeleteSpeakerConfirm
-            open={confirmDelete}
-            speakerName={draft.name}
-            speakerStatus={draft.status}
-            kind={draft.kind === "speaker" ? "speaker" : "prayer"}
-            busy={Boolean(deleting)}
-            onConfirm={() => {
-              onDelete();
-              setConfirmDelete(false);
-            }}
-            onCancel={() => setConfirmDelete(false)}
-          />
-        )}
-      </form>
-    </div>
+          {showDelete && onDelete && (
+            <DeleteSpeakerConfirm
+              open={confirmDelete}
+              speakerName={draft.name}
+              speakerStatus={draft.status}
+              kind={draft.kind === "speaker" ? "speaker" : "prayer"}
+              busy={Boolean(deleting)}
+              onConfirm={() => {
+                onDelete();
+                setConfirmDelete(false);
+              }}
+              onCancel={() => setConfirmDelete(false)}
+            />
+          )}
+        </form>
+      </div>
+      <DiscardChangesConfirm
+        open={exit.confirmOpen}
+        onKeepEditing={exit.onKeepEditing}
+        onDiscard={exit.onDiscard}
+      />
+    </>
   );
 }

--- a/src/features/assign-slot/AssignSlotHeader.tsx
+++ b/src/features/assign-slot/AssignSlotHeader.tsx
@@ -1,17 +1,23 @@
 import { Link } from "@/lib/nav";
-import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
 
 interface Props {
   eyebrow: string;
   title: string;
   subtitle?: string | undefined;
+  /** When provided, the cancel control fires this callback instead of
+   *  routing. AssignSlotForm wires it to gate close on dirty-form
+   *  discard confirm. Without it, the control falls back to a plain
+   *  Link to /schedule (used by the page's not-found / loading
+   *  branches where there's nothing to discard). */
+  onCancel?: () => void;
 }
 
 /** Sticky header for the per-row Assign + Invite pages. Eyebrow
- *  carries the slot context ("Assign speaker · 02"), title carries
- *  the action ("New speaker"), subtitle carries the meeting date.
- *  Cancel returns to the schedule. */
-export function AssignSlotHeader({ eyebrow, title, subtitle }: Props) {
+ *  carries the slot context ("Edit speaker"), title carries the
+ *  speaker / prayer-giver name, subtitle carries the meeting date.
+ *  Right side is the labeled Cancel control — replaces the prior
+ *  14px walnut-3 "×" that users couldn't find. */
+export function AssignSlotHeader({ eyebrow, title, subtitle, onCancel }: Props) {
   return (
     <header className="sticky top-0 z-20 shrink-0 flex items-start justify-between gap-3 border-b border-border bg-chalk px-4 sm:px-8 py-4">
       <div className="flex flex-col gap-0.5 min-w-0">
@@ -25,14 +31,44 @@ export function AssignSlotHeader({ eyebrow, title, subtitle }: Props) {
           <p className="font-serif italic text-[12.5px] text-walnut-3 truncate">{subtitle}</p>
         )}
       </div>
-      <Link
-        to="/schedule"
-        aria-label="Cancel and return to schedule"
-        title="Cancel"
-        className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
-      >
-        <RemoveIcon />
-      </Link>
+      {onCancel ? (
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel and return to schedule"
+          aria-keyshortcuts="Escape"
+          className={CANCEL_CLASSES}
+        >
+          <CancelIcon />
+          <span>Cancel</span>
+        </button>
+      ) : (
+        <Link to="/schedule" aria-label="Cancel and return to schedule" className={CANCEL_CLASSES}>
+          <CancelIcon />
+          <span>Cancel</span>
+        </Link>
+      )}
     </header>
+  );
+}
+
+const CANCEL_CLASSES =
+  "shrink-0 inline-flex items-center gap-1.5 min-h-11 rounded-md px-2.5 py-2 font-sans text-[13px] font-medium text-walnut-2 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30";
+
+function CancelIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
   );
 }

--- a/src/features/assign-slot/DiscardChangesConfirm.tsx
+++ b/src/features/assign-slot/DiscardChangesConfirm.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+interface Props {
+  open: boolean;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}
+
+/** Two-button "discard your changes?" prompt fired when the user
+ *  cancels the per-row Assign + Invite form with unsaved edits. The
+ *  templates editor has a richer 3-button variant (Save and exit /
+ *  Discard / Keep editing); here there are two save actions
+ *  (Save as Planned, Continue), so an in-prompt save is ambiguous. */
+export function DiscardChangesConfirm({ open, onKeepEditing, onDiscard }: Props) {
+  useLockBodyScroll(open);
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      onKeepEditing();
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, onKeepEditing]);
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="discard-changes-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onKeepEditing();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+        <h2
+          id="discard-changes-title"
+          className="font-display text-[19px] font-semibold text-walnut mb-1.5"
+        >
+          Discard your changes?
+        </h2>
+        <p className="font-serif text-[14px] text-walnut-2 leading-relaxed mb-5">
+          You have unsaved edits. Closing now will lose them.
+        </p>
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <button
+            type="button"
+            onClick={onKeepEditing}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2"
+          >
+            Keep editing
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            className="rounded-md border border-bordeaux bg-bordeaux px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-bordeaux-deep"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/assign-slot/hooks/useDiscardableExit.ts
+++ b/src/features/assign-slot/hooks/useDiscardableExit.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "@/lib/nav";
+
+interface Options {
+  dirty: boolean;
+}
+
+interface DiscardableExit {
+  /** Wire to the header cancel button. Opens the confirm when dirty,
+   *  otherwise navigates straight to /schedule. */
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}
+
+/** Form-level "close with discard guard" — opens a confirm when there
+ *  are unsaved changes, otherwise navigates back to the schedule.
+ *  Also binds Esc to the same path so desktop keyboard users hit the
+ *  guard. The DiscardChangesConfirm + DeleteSpeakerConfirm modals own
+ *  their own Esc handlers with `stopImmediatePropagation`, so this
+ *  listener stays silent while either modal is open. */
+export function useDiscardableExit({ dirty }: Options): DiscardableExit {
+  const navigate = useNavigate();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const requestCancel = useCallback(() => {
+    if (dirty) setConfirmOpen(true);
+    else navigate("/schedule");
+  }, [dirty, navigate]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      requestCancel();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [requestCancel]);
+
+  return {
+    requestCancel,
+    confirmOpen,
+    onKeepEditing: () => setConfirmOpen(false),
+    onDiscard: () => {
+      setConfirmOpen(false);
+      navigate("/schedule");
+    },
+  };
+}

--- a/src/features/assign-slot/types.ts
+++ b/src/features/assign-slot/types.ts
@@ -1,0 +1,29 @@
+import type { SpeakerRole, SpeakerStatus } from "@/lib/types";
+
+export type AssignAction = "save-and-continue" | "save-as-planned";
+
+export interface AssignSpeakerSeed {
+  kind: "speaker";
+  /** Existing speaker doc id when editing. `null` for new. */
+  speakerId: string | null;
+  name: string;
+  topic: string;
+  role: SpeakerRole;
+  email: string;
+  phone: string;
+  /** Status of an existing speaker — drives the delete confirm
+   *  dialog's invited/confirmed warning. */
+  status: SpeakerStatus;
+}
+
+export interface AssignPrayerSeed {
+  kind: "prayer";
+  name: string;
+  email: string;
+  phone: string;
+  /** Status of the prayer-giver — drives the field-locking rule
+   *  (anything other than "planned" locks all inputs). */
+  status: SpeakerStatus;
+}
+
+export type AssignSeed = AssignSpeakerSeed | AssignPrayerSeed;

--- a/src/features/assign-slot/utils/isDirty.ts
+++ b/src/features/assign-slot/utils/isDirty.ts
@@ -1,0 +1,22 @@
+import type { AssignSeed } from "../types";
+
+/** Field-by-field compare of the in-progress draft against the seed.
+ *  Status is excluded — it has its own audit-stamping write path
+ *  (onStatusChange persists immediately) and isn't part of the form's
+ *  Save / Continue payload, so flipping it shouldn't make the form
+ *  read as "unsaved". */
+export function isDirty(draft: AssignSeed, seed: AssignSeed): boolean {
+  if (draft.kind === "speaker" && seed.kind === "speaker") {
+    return (
+      draft.name !== seed.name ||
+      draft.topic !== seed.topic ||
+      draft.role !== seed.role ||
+      draft.email !== seed.email ||
+      draft.phone !== seed.phone
+    );
+  }
+  if (draft.kind === "prayer" && seed.kind === "prayer") {
+    return draft.name !== seed.name || draft.email !== seed.email || draft.phone !== seed.phone;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Replace the tiny 14 px walnut-3 "×" in the per-row Assign + Invite header with a labeled **Cancel** button (icon + text, walnut, 44 px hit target) — same control on desktop and mobile.
- Bind **Esc** at the form level so desktop keyboard users land on the same exit path.
- When the form is dirty (`draft` diverges from `seed`), Cancel + Esc open a 2-button `DiscardChangesConfirm` — *Keep editing* / *Discard*. Two-button (not the templates' three-button "Save and exit") because this form has two save actions (Save as Planned + Continue), so an in-prompt save is ambiguous.
- Move `<AssignSlotHeader>` inside `<AssignSlotForm>` so the form (which owns the draft) drives the close. Pages now pass `eyebrow/title/subtitle` to the form; standalone Header still falls back to a plain Link when no `onCancel` is given (used by the speaker-not-found branch).

## Files
- `src/features/assign-slot/AssignSlotHeader.tsx` — new `onCancel` prop, labeled control replaces bare X.
- `src/features/assign-slot/AssignSlotForm.tsx` — pulls Header inside; renders `DiscardChangesConfirm`.
- `src/features/assign-slot/DiscardChangesConfirm.tsx` — new 2-button modal.
- `src/features/assign-slot/AssignFields.tsx` — extracted dispatcher (kind → speaker/prayer fields) so `AssignSlotFields` stays under 150 LOC.
- `src/features/assign-slot/types.ts`, `utils/isDirty.ts`, `hooks/useDiscardableExit.ts` — new helpers, each kept tiny so every touched file stays under the LOC cap.
- `src/app/routes/assign-{speaker,prayer}/*` — drop the explicit standalone `<AssignSlotHeader>` in the normal branch; pass header props through the form.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint` (0 errors; pre-existing warnings only)
- [x] `pnpm format:check`
- [x] `pnpm test` — 433 tests pass; the 7 file-load failures are environmental (missing `VITE_FIREBASE_API_KEY` in this sandbox), pre-existing on `develop`.
- [ ] Manual smoke: open `/week/<date>/speaker/<id>/assign` on desktop + mobile, verify Cancel button is obvious, Esc works on desktop, typing then hitting Cancel/Esc opens the discard prompt, hitting Cancel without typing exits cleanly.
- [ ] Same for `/week/<date>/prayer/<role>/assign`.

## Out of scope (worth a follow-up issue?)
- Browser-back / `beforeunload` interception when dirty — currently only header Cancel + Esc are guarded; a hard refresh or browser back still discards silently.

https://claude.ai/code/session_013AuubKx3zS51PCohLMLPGB

---
_Generated by [Claude Code](https://claude.ai/code/session_013AuubKx3zS51PCohLMLPGB)_