### PR TITLE
feat(ui): shared HeaderCloseButton across chat + invite headers

### DIFF
--- a/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
@@ -1,4 +1,4 @@
-import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
 import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitationActionBar";
 
 interface Props {
@@ -51,7 +51,11 @@ export function PrepareInvitationHeader(props: Props) {
             onSendSms={props.onSendSms}
           />
         </div>
-        <CancelButton onClick={props.onCancel} />
+        <HeaderCloseButton
+          onClick={props.onCancel}
+          label="Cancel"
+          ariaLabel="Cancel and return to schedule"
+        />
       </div>
       <div className="lg:hidden flex justify-center">
         <PrepareInvitationActionBar
@@ -67,19 +71,5 @@ export function PrepareInvitationHeader(props: Props) {
         />
       </div>
     </header>
-  );
-}
-
-function CancelButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Cancel and return to schedule"
-      title="Cancel"
-      className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
-    >
-      <RemoveIcon />
-    </button>
   );
 }

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
@@ -1,4 +1,4 @@
-import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
 import type { PrayerRole } from "@/lib/types";
 import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitationActionBar";
 
@@ -54,25 +54,15 @@ export function PreparePrayerInvitationHeader(props: Props) {
         <div className="hidden lg:block shrink-0">
           <PrepareInvitationActionBar {...actionBarProps} />
         </div>
-        <CancelButton onClick={props.onCancel} />
+        <HeaderCloseButton
+          onClick={props.onCancel}
+          label="Cancel"
+          ariaLabel="Cancel and return to schedule"
+        />
       </div>
       <div className="lg:hidden flex justify-center">
         <PrepareInvitationActionBar {...actionBarProps} />
       </div>
     </header>
-  );
-}
-
-function CancelButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Cancel and return to schedule"
-      title="Cancel"
-      className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
-    >
-      <RemoveIcon />
-    </button>
   );
 }

--- a/src/components/ui/HeaderCloseButton.tsx
+++ b/src/components/ui/HeaderCloseButton.tsx
@@ -1,0 +1,45 @@
+interface Props {
+  onClick: () => void;
+  /** Visible label. Defaults to "Close". Pages with a routing-style
+   *  cancel pass "Cancel" here. */
+  label?: string;
+  /** Defaults to the visible label. Override when more context helps
+   *  screen readers (e.g. "Close conversation"). */
+  ariaLabel?: string;
+}
+
+/** Labeled close affordance for sticky headers and drawer headers —
+ *  X icon + visible text, 44px hit target, focus ring. Replaces the
+ *  small icon-only or tiny-mono-text close patterns that users
+ *  couldn't find. */
+export function HeaderCloseButton({ onClick, label = "Close", ariaLabel }: Props) {
+  return (
+    <button type="button" onClick={onClick} aria-label={ariaLabel ?? label} className={CLASSES}>
+      <HeaderCloseIcon />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export const HEADER_CLOSE_BUTTON_CLASSES =
+  "shrink-0 inline-flex items-center gap-1.5 min-h-11 rounded-md px-2.5 py-2 font-sans text-[13px] font-medium text-walnut-2 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30";
+
+const CLASSES = HEADER_CLOSE_BUTTON_CLASSES;
+
+export function HeaderCloseIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
+}

--- a/src/features/assign-slot/AssignSlotHeader.tsx
+++ b/src/features/assign-slot/AssignSlotHeader.tsx
@@ -1,3 +1,8 @@
+import {
+  HEADER_CLOSE_BUTTON_CLASSES,
+  HeaderCloseButton,
+  HeaderCloseIcon,
+} from "@/components/ui/HeaderCloseButton";
 import { Link } from "@/lib/nav";
 
 interface Props {
@@ -32,43 +37,21 @@ export function AssignSlotHeader({ eyebrow, title, subtitle, onCancel }: Props) 
         )}
       </div>
       {onCancel ? (
-        <button
-          type="button"
+        <HeaderCloseButton
           onClick={onCancel}
-          aria-label="Cancel and return to schedule"
-          aria-keyshortcuts="Escape"
-          className={CANCEL_CLASSES}
-        >
-          <CancelIcon />
-          <span>Cancel</span>
-        </button>
+          label="Cancel"
+          ariaLabel="Cancel and return to schedule"
+        />
       ) : (
-        <Link to="/schedule" aria-label="Cancel and return to schedule" className={CANCEL_CLASSES}>
-          <CancelIcon />
+        <Link
+          to="/schedule"
+          aria-label="Cancel and return to schedule"
+          className={HEADER_CLOSE_BUTTON_CLASSES}
+        >
+          <HeaderCloseIcon />
           <span>Cancel</span>
         </Link>
       )}
     </header>
-  );
-}
-
-const CANCEL_CLASSES =
-  "shrink-0 inline-flex items-center gap-1.5 min-h-11 rounded-md px-2.5 py-2 font-sans text-[13px] font-medium text-walnut-2 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30";
-
-function CancelIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M18 6L6 18M6 6l12 12" />
-    </svg>
   );
 }

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { Drawer } from "vaul";
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
 import { useKeyboardAwareViewport } from "@/hooks/useKeyboardAwareViewport";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
@@ -75,7 +76,7 @@ export function BishopInvitationDialog({
             <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
           )}
           <Drawer.Title className="sr-only">Conversation with {speaker.name}</Drawer.Title>
-          <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
+          <div className="flex items-center gap-3 px-5 py-3.5 border-b border-border bg-parchment">
             <div className="flex-1 min-w-0">
               <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
                 Conversation
@@ -91,14 +92,7 @@ export function BishopInvitationDialog({
                 invitation={invitation}
               />
             )}
-            <button
-              type="button"
-              onClick={onClose}
-              className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
-              aria-label="Close"
-            >
-              Close
-            </button>
+            <HeaderCloseButton onClick={onClose} />
           </div>
           {invitation && invitationId ? (
             <BishopInvitationChat

--- a/src/features/invitations/SpeakerChatHeader.tsx
+++ b/src/features/invitations/SpeakerChatHeader.tsx
@@ -1,3 +1,5 @@
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
+
 interface Props {
   onClose?: (() => void) | undefined;
 }
@@ -17,16 +19,7 @@ export function SpeakerChatHeader({ onClose }: Props) {
           This is a group conversation — the bishop, counselors, and clerks can all see and reply.
         </p>
       </div>
-      {onClose && (
-        <button
-          type="button"
-          onClick={onClose}
-          className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
-          aria-label="Close conversation"
-        >
-          Close
-        </button>
-      )}
+      {onClose && <HeaderCloseButton onClick={onClose} ariaLabel="Close conversation" />}
     </header>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts the labeled Cancel button introduced in eaa7fa4 (AssignSlot page) into a tiny shared primitive at `src/components/ui/HeaderCloseButton.tsx` — X icon + visible label (defaults to **Close**), 44px hit target, focus ring, walnut→bordeaux hover.
- Applies it across the four remaining headers that still used a small icon-only `×` or a tiny mono "Close" text label: SpeakerChatHeader, BishopInvitationDialog, PrepareInvitationHeader, PreparePrayerInvitationHeader.
- Refactors AssignSlotHeader to consume the same primitive so the five surfaces stay locked together.

## What changes visually

| Surface | Before | After |
|---|---|---|
| AssignSlot pages | Labeled Cancel (eaa7fa4) | unchanged — now sourced from the primitive |
| Speaker chat drawer | tiny mono `Close` (`text-[11px]`, `px-2 py-1`) | labeled `Close` button, 44px hit target |
| Bishop chat dialog | tiny mono `Close` | labeled `Close`; header row now `items-center` so the `…` overflow menu and the close button share a vertical axis |
| Prepare Speaker Invitation | icon-only `×` (RemoveIcon) | labeled `Cancel` |
| Prepare Prayer Invitation | icon-only `×` (RemoveIcon) | labeled `Cancel` |

No dirty-state guard or Esc binding is added on the new surfaces — that remains scoped to AssignSlot for now.

Net diff: −50 lines across the touched files (private CancelButton helpers and unused RemoveIcon imports removed).

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm lint` 0 errors
- [ ] `pnpm format:check` clean
- [ ] AssignSlot pages (`/week/:date/speaker/:id`, etc.) — Cancel button visually identical, dirty-state guard + Esc still work
- [ ] Speaker invite landing page → open chat drawer → Close button visible with icon + text, focus ring on Tab, closes drawer
- [ ] Bishop side: from /schedule open BishopInvitationDialog (with and without an existing invitation) → `…` action menu and Close button align on the same horizontal center
- [ ] `/week/:date/speaker/:id/letter` (Prepare Speaker Invitation) — Cancel button labeled, returns to schedule
- [ ] Prayer variant of the prepare-invitation page — same
- [ ] Mobile viewport (375px) — close button never pushed off-screen on any of the five surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)