### PR TITLE
feat(prepare-invitation): explicit Save, platform-aware export, sent-letter download

### DIFF
--- a/src/app/routes/prepare-invitation/PrepareInvitationContent.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationContent.tsx
@@ -1,0 +1,111 @@
+import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
+import { UnsavedLetterConfirm } from "@/features/templates/UnsavedLetterConfirm";
+import { buildSavedVersionStamp } from "@/features/templates/utils/letterDates";
+import type { LetterVars } from "@/features/templates/utils/prepareInvitationVars";
+import type { Speaker } from "@/lib/types";
+import { PrepareInvitationHeader } from "./PrepareInvitationHeader";
+import { computeSendValidation } from "./utils/prepareInvitationValidation";
+
+interface FormState {
+  busy: boolean;
+  hydrated: boolean;
+  dirty: boolean;
+  letterHasOverride: boolean;
+  initialJson: string | null;
+  initialMarkdown: { bodyMarkdown: string; footerMarkdown: string };
+  letterStateJson: string | null;
+  letterBody: string;
+  letterFooter: string;
+  resetKey: number;
+  error: string | null;
+  savedAt: unknown;
+  setLetterStateJson: (json: string) => void;
+  captureInitial: (json: string) => void;
+  clearLetterOverride: () => Promise<void>;
+}
+
+interface ActionState {
+  save: () => Promise<void>;
+  send: (email?: string) => void;
+  sendSms: (phone?: string) => void;
+}
+
+interface ExitState {
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  busy: boolean;
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => Promise<void>;
+}
+
+interface Props {
+  date: string;
+  speaker: Speaker;
+  vars: LetterVars;
+  form: FormState;
+  actions: ActionState;
+  exit: ExitState;
+}
+
+/** Post-guard render shell for the speaker prepare page. Owns the
+ *  header + body layout, the editor mount, and the unsaved-changes
+ *  modal. Extracted so PrepareInvitationPage stays inside the
+ *  component-size budget while keeping the orchestration (hooks,
+ *  guards, embed branch) at the route level. */
+export function PrepareInvitationContent({ date, speaker, vars, form, actions, exit }: Props) {
+  const { email, hasEmail } = computeSendValidation(speaker);
+  const printVersionStamp = buildSavedVersionStamp(form.savedAt);
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PrepareInvitationHeader
+        email={email}
+        hasEmail={hasEmail}
+        busy={form.busy}
+        hasOverride={form.letterHasOverride}
+        dirty={form.dirty}
+        speakerName={speaker.name}
+        speakerEmail={speaker.email ?? ""}
+        speakerPhone={speaker.phone ?? ""}
+        assignedDate={date}
+        onCancel={exit.requestCancel}
+        onRevert={() => void form.clearLetterOverride()}
+        onSave={() => void actions.save().catch(() => {})}
+        onSend={actions.send}
+        onSendSms={actions.sendSms}
+      />
+      <div className="flex-1 min-h-0 lg:overflow-hidden">
+        {form.hydrated ? (
+          <PrepareInvitationLetterTab
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            liveStateJson={form.letterStateJson}
+            body={form.letterBody}
+            footer={form.letterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
+            vars={vars}
+            {...(printVersionStamp ? { printVersionStamp } : {})}
+          />
+        ) : (
+          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
+            Loading letter…
+          </p>
+        )}
+        {form.error && (
+          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
+        )}
+      </div>
+      <UnsavedLetterConfirm
+        open={exit.confirmOpen}
+        busy={exit.busy}
+        error={exit.error}
+        onKeepEditing={exit.onKeepEditing}
+        onDiscard={exit.onDiscard}
+        onSaveAndExit={() => void exit.onSaveAndExit()}
+      />
+    </main>
+  );
+}

--- a/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
@@ -9,11 +9,15 @@ interface Props {
   hasEmail: boolean;
   busy: boolean;
   hasOverride: boolean;
+  /** True when the editor state has unsaved edits — gates the action
+   *  bar's Save (enabled) and Share/Download (disabled) affordances. */
+  dirty: boolean;
   /** Meeting date (ISO YYYY-MM-DD) — threaded to the action bar's
    *  share path so the generated PDF filename includes it. */
   assignedDate: string;
   onCancel: () => void;
   onRevert: () => void;
+  onSave: () => void;
   onSend: (email: string) => void;
   onSendSms: (phone: string) => void;
 }
@@ -42,11 +46,13 @@ export function PrepareInvitationHeader(props: Props) {
           <PrepareInvitationActionBar
             busy={props.busy}
             hasOverride={props.hasOverride}
+            dirty={props.dirty}
             speakerName={props.speakerName}
             speakerEmail={props.speakerEmail}
             speakerPhone={props.speakerPhone}
             assignedDate={props.assignedDate}
             onRevert={props.onRevert}
+            onSave={props.onSave}
             onSend={props.onSend}
             onSendSms={props.onSendSms}
           />

--- a/src/app/routes/prepare-invitation/PrepareInvitationPage.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationPage.tsx
@@ -1,21 +1,20 @@
 import { useMemo, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
-import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
 import { EmbedLetterView } from "@/features/embed/EmbedLetterView";
 import { useEmbedAuthBootstrap } from "@/features/embed/useEmbedAuthBootstrap";
 import { useEmbedShareBridge } from "@/features/embed/useEmbedShareBridge";
-import { PrepareInvitationHeader } from "./PrepareInvitationHeader";
 import { formatAssignedDate, formatToday } from "@/features/templates/utils/letterDates";
 import { useSpeakerLetterTemplate } from "@/features/templates/hooks/useSpeakerLetterTemplate";
 import { usePrepareInvitation } from "@/features/templates/hooks/usePrepareInvitation";
 import { usePrepareInvitationActions } from "@/features/templates/hooks/usePrepareInvitationActions";
+import { useSavableExit } from "@/features/templates/hooks/useSavableExit";
 import { useAuthStore } from "@/stores/authStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { PrepareInvitationContent } from "./PrepareInvitationContent";
 import { PrepareInvitationPageMessage } from "../PrepareInvitationPageMessage";
-import { computeSendValidation } from "./utils/prepareInvitationValidation";
 
 export function PrepareInvitationPage() {
   const { date, speakerId } = useParams<{ date: string; speakerId: string }>();
@@ -23,7 +22,6 @@ export function PrepareInvitationPage() {
   const isEmbed = searchParams.get("embed") === "ios";
   const embedAuth = useEmbedAuthBootstrap();
   useEmbedShareBridge();
-  const navigate = useNavigate();
   const wardId = useCurrentWardStore((s) => s.wardId);
   const me = useCurrentMember();
   const authUser = useAuthStore((s) => s.user);
@@ -70,6 +68,8 @@ export function PrepareInvitationPage() {
     onDone: () => setDone(true),
   });
 
+  const exit = useSavableExit({ dirty: form.dirty, onSave: actions.save });
+
   if (!wardId || !date || !speakerId) {
     return (
       <PrepareInvitationPageMessage
@@ -105,50 +105,14 @@ export function PrepareInvitationPage() {
     return <EmbedLetterView authStatus={embedAuth} form={form} date={date} wardName={wardName} vars={vars} />;
   }
 
-  const { email, hasEmail } = computeSendValidation(speaker.data);
-
-  const toolbarProps = {
-    busy: form.busy,
-    hasOverride: form.letterHasOverride,
-    speakerName: speaker.data.name,
-    speakerEmail: speaker.data.email ?? "",
-    speakerPhone: speaker.data.phone ?? "",
-    assignedDate: date,
-    onRevert: () => void form.clearLetterOverride(),
-    onSend: actions.send,
-    onSendSms: actions.sendSms,
-  };
-
   return (
-    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
-      <PrepareInvitationHeader
-        email={email}
-        hasEmail={hasEmail}
-        onCancel={() => navigate("/schedule")}
-        {...toolbarProps}
-      />
-      <div className="flex-1 min-h-0 lg:overflow-hidden">
-        {form.hydrated ? (
-          <PrepareInvitationLetterTab
-            initialJson={form.initialJson}
-            initialMarkdown={form.initialMarkdown}
-            liveStateJson={form.letterStateJson}
-            body={form.letterBody}
-            footer={form.letterFooter}
-            onChange={form.setLetterStateJson}
-            onInitial={form.captureInitial}
-            resetKey={form.resetKey}
-            vars={vars}
-          />
-        ) : (
-          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
-            Loading letter…
-          </p>
-        )}
-        {form.error && (
-          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
-        )}
-      </div>
-    </main>
+    <PrepareInvitationContent
+      date={date}
+      speaker={speaker.data}
+      vars={vars}
+      form={form}
+      actions={actions}
+      exit={exit}
+    />
   );
 }

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationContent.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationContent.tsx
@@ -1,0 +1,123 @@
+import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
+import { UnsavedLetterConfirm } from "@/features/templates/UnsavedLetterConfirm";
+import { buildSavedVersionStamp } from "@/features/templates/utils/letterDates";
+import type { LetterVars } from "@/features/templates/utils/prepareInvitationVars";
+import { isValidEmail } from "@/lib/email";
+import type { PrayerRole } from "@/lib/types";
+import { PreparePrayerInvitationHeader } from "./PreparePrayerInvitationHeader";
+
+interface FormState {
+  busy: boolean;
+  hydrated: boolean;
+  dirty: boolean;
+  letterHasOverride: boolean;
+  initialJson: string | null;
+  initialMarkdown: { bodyMarkdown: string; footerMarkdown: string };
+  letterStateJson: string | null;
+  letterBody: string;
+  letterFooter: string;
+  resetKey: number;
+  error: string | null;
+  savedAt: unknown;
+  setLetterStateJson: (json: string) => void;
+  captureInitial: (json: string) => void;
+  clearLetterOverride: () => Promise<void>;
+}
+
+interface ActionState {
+  save: () => Promise<void>;
+  send: (email?: string) => void;
+  sendSms: (phone?: string) => void;
+}
+
+interface ExitState {
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  busy: boolean;
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => Promise<void>;
+}
+
+interface Props {
+  date: string;
+  role: PrayerRole;
+  prayerGiverName: string;
+  prayerGiverEmail: string;
+  prayerGiverPhone: string;
+  vars: LetterVars;
+  form: FormState;
+  actions: ActionState;
+  exit: ExitState;
+}
+
+/** Post-guard render shell for the prayer prepare page. Mirrors
+ *  PrepareInvitationContent for the speaker side; both stay just
+ *  separate enough that header / hook differences don't have to
+ *  branch inside one component. */
+export function PreparePrayerInvitationContent({
+  date,
+  role,
+  prayerGiverName,
+  prayerGiverEmail,
+  prayerGiverPhone,
+  vars,
+  form,
+  actions,
+  exit,
+}: Props) {
+  const printVersionStamp = buildSavedVersionStamp(form.savedAt);
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PreparePrayerInvitationHeader
+        role={role}
+        email={prayerGiverEmail}
+        hasEmail={isValidEmail(prayerGiverEmail)}
+        busy={form.busy}
+        hasOverride={form.letterHasOverride}
+        dirty={form.dirty}
+        speakerName={prayerGiverName}
+        speakerEmail={prayerGiverEmail}
+        speakerPhone={prayerGiverPhone}
+        assignedDate={date}
+        onCancel={exit.requestCancel}
+        onRevert={() => void form.clearLetterOverride()}
+        onSave={() => void actions.save().catch(() => {})}
+        onSend={actions.send}
+        onSendSms={actions.sendSms}
+      />
+      <div className="flex-1 min-h-0 lg:overflow-hidden">
+        {form.hydrated ? (
+          <PrepareInvitationLetterTab
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            liveStateJson={form.letterStateJson}
+            body={form.letterBody}
+            footer={form.letterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
+            vars={vars}
+            {...(printVersionStamp ? { printVersionStamp } : {})}
+          />
+        ) : (
+          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
+            Loading letter…
+          </p>
+        )}
+        {form.error && (
+          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
+        )}
+      </div>
+      <UnsavedLetterConfirm
+        open={exit.confirmOpen}
+        busy={exit.busy}
+        error={exit.error}
+        onKeepEditing={exit.onKeepEditing}
+        onDiscard={exit.onDiscard}
+        onSaveAndExit={() => void exit.onSaveAndExit()}
+      />
+    </main>
+  );
+}

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
@@ -11,11 +11,15 @@ interface Props {
   hasEmail: boolean;
   busy: boolean;
   hasOverride: boolean;
+  /** True when the editor state has unsaved edits — gates Save +
+   *  Share/Download in the action bar. */
+  dirty: boolean;
   /** Meeting date (ISO YYYY-MM-DD) — threaded to the action bar's
    *  share path so the generated PDF filename includes it. */
   assignedDate: string;
   onCancel: () => void;
   onRevert: () => void;
+  onSave: () => void;
   onSend: (email: string) => void;
   onSendSms: (phone: string) => void;
 }
@@ -29,11 +33,13 @@ export function PreparePrayerInvitationHeader(props: Props) {
   const actionBarProps = {
     busy: props.busy,
     hasOverride: props.hasOverride,
+    dirty: props.dirty,
     speakerName: props.speakerName,
     speakerEmail: props.speakerEmail,
     speakerPhone: props.speakerPhone,
     assignedDate: props.assignedDate,
     onRevert: props.onRevert,
+    onSave: props.onSave,
     onSend: props.onSend,
     onSendSms: props.onSendSms,
   };

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationPage.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationPage.tsx
@@ -1,22 +1,21 @@
 import { useMemo, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useMeeting } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { usePrayerLetterTemplate } from "@/features/templates/hooks/usePrayerLetterTemplate";
-import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
 import { EmbedLetterView } from "@/features/embed/EmbedLetterView";
 import { useEmbedAuthBootstrap } from "@/features/embed/useEmbedAuthBootstrap";
 import { useEmbedShareBridge } from "@/features/embed/useEmbedShareBridge";
 import { formatAssignedDate, formatToday } from "@/features/templates/utils/letterDates";
-import { isValidEmail } from "@/lib/email";
+import { useSavableExit } from "@/features/templates/hooks/useSavableExit";
 import { type PrayerRole, prayerRoleSchema } from "@/lib/types";
 import { useAuthStore } from "@/stores/authStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { usePrayerParticipant } from "@/features/prayers/hooks/usePrayerParticipant";
 import { usePreparePrayerInvitation } from "@/features/prayers/hooks/usePreparePrayerInvitation";
 import { usePreparePrayerActions } from "@/features/prayers/hooks/usePreparePrayerActions";
-import { PreparePrayerInvitationHeader } from "./PreparePrayerInvitationHeader";
+import { PreparePrayerInvitationContent } from "./PreparePrayerInvitationContent";
 import { PrepareInvitationPageMessage } from "../PrepareInvitationPageMessage";
 
 export function PreparePrayerInvitationPage() {
@@ -25,7 +24,6 @@ export function PreparePrayerInvitationPage() {
   const isEmbed = searchParams.get("embed") === "ios";
   const embedAuth = useEmbedAuthBootstrap();
   useEmbedShareBridge();
-  const navigate = useNavigate();
   const wardId = useCurrentWardStore((s) => s.wardId);
   const me = useCurrentMember();
   const authUser = useAuthStore((s) => s.user);
@@ -84,6 +82,8 @@ export function PreparePrayerInvitationPage() {
     onDone: () => setDone(true),
   });
 
+  const exit = useSavableExit({ dirty: form.dirty, onSave: actions.save });
+
   if (!wardId || !date || !role) {
     return (
       <PrepareInvitationPageMessage
@@ -115,51 +115,17 @@ export function PreparePrayerInvitationPage() {
     return <EmbedLetterView authStatus={embedAuth} form={form} date={date} wardName={wardName} vars={vars} />;
   }
 
-  const hasEmail = isValidEmail(prayerGiverEmail);
-
-  const toolbarProps = {
-    busy: form.busy,
-    hasOverride: form.letterHasOverride,
-    speakerName: prayerGiverName,
-    speakerEmail: prayerGiverEmail,
-    speakerPhone: prayerGiverPhone,
-    assignedDate: date,
-    onRevert: () => void form.clearLetterOverride(),
-    onSend: actions.send,
-    onSendSms: actions.sendSms,
-  };
-
   return (
-    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
-      <PreparePrayerInvitationHeader
-        role={role}
-        email={prayerGiverEmail}
-        hasEmail={hasEmail}
-        onCancel={() => navigate("/schedule")}
-        {...toolbarProps}
-      />
-      <div className="flex-1 min-h-0 lg:overflow-hidden">
-        {form.hydrated ? (
-          <PrepareInvitationLetterTab
-            initialJson={form.initialJson}
-            initialMarkdown={form.initialMarkdown}
-            liveStateJson={form.letterStateJson}
-            body={form.letterBody}
-            footer={form.letterFooter}
-            onChange={form.setLetterStateJson}
-            onInitial={form.captureInitial}
-            resetKey={form.resetKey}
-            vars={vars}
-          />
-        ) : (
-          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
-            Loading letter…
-          </p>
-        )}
-        {form.error && (
-          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
-        )}
-      </div>
-    </main>
+    <PreparePrayerInvitationContent
+      date={date}
+      role={role}
+      prayerGiverName={prayerGiverName}
+      prayerGiverEmail={prayerGiverEmail}
+      prayerGiverPhone={prayerGiverPhone}
+      vars={vars}
+      form={form}
+      actions={actions}
+      exit={exit}
+    />
   );
 }

--- a/src/features/invitations/InvitationLinkActions/InvitationLinkActions.tsx
+++ b/src/features/invitations/InvitationLinkActions/InvitationLinkActions.tsx
@@ -3,6 +3,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { OverflowMenu, type OverflowMenuItem } from "@/components/ui/OverflowMenu";
 import type { SpeakerInvitation } from "@/lib/types";
 import { callRotateInvitationLink } from "../utils/invitationsCallable";
+import { useDownloadSentLetter } from "./useDownloadSentLetter";
 
 interface Props {
   wardId: string;
@@ -32,6 +33,8 @@ export function InvitationLinkActions({
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   const [confirmOpen, setConfirmOpen] = useState(false);
   const deliverable = availableChannels(invitation);
+  const downloadSent = useDownloadSentLetter(invitation, invitationId);
+  const canDownloadSent = Boolean(invitation.editorStateJson || invitation.bodyMarkdown);
 
   useEffect(() => {
     if (status.kind !== "sent") return;
@@ -63,8 +66,14 @@ export function InvitationLinkActions({
   const items: OverflowMenuItem[] = [];
   if (deliverable.length > 0) {
     items.push({
-      label: `Resend via ${formatChannels(deliverable)}`,
+      label: `Resend Invite via ${formatChannels(deliverable)}`,
       onSelect: () => setConfirmOpen(true),
+    });
+  }
+  if (canDownloadSent) {
+    items.push({
+      label: downloadSent.busy ? "Preparing…" : "Download Sent Invitation Letter",
+      onSelect: () => void downloadSent.trigger().catch(() => {}),
     });
   }
 
@@ -88,7 +97,7 @@ export function InvitationLinkActions({
         open={confirmOpen}
         title="Resend invitation link?"
         body={`A new invitation link will be delivered to ${invitation.speakerName} via ${formatChannels(deliverable)}. Any earlier link is invalidated.`}
-        confirmLabel={`Resend via ${formatChannels(deliverable)}`}
+        confirmLabel={`Resend Invite via ${formatChannels(deliverable)}`}
         busy={status.kind === "working"}
         onCancel={() => setConfirmOpen(false)}
         onConfirm={() => {
@@ -96,6 +105,7 @@ export function InvitationLinkActions({
           void resend();
         }}
       />
+      {downloadSent.portal}
     </div>
   );
 }

--- a/src/features/invitations/InvitationLinkActions/__tests__/InvitationLinkActions.test.tsx
+++ b/src/features/invitations/InvitationLinkActions/__tests__/InvitationLinkActions.test.tsx
@@ -57,7 +57,7 @@ describe("InvitationLinkActions", () => {
   it("Resend menu item shows both channels when invitation has email + phone", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    expect(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" })).toBeTruthy();
   });
 
   it("renders no overflow items when no delivery channel is available", () => {
@@ -70,7 +70,7 @@ describe("InvitationLinkActions", () => {
   it("selecting Resend opens a confirmation dialog instead of firing immediately", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" }));
     expect(screen.getByRole("dialog", { name: "Resend invitation link?" })).toBeTruthy();
     expect(mockFn).not.toHaveBeenCalled();
   });
@@ -78,7 +78,7 @@ describe("InvitationLinkActions", () => {
   it("Cancel on the confirm dialog does not fire the callable", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" }));
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockFn).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -92,8 +92,8 @@ describe("InvitationLinkActions", () => {
     const inv = mkInvitation({ speakerEmail: undefined });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via SMS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Resend via SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via SMS" }));
+    fireEvent.click(screen.getByRole("button", { name: "Resend Invite via SMS" }));
     await waitFor(() => expect(screen.getByText("Delivery failed.")).toBeTruthy());
   });
 
@@ -107,8 +107,8 @@ describe("InvitationLinkActions", () => {
     });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Resend via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("button", { name: "Resend Invite via EMAIL + SMS" }));
     await waitFor(() => expect(screen.getByText("Sent via SMS")).toBeTruthy());
   });
 });

--- a/src/features/invitations/InvitationLinkActions/useDownloadSentLetter.tsx
+++ b/src/features/invitations/InvitationLinkActions/useDownloadSentLetter.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { letterCanvasToPdf } from "@/features/page-editor/utils/letterToPdf";
+import { downloadFile, shareLetterPdf } from "@/features/page-editor/utils/shareLetterPdf";
+import { LetterCanvas } from "@/features/templates/LetterCanvas";
+import { formatVersionTimestamp } from "@/features/templates/utils/letterDates";
+import type { SpeakerInvitation } from "@/lib/types";
+
+interface Result {
+  /** Fire to render the snapshot portal, capture the PDF, and hand it
+   *  to the platform-appropriate sink (Web Share on mobile, direct
+   *  download on desktop). Throws on capture failure. */
+  trigger: () => Promise<void>;
+  /** True while the PDF is being generated — disable any UI that
+   *  shouldn't fire a parallel capture. */
+  busy: boolean;
+  /** Render this in the host component to keep the transient portal
+   *  in the React tree. Returns null when no capture is in flight. */
+  portal: React.ReactNode;
+}
+
+const PORTAL_ATTR = "data-sent-invitation-portal";
+
+/** Captures the *originally sent* invitation letter as a PDF and
+ *  hands it to the OS share sheet (mobile) or downloads it (desktop).
+ *  Renders a transient hidden LetterCanvas portal sourced from the
+ *  frozen invitation snapshot — the bishop always sees what the
+ *  speaker actually received, even after the ward template was
+ *  edited downstream. The portal uses its own data attribute so it
+ *  never collides with the prepare page's `[data-print-only-letter]`
+ *  selector. */
+export function useDownloadSentLetter(invitation: SpeakerInvitation, invitationId: string): Result {
+  const isMobile = useIsMobile();
+  const [active, setActive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Resolves once the off-screen portal has mounted into the DOM —
+  // letterCanvasToPdf needs an actual HTMLElement, and React doesn't
+  // give us a synchronous "node attached" callback otherwise.
+  const mountedResolverRef = useRef<(() => void) | null>(null);
+  const mountedPromiseRef = useRef<Promise<void> | null>(null);
+
+  const trigger = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    mountedPromiseRef.current = new Promise<void>((resolve) => {
+      mountedResolverRef.current = resolve;
+    });
+    setActive(true);
+    try {
+      await mountedPromiseRef.current;
+      const target = document.querySelector<HTMLElement>(`[${PORTAL_ATTR}]`);
+      if (!target) throw new Error("Couldn't render the sent letter for download.");
+      const filename = pdfFilename(invitation.speakerName, invitation.speakerRef.meetingDate);
+      const { file } = await letterCanvasToPdf(target, filename);
+      if (isMobile) {
+        await shareLetterPdf(file, filename, `Invitation for ${invitation.speakerName}`);
+      } else {
+        downloadFile(file, filename);
+      }
+    } finally {
+      setActive(false);
+      setBusy(false);
+      mountedResolverRef.current = null;
+      mountedPromiseRef.current = null;
+    }
+  }, [busy, invitation, isMobile]);
+
+  return {
+    trigger,
+    busy,
+    portal: active ? (
+      <SentLetterPortal
+        invitation={invitation}
+        invitationId={invitationId}
+        onMounted={() => mountedResolverRef.current?.()}
+      />
+    ) : null,
+  };
+}
+
+interface PortalProps {
+  invitation: SpeakerInvitation;
+  invitationId: string;
+  onMounted: () => void;
+}
+
+/** Off-screen rendered copy of the invitation snapshot. Stays in the
+ *  React tree only during a capture window; styled by the global
+ *  `[data-print-only-letter]` rule analogue applied via the portal
+ *  attribute so it never paints on screen — `letterCanvasToPdf`
+ *  parks it at `left: -100000px` for the duration of the html2canvas
+ *  call, then reverts. */
+function SentLetterPortal({ invitation, invitationId, onMounted }: PortalProps) {
+  useEffect(() => {
+    onMounted();
+  }, [onMounted]);
+  const stampText = formatVersionTimestamp(invitation.createdAt);
+  const versionStamp = stampText ? ({ label: "Sent", text: stampText } as const) : undefined;
+  return createPortal(
+    <div data-sent-invitation-portal={invitationId} style={{ display: "none" }}>
+      <LetterCanvas
+        wardName={invitation.wardName}
+        assignedDate={invitation.assignedDate}
+        today={invitation.sentOn}
+        bodyMarkdown={invitation.bodyMarkdown}
+        footerMarkdown={invitation.footerMarkdown}
+        {...(invitation.editorStateJson ? { editorStateJson: invitation.editorStateJson } : {})}
+        {...(versionStamp ? { versionStamp } : {})}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+function pdfFilename(speakerName: string, date: string): string {
+  const slug = speakerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `invitation-${slug || "speaker"}-${date}.pdf`;
+}

--- a/src/features/page-editor/utils/shareLetterPdf.ts
+++ b/src/features/page-editor/utils/shareLetterPdf.ts
@@ -28,11 +28,14 @@ export async function shareLetterPdf(
       if (err instanceof DOMException && err.name === "AbortError") return "shared";
     }
   }
-  download(file, filename);
+  downloadFile(file, filename);
   return "downloaded";
 }
 
-function download(file: File, filename: string): void {
+/** Triggers a plain browser download. Exported so callers that
+ *  explicitly want a download (desktop "Download letter" affordance)
+ *  can bypass the share-sheet round-trip in `shareLetterPdf`. */
+export function downloadFile(file: File, filename: string): void {
   const url = URL.createObjectURL(file);
   const a = document.createElement("a");
   a.href = url;

--- a/src/features/prayers/hooks/usePreparePrayerActions.ts
+++ b/src/features/prayers/hooks/usePreparePrayerActions.ts
@@ -113,6 +113,21 @@ export function usePreparePrayerActions(args: Args) {
     });
   }
 
+  /** Persist the in-flight letter as a per-prayer-giver override
+   *  without triggering a send. Mirrors the speaker-side `save`. */
+  async function save(): Promise<void> {
+    form.setBusy(true);
+    form.setError(null);
+    try {
+      await form.persistOverrides();
+    } catch (e) {
+      form.setError(friendlyWriteError(e));
+      throw e;
+    } finally {
+      form.setBusy(false);
+    }
+  }
+
   return {
     markInvited: () =>
       void runAction(() =>
@@ -125,5 +140,6 @@ export function usePreparePrayerActions(args: Args) {
       void runAction(() => sendVia(["email"], email ? { email } : undefined)),
     sendSms: (phone?: string) =>
       void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
+    save,
   };
 }

--- a/src/features/prayers/hooks/usePreparePrayerInvitation.ts
+++ b/src/features/prayers/hooks/usePreparePrayerInvitation.ts
@@ -40,6 +40,7 @@ export function usePreparePrayerInvitation(args: Args) {
   });
   const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
   const [letterHasOverride, setLetterHasOverride] = useState(false);
+  const [savedAt, setSavedAt] = useState<unknown>(null);
   const [hydrated, setHydrated] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -67,6 +68,7 @@ export function usePreparePrayerInvitation(args: Args) {
       setInitialMarkdown(md);
       setLetterStateJson(json);
       setLetterHasOverride(Boolean(override));
+      setSavedAt(override?.updatedAt ?? null);
       setError(null);
       setHydrated(true);
     })();
@@ -103,6 +105,10 @@ export function usePreparePrayerInvitation(args: Args) {
     if (!letterStateJson) return;
     await savePrayerLetterOverride(wardId, date, role, { editorStateJson: letterStateJson });
     setLetterHasOverride(true);
+    // Mirror the speaker hook: advance the dirty baseline + the
+    // version-stamp timestamp on a successful save.
+    setInitialJson(letterStateJson);
+    setSavedAt(new Date());
   }
 
   function revertLetterToWardDefault() {
@@ -112,6 +118,7 @@ export function usePreparePrayerInvitation(args: Args) {
       bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_PRAYER_LETTER_BODY,
       footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_PRAYER_LETTER_FOOTER,
     });
+    setSavedAt(null);
     setResetKey((k) => k + 1);
   }
 
@@ -129,6 +136,8 @@ export function usePreparePrayerInvitation(args: Args) {
     }
   }
 
+  const dirty = letterStateJson !== null && letterStateJson !== initialJson;
+
   return {
     initialJson,
     initialMarkdown,
@@ -138,6 +147,8 @@ export function usePreparePrayerInvitation(args: Args) {
     letterBody,
     letterFooter,
     letterHasOverride,
+    savedAt,
+    dirty,
     hydrated,
     resetKey,
     error,

--- a/src/features/templates/LetterCanvas.tsx
+++ b/src/features/templates/LetterCanvas.tsx
@@ -27,6 +27,12 @@ interface Props {
    *  inside the settings page. The landing page + PDF paths skip this
    *  so the letter renders at true letter-sheet proportions. */
   compact?: boolean;
+  /** Reference-only metadata stamp rendered in the page's bottom
+   *  margin, visually outside the letter card. Captured in PDF export
+   *  so the holder of a printed copy knows which version they have.
+   *  Omitted on live preview / embed paths so the on-screen paper
+   *  stays clean while editing. */
+  versionStamp?: { label: "Saved" | "Sent"; text: string };
 }
 
 /**
@@ -44,10 +50,12 @@ export function LetterCanvas({
   footerMarkdown,
   editorStateJson,
   compact,
+  versionStamp,
 }: Props) {
   const rendered = editorStateJson ? renderLetterState(editorStateJson, { assignedDate }) : null;
   return (
     <div
+      data-letter-page
       className={cn(
         // Typography rules mirror the editor's contenteditable
         // (`prose prose-sm font-serif text-[16.5px] leading-[1.65]
@@ -90,6 +98,32 @@ export function LetterCanvas({
           </div>
         </>
       )}
+
+      {versionStamp && <VersionStamp stamp={versionStamp} compact={compact === true} />}
+    </div>
+  );
+}
+
+/** Reference-only metadata, sitting in the page's bottom margin so
+ *  the holder of a printed copy can identify which version they have.
+ *  Visually + structurally separate from the letter content above. */
+function VersionStamp({
+  stamp,
+  compact,
+}: {
+  stamp: { label: "Saved" | "Sent"; text: string };
+  compact: boolean;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute left-0 right-0 text-center",
+        "font-mono text-[8.5px] tracking-[0.18em] uppercase text-walnut-3/60",
+        compact ? "bottom-2" : "bottom-[0.3in]",
+      )}
+    >
+      {stamp.label} {stamp.text}
     </div>
   );
 }

--- a/src/features/templates/PrepareInvitationActionBar/PrepareInvitationActionBar.tsx
+++ b/src/features/templates/PrepareInvitationActionBar/PrepareInvitationActionBar.tsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
-import { RotateCcw, Send, Share } from "lucide-react";
+import { Download, RotateCcw, Send, Share } from "lucide-react";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { letterCanvasToPdf } from "@/features/page-editor/utils/letterToPdf";
-import { shareLetterPdf } from "@/features/page-editor/utils/shareLetterPdf";
+import { downloadFile, shareLetterPdf } from "@/features/page-editor/utils/shareLetterPdf";
 import { PrepareInvitationDialogs } from "../PrepareInvitationDialogs";
 import { PrepareInvitationGroupBtn as GroupBtn } from "../PrepareInvitationGroupBtn";
+import { ToolbarSaveButton } from "./ToolbarSaveButton";
 
 interface Props {
   busy: boolean;
   hasOverride: boolean;
+  /** True when the editor state has unsaved edits. Gates the
+   *  Download/Share button (must save first so the PDF + Firestore
+   *  agree on what's "the letter"). */
+  dirty: boolean;
   speakerName: string;
   /** Current email / phone on file for the speaker. Used to prefill
    *  the Send-channel dialog; empty strings are handled (the dialog
@@ -17,6 +23,7 @@ interface Props {
   /** Meeting date (ISO YYYY-MM-DD) — used for the shared PDF filename. */
   assignedDate: string;
   onRevert: () => void;
+  onSave: () => void;
   /** Called with the final email the bishop confirmed in the dialog.
    *  The parent is responsible for persisting it to the speaker doc
    *  when it differs from what was on file. */
@@ -30,42 +37,52 @@ type PendingSend = "email" | "sms" | null;
 const ICON_SIZE = 14;
 const ICON_STROKE = 1.75;
 
-/** Top-of-page action toolbar for the Prepare Invitation page. Two
- *  icon-only buttons in a connected group (Revert · Share), then
- *  text-labelled Send Email + Send SMS buttons. Share renders the
- *  LetterCanvas portal to a PDF and hands it to the OS share sheet
- *  (Web Share API, with download fallback) so the bishop can route
- *  the letter through any installed app — same path as the speaker
- *  invite landing page. Sharing never flips status; the bishop
- *  controls status explicitly via the menu on the assign page. */
+/** Top-of-page action toolbar for the Prepare Invitation page.
+ *  Three groups: [Revert | Share/Download], [Save], [Send Email,
+ *  Send SMS]. The Share/Download split picks Share on touch viewports
+ *  (Web Share API → OS share sheet) and Download on desktop (direct
+ *  PDF download — no surprising "I clicked Share but got a download"
+ *  fallback). Both paths are gated on `!dirty` so the artifact the
+ *  bishop hands out always matches what's persisted in Firestore. */
 export function PrepareInvitationActionBar({
   busy,
   hasOverride,
+  dirty,
   speakerName,
   speakerEmail,
   speakerPhone,
   assignedDate,
   onRevert,
+  onSave,
   onSend,
   onSendSms,
 }: Props) {
   const [pending, setPending] = useState<PendingConfirm>(null);
   const [pendingSend, setPendingSend] = useState<PendingSend>(null);
-  const [sharing, setSharing] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const isMobile = useIsMobile();
 
-  async function doShare() {
-    if (sharing) return;
+  async function doExport() {
+    if (exporting) return;
     const target = document.querySelector<HTMLElement>("[data-print-only-letter]");
     if (!target) return;
-    setSharing(true);
+    setExporting(true);
     try {
       const filename = pdfFilename(speakerName, assignedDate);
       const { file } = await letterCanvasToPdf(target, filename);
-      await shareLetterPdf(file, filename, `Invitation for ${speakerName}`);
+      if (isMobile) {
+        await shareLetterPdf(file, filename, `Invitation for ${speakerName}`);
+      } else {
+        downloadFile(file, filename);
+      }
     } finally {
-      setSharing(false);
+      setExporting(false);
     }
   }
+
+  const exportLabel = isMobile ? "Share letter" : "Download letter";
+  const exportDisabledLabel = dirty ? `Save to ${isMobile ? "share" : "download"}` : exportLabel;
+  const ExportIcon = isMobile ? Share : Download;
 
   return (
     <div className="flex flex-col items-center">
@@ -82,13 +99,14 @@ export function PrepareInvitationActionBar({
           </GroupBtn>
           <GroupBtn
             position="last"
-            label="Share letter"
-            onClick={() => void doShare()}
-            disabled={busy || sharing}
+            label={dirty ? exportDisabledLabel : exportLabel}
+            onClick={() => void doExport()}
+            disabled={busy || exporting || dirty}
           >
-            <Share size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <ExportIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </GroupBtn>
         </div>
+        <ToolbarSaveButton dirty={dirty} busy={busy} onSave={onSave} />
         <button
           type="button"
           onClick={() => setPendingSend("email")}

--- a/src/features/templates/PrepareInvitationActionBar/ToolbarSaveButton.tsx
+++ b/src/features/templates/PrepareInvitationActionBar/ToolbarSaveButton.tsx
@@ -1,0 +1,34 @@
+import { Save } from "lucide-react";
+
+interface Props {
+  /** True when the editor state differs from the last saved/initial
+   *  snapshot. Drives the disabled state. */
+  dirty: boolean;
+  busy: boolean;
+  onSave: () => void;
+}
+
+const ICON_SIZE = 14;
+const ICON_STROKE = 1.75;
+
+/** Save the current letter as a per-speaker override without sending.
+ *  Disabled when there's nothing to save (so the bishop never wonders
+ *  "did anything happen?" after clicking) or while another action is
+ *  in flight. Same neutral chrome as Send Email so the eye groups
+ *  Save / Send Email / Send SMS as the three terminal actions. */
+export function ToolbarSaveButton({ dirty, busy, onSave }: Props) {
+  const disabled = !dirty || busy;
+  return (
+    <button
+      type="button"
+      onClick={onSave}
+      disabled={disabled}
+      aria-label={dirty ? "Save changes" : "No changes to save"}
+      title={dirty ? "Save changes" : "No changes to save"}
+      className="inline-flex items-center gap-2 rounded-md border border-border-strong bg-chalk px-3.5 sm:px-4 h-9 sm:h-10 text-walnut font-sans text-[13px] font-semibold tracking-[0.01em] transition-colors hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-chalk"
+    >
+      <Save size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+      <span>Save</span>
+    </button>
+  );
+}

--- a/src/features/templates/PrepareInvitationLetterTab.tsx
+++ b/src/features/templates/PrepareInvitationLetterTab.tsx
@@ -22,6 +22,11 @@ interface Props {
   onInitial: (json: string) => void;
   resetKey: number;
   vars: LetterVars;
+  /** Reference-only metadata stamp threaded into the off-screen
+   *  PrintOnlyLetter portal so the PDF export carries it. The on-
+   *  screen editor + mobile preview deliberately omit it — pure
+   *  reference metadata, not part of the letter content. */
+  printVersionStamp?: { label: "Saved" | "Sent"; text: string };
 }
 
 /** Per-speaker letter editor on the prepare-invitation route — same
@@ -39,6 +44,7 @@ export function PrepareInvitationLetterTab({
   onInitial,
   resetKey,
   vars,
+  printVersionStamp,
 }: Props) {
   const isMobile = useIsMobile();
   const renderedBody = useMemo(() => interpolate(body, vars), [body, vars]);
@@ -58,6 +64,7 @@ export function PrepareInvitationLetterTab({
         bodyMarkdown={renderedBody}
         footerMarkdown={renderedFooter}
         {...(printEditorStateJson ? { editorStateJson: printEditorStateJson } : {})}
+        {...(printVersionStamp ? { versionStamp: printVersionStamp } : {})}
       />
       <div className="relative h-full">
         {isMobile ? (

--- a/src/features/templates/PrintOnlyLetter.tsx
+++ b/src/features/templates/PrintOnlyLetter.tsx
@@ -9,6 +9,9 @@ interface Props {
   bodyMarkdown: string;
   footerMarkdown: string;
   editorStateJson?: string;
+  /** Reference-only metadata stamp captured by the PDF export but
+   *  hidden from the live editor preview. */
+  versionStamp?: { label: "Saved" | "Sent"; text: string };
 }
 
 /** Portals a print-only `<LetterCanvas>` into `document.body` so the

--- a/src/features/templates/UnsavedLetterConfirm.tsx
+++ b/src/features/templates/UnsavedLetterConfirm.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+interface Props {
+  open: boolean;
+  /** True while the Save & exit path is in flight. Disables every
+   *  button so a double-click can't queue two saves. */
+  busy: boolean;
+  /** Surface a save failure inline so the bishop sees the reason
+   *  instead of the modal silently staying open. */
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => void;
+}
+
+/** Three-button exit guard for the Prepare Invitation editor.
+ *  Save & exit / Discard / Cancel — explicit choices so the bishop
+ *  always knows what happens to in-flight edits. Modeled on the
+ *  assign-slot DiscardChangesConfirm but adds the Save path the
+ *  letter editor needs.
+ *
+ *  Esc keeps editing (capture-phase + `stopImmediatePropagation` so
+ *  the page's exit-guard Esc handler doesn't reopen this same
+ *  modal). Backdrop click also keeps editing — accidental dismissals
+ *  shouldn't navigate away. */
+export function UnsavedLetterConfirm({
+  open,
+  busy,
+  error,
+  onKeepEditing,
+  onDiscard,
+  onSaveAndExit,
+}: Props) {
+  useLockBodyScroll(open);
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      if (!busy) onKeepEditing();
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, busy, onKeepEditing]);
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="unsaved-letter-confirm-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onKeepEditing();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+        <h2
+          id="unsaved-letter-confirm-title"
+          className="font-display text-[19px] font-semibold text-walnut mb-1.5"
+        >
+          Unsaved changes
+        </h2>
+        <p className="font-serif text-[14px] text-walnut-2 leading-relaxed mb-5">
+          You have unsaved edits to this letter. Save them before leaving so the next download or
+          send uses your latest copy?
+        </p>
+        {error && (
+          <p className="font-sans text-[12.5px] text-bordeaux mb-4" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={onKeepEditing}
+            disabled={busy}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={busy}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-bordeaux hover:bg-bordeaux/5 disabled:opacity-60"
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            onClick={onSaveAndExit}
+            disabled={busy}
+            className="rounded-md border border-walnut bg-walnut px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-walnut-2 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {busy ? "Saving…" : "Save & exit"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/templates/hooks/usePrepareInvitation.ts
+++ b/src/features/templates/hooks/usePrepareInvitation.ts
@@ -48,6 +48,7 @@ export function usePrepareInvitation(args: Args) {
   });
   const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
   const [letterHasOverride, setLetterHasOverride] = useState(false);
+  const [savedAt, setSavedAt] = useState<unknown>(null);
   const [hydrated, setHydrated] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -75,6 +76,7 @@ export function usePrepareInvitation(args: Args) {
       setInitialMarkdown(md);
       setLetterStateJson(json);
       setLetterHasOverride(Boolean(override));
+      setSavedAt(override?.updatedAt ?? null);
       setError(null);
       setHydrated(true);
     })();
@@ -111,6 +113,13 @@ export function usePrepareInvitation(args: Args) {
     if (!letterStateJson) return;
     await saveSpeakerLetterOverride(wardId, date, speakerId, { editorStateJson: letterStateJson });
     setLetterHasOverride(true);
+    // Advance the dirty baseline so the toolbar Save button + exit
+    // guard reflect the freshly-persisted state. `serverTimestamp()`
+    // resolves on the server; mirroring with `new Date()` locally is
+    // a near-enough approximation for the version stamp without a
+    // round-trip read.
+    setInitialJson(letterStateJson);
+    setSavedAt(new Date());
   }
 
   function revertLetterToWardDefault() {
@@ -120,6 +129,7 @@ export function usePrepareInvitation(args: Args) {
       bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
       footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
     });
+    setSavedAt(null);
     setResetKey((k) => k + 1);
   }
 
@@ -137,6 +147,8 @@ export function usePrepareInvitation(args: Args) {
     }
   }
 
+  const dirty = letterStateJson !== null && letterStateJson !== initialJson;
+
   return {
     initialJson,
     initialMarkdown,
@@ -146,6 +158,8 @@ export function usePrepareInvitation(args: Args) {
     letterBody,
     letterFooter,
     letterHasOverride,
+    savedAt,
+    dirty,
     hydrated,
     resetKey,
     error,

--- a/src/features/templates/hooks/usePrepareInvitationActions.ts
+++ b/src/features/templates/hooks/usePrepareInvitationActions.ts
@@ -126,6 +126,22 @@ export function usePrepareInvitationActions(args: Args) {
     await updateSpeaker(args.wardId, args.date, args.speakerId, { status: "invited" });
   }
 
+  /** Save the in-flight letter as a per-speaker override without
+   *  triggering a send. Surfaces busy/error through the same form
+   *  channels as Send so the toolbar disables consistently. */
+  async function save(): Promise<void> {
+    form.setBusy(true);
+    form.setError(null);
+    try {
+      await form.persistOverrides();
+    } catch (e) {
+      form.setError(friendlyWriteError(e));
+      throw e;
+    } finally {
+      form.setBusy(false);
+    }
+  }
+
   return {
     markInvited: () =>
       void runAction(() =>
@@ -135,5 +151,6 @@ export function usePrepareInvitationActions(args: Args) {
       void runAction(() => sendVia(["email"], email ? { email } : undefined)),
     sendSms: (phone?: string) =>
       void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
+    save,
   };
 }

--- a/src/features/templates/hooks/useSavableExit.ts
+++ b/src/features/templates/hooks/useSavableExit.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "@/lib/nav";
+
+interface Options {
+  /** True when the editor has unsaved changes. When false the
+   *  Cancel/Esc path navigates straight to /schedule with no
+   *  confirmation. */
+  dirty: boolean;
+  /** Persist the in-flight letter. Returns/awaits a promise so the
+   *  modal can show a busy state and avoid navigating on save
+   *  failure. Throws on failure — caller surfaces the error. */
+  onSave: () => Promise<void>;
+}
+
+interface SavableExit {
+  /** Wire to the header Cancel/X button. Opens the confirm modal
+   *  when there are unsaved edits, otherwise navigates straight to
+   *  /schedule. */
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  busy: boolean;
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => Promise<void>;
+}
+
+/** Three-way exit guard for editors with explicit Save (Prepare
+ *  Invitation, Prepare Prayer Invitation). When `dirty`, opens a
+ *  modal offering Save & exit / Discard / Cancel. Mirrors
+ *  `useDiscardableExit` in the assign-slot feature but adds the
+ *  Save path and the busy/error bookkeeping it needs.
+ *
+ *  Esc routes through `requestCancel` so desktop keyboard users hit
+ *  the same guard. The host modal owns its own Esc handler with
+ *  `stopImmediatePropagation`, so this listener stays silent while
+ *  the modal is already open. */
+export function useSavableExit({ dirty, onSave }: Options): SavableExit {
+  const navigate = useNavigate();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestCancel = useCallback(() => {
+    if (dirty) {
+      setError(null);
+      setConfirmOpen(true);
+    } else {
+      navigate("/schedule");
+    }
+  }, [dirty, navigate]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      requestCancel();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [requestCancel]);
+
+  return {
+    requestCancel,
+    confirmOpen,
+    busy,
+    error,
+    onKeepEditing: () => {
+      if (busy) return;
+      setConfirmOpen(false);
+    },
+    onDiscard: () => {
+      setConfirmOpen(false);
+      navigate("/schedule");
+    },
+    onSaveAndExit: async () => {
+      if (busy) return;
+      setBusy(true);
+      setError(null);
+      try {
+        await onSave();
+        setConfirmOpen(false);
+        navigate("/schedule");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Couldn't save. Try again.");
+      } finally {
+        setBusy(false);
+      }
+    },
+  };
+}

--- a/src/features/templates/utils/letterDates.ts
+++ b/src/features/templates/utils/letterDates.ts
@@ -21,3 +21,50 @@ export function formatToday(): string {
     year: "numeric",
   });
 }
+
+/** Convenience for the prepare pages: turn the persisted `savedAt`
+ *  Firestore Timestamp into the `versionStamp` prop shape consumed by
+ *  PrintOnlyLetter, or `null` when there's no parseable timestamp.
+ *  Returning the discriminated shape directly keeps the per-page glue
+ *  one inlinable expression. */
+export function buildSavedVersionStamp(savedAt: unknown): { label: "Saved"; text: string } | null {
+  const text = formatVersionTimestamp(savedAt);
+  return text ? { label: "Saved", text } : null;
+}
+
+/** Renders a short reference timestamp for the bottom-of-page version
+ *  stamp on PDF exports — e.g. "May 2, 2026 · 2:23 PM". Accepts a
+ *  Date, ISO string, or a Firestore Timestamp-shaped object with
+ *  `toDate()`. Returns `null` when the value is missing or unparseable
+ *  so callers can omit the stamp without rendering "Saved Invalid Date". */
+export function formatVersionTimestamp(value: unknown): string | null {
+  const date = coerceDate(value);
+  if (!date) return null;
+  const d = date.toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const t = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${d} · ${t}`;
+}
+
+function coerceDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === "string") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  if (typeof value === "object" && value !== null && "toDate" in value) {
+    const fn = (value as { toDate: () => Date }).toDate;
+    if (typeof fn === "function") {
+      const d = fn.call(value);
+      return d instanceof Date && !Number.isNaN(d.getTime()) ? d : null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary

- **Save + exit guard.** New toolbar Save button (lucide `Save`, enabled only when dirty). Cancel/X/Esc opens a 3-button modal — Cancel / Discard / **Save & exit** — when there are unsaved edits. Closing the tab no longer silently drops every customization.
- **Share/Download split, gated on save.** Mobile keeps `Share` (Web Share API). Desktop now shows `Download` and triggers a direct PDF download (no surprise share-sheet fallback). Both disabled while dirty with the tooltip "Save to download" / "Save to share" — *what you save is what you share*.
- **Reference-only version stamp on PDF output.** A small mono "Saved {date · time}" line in the page's bottom margin — visually and structurally outside the letter content, never mistaken for the bishop's message. Live editor preview deliberately stays clean.
- **Download Sent Invitation Letter** in the bishop's conversation drawer overflow menu. Sourced from the immutable `speakerInvitations` snapshot and stamped "Sent {date · time}" from `createdAt`, so the bishop always retrieves the exact letter the speaker received — even if the ward template was edited afterward.
- **"Resend via SMS" → "Resend Invite via SMS"** for unambiguous wording (it rotates and redelivers the invitation link, not a chat reply).

Same wiring applied to the parallel prayer prepare page (`PreparePrayerInvitation*`). No changes to the invitation flow itself — token lifecycle, delivery channels, and recipients are untouched, so `docs/invitation-flow.md` doesn't need a sync.

## Test plan

- [ ] **Desktop, prepare page**: button reads "Download letter" with download icon. Edits are blocked from export until you click Save (button greys out, tooltip explains). Click Save → button activates → click Download → PDF downloads as `invitation-{slug}-{date}.pdf`. Open the PDF — bottom of the page shows a small `Saved {today · time}` line.
- [ ] **Mobile (DevTools 375px or real device)**: button reads "Share letter" with share icon → opens OS share sheet (or downloads on browsers without Web Share). Same Save-first gate.
- [ ] **Reload after Save**: edits persist (no longer evaporate).
- [ ] **Edit + Cancel/X/Esc**: 3-button modal appears. *Save & exit* persists then navigates; *Discard* navigates without saving; *Cancel* keeps editing. *Save & exit* surfaces an inline error and stays open if save fails.
- [ ] **Live editor preview** has **no** version stamp on screen — only on the captured PDF.
- [ ] **Bishop drawer → overflow menu** for an already-sent invitation shows two items: "Resend Invite via {channels}" and "Download Sent Invitation Letter". Click Download → PDF of the *sent* letter (mobile share / desktop download). Modify the ward template afterward — re-download still produces the originally-sent letter.
- [ ] **Prayer prepare page** mirrors all of the above (`/week/:date/prayer/:role/prepare`).

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors
- `pnpm format:check` — clean
- `pnpm test` — 473/473 passing (InvitationLinkActions tests updated for the relabel)
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)