### PR TITLE
feat(schedule): dynamic speaker slots — floor 2, ceiling 4 + Add another speaker

### DIFF
--- a/src/features/schedule/AddAnotherSpeakerRow.tsx
+++ b/src/features/schedule/AddAnotherSpeakerRow.tsx
@@ -1,0 +1,48 @@
+import { Link } from "@/lib/nav";
+
+interface Props {
+  /** Meeting date (ISO YYYY-MM-DD) — destination is the same
+   *  per-row Assign + Invite flow that empty placeholder rows use. */
+  date: string;
+}
+
+/** "+ Add another speaker" affordance shown below the filled
+ *  speaker rows when the count is at or above the floor but below
+ *  the ceiling. Visually distinct from a slot placeholder: no
+ *  numbered leading column (since this is an action, not a slot),
+ *  brass `+` glyph + walnut verb. Mirrors the iOS `addSpeakerRow`
+ *  pattern on `MeetingCardBody`. */
+export function AddAnotherSpeakerRow({ date }: Props) {
+  return (
+    <li className="border-b border-border last:border-b-0">
+      <Link
+        to={`/week/${date}/speaker/new/assign`}
+        className="flex items-center gap-3 h-12 group/add hover:bg-parchment-2 transition-colors"
+      >
+        {/* Spacer matching the leading-label column on the rows above
+            so the pill aligns with the assignee-name column. */}
+        <div className="w-6 shrink-0" aria-hidden="true" />
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full border border-brass bg-parchment-2 text-brass-deep shrink-0">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.25"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </span>
+          <span className="font-sans text-[13px] text-walnut-2 group-hover/add:text-walnut">
+            Add another speaker
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/schedule/MobileSundayBody.tsx
+++ b/src/features/schedule/MobileSundayBody.tsx
@@ -1,10 +1,10 @@
 import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
-import { SpeakerRow } from "./SpeakerRow";
-import { PrayerRow } from "./PrayerRow";
+import { AddAnotherSpeakerRow } from "./AddAnotherSpeakerRow";
 import { EmptyRosterRow } from "./EmptyRosterRow";
-
-const SPEAKER_SLOT_COUNT = 4;
+import { PrayerRow } from "./PrayerRow";
+import { SpeakerRow } from "./SpeakerRow";
+import { canAddAnotherSpeaker, speakerPlaceholderCount } from "./utils/speakerSlots";
 
 interface Props {
   date: string;
@@ -12,14 +12,15 @@ interface Props {
   speakers: WithId<Speaker>[];
 }
 
-/** Mobile body for a regular Sunday. Always renders 4 speaker slots
- *  + 2 prayer slots — empty slots fall back to "Not assigned"
- *  placeholder rows. Mirrors the desktop card body's vertical rhythm
- *  so the list reads as a consistent table without requiring the
- *  user to count present-vs-missing. The kebab menu in the date row
- *  is the entry point for "Plan speakers" / "Plan prayers" actions. */
+/** Mobile body for a regular Sunday. Speaker rows render dynamically
+ *  (floor of 2 placeholder rows on a fresh card, ceiling of 4 visible
+ *  before the explicit "Add another speaker" affordance hides) so a
+ *  partially-filled meeting doesn't push prayers off the visible
+ *  list with empty noise. Prayer rows always render — bishops use
+ *  them as the implicit footer. */
 export function MobileSundayBody({ date, meeting, speakers }: Props) {
-  const placeholderCount = Math.max(0, SPEAKER_SLOT_COUNT - speakers.length);
+  const placeholderCount = speakerPlaceholderCount(speakers.length);
+  const showAddAnother = canAddAnotherSpeaker(speakers.length);
   return (
     <div className="px-4 pb-3">
       <ul className="list-none m-0 p-0">
@@ -37,6 +38,7 @@ export function MobileSundayBody({ date, meeting, speakers }: Props) {
             />
           );
         })}
+        {showAddAnother && <AddAnotherSpeakerRow date={date} />}
         <PrayerRow
           role="opening"
           date={date}

--- a/src/features/schedule/SundayCard/__tests__/SundayCard.test.tsx
+++ b/src/features/schedule/SundayCard/__tests__/SundayCard.test.tsx
@@ -68,7 +68,11 @@ describe("SundayCard", () => {
 
   it("shows Assign Speaker pills on empty rows", () => {
     renderCard();
-    // 4 empty speaker slots all render as Assign pills.
-    expect(screen.getAllByText("Assign Speaker").length).toBeGreaterThan(0);
+    // Fresh card with no speakers shows the floor of 2 placeholder
+    // rows — not the old fixed 4 — so the meeting reads as an
+    // invitation to assign without padding the height with empty
+    // noise.
+    expect(screen.getAllByText("Assign Speaker")).toHaveLength(2);
+    expect(screen.queryByText("Add another speaker")).toBeNull();
   });
 });

--- a/src/features/schedule/SundayCardBody.tsx
+++ b/src/features/schedule/SundayCardBody.tsx
@@ -1,10 +1,10 @@
 import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
+import { AddAnotherSpeakerRow } from "./AddAnotherSpeakerRow";
 import { EmptyRosterRow } from "./EmptyRosterRow";
 import { PrayerRow } from "./PrayerRow";
 import { SpeakerRow } from "./SpeakerRow";
-
-const SPEAKER_SLOT_COUNT = 4;
+import { canAddAnotherSpeaker, speakerPlaceholderCount } from "./utils/speakerSlots";
 
 interface Props {
   speakers: WithId<Speaker>[];
@@ -12,11 +12,16 @@ interface Props {
   meeting: SacramentMeeting | null;
 }
 
+/** Desktop schedule card body. Speaker rows render dynamically: the
+ *  card holds at least the floor (2) so a fresh card invites action,
+ *  grows naturally as speakers are added, and stops at the ceiling
+ *  (4) by hiding the explicit "Add another speaker" affordance —
+ *  rosters that legitimately need a 5th can still be backed by data,
+ *  but the typical card stays visually compact. Mirrors the iOS
+ *  `MeetingCardBody` slot rules. */
 export function SundayCardBody({ speakers, date, meeting }: Props) {
-  // Fixed slot count keeps every Sunday card the same height across
-  // the schedule grid — actual speakers fill the first slots, empty
-  // placeholder rows back-fill up to SPEAKER_SLOT_COUNT.
-  const placeholderCount = Math.max(0, SPEAKER_SLOT_COUNT - speakers.length);
+  const placeholderCount = speakerPlaceholderCount(speakers.length);
+  const showAddAnother = canAddAnotherSpeaker(speakers.length);
   return (
     <div className="flex flex-1 flex-col px-4 pb-4">
       <ul className="list-none m-0 p-0 mb-2">
@@ -34,6 +39,7 @@ export function SundayCardBody({ speakers, date, meeting }: Props) {
             />
           );
         })}
+        {showAddAnother && <AddAnotherSpeakerRow date={date} />}
       </ul>
       <ul className="list-none m-0 p-0 mb-2 border-t-2 border-walnut-3 pt-1">
         <PrayerRow

--- a/src/features/schedule/utils/speakerSlots.test.ts
+++ b/src/features/schedule/utils/speakerSlots.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { canAddAnotherSpeaker, speakerPlaceholderCount } from "./speakerSlots";
+
+describe("speakerPlaceholderCount", () => {
+  // The card rests on a 2-row visual floor so a fresh meeting reads
+  // as "two slots inviting action" rather than a single lonely row.
+  it("pads up to the floor when the assigned count is below it", () => {
+    expect(speakerPlaceholderCount(0)).toBe(2);
+    expect(speakerPlaceholderCount(1)).toBe(1);
+  });
+
+  // Once the floor is met, no more padding — the card grows row-by-row
+  // with the actual speakers.
+  it("returns 0 when the assigned count is at or above the floor", () => {
+    expect(speakerPlaceholderCount(2)).toBe(0);
+    expect(speakerPlaceholderCount(3)).toBe(0);
+    expect(speakerPlaceholderCount(4)).toBe(0);
+    expect(speakerPlaceholderCount(7)).toBe(0);
+  });
+});
+
+describe("canAddAnotherSpeaker", () => {
+  // Below the floor the empty placeholder slots already invite the
+  // bishop to assign — a second add affordance would be redundant.
+  it("is false below the floor", () => {
+    expect(canAddAnotherSpeaker(0)).toBe(false);
+    expect(canAddAnotherSpeaker(1)).toBe(false);
+  });
+
+  // Between floor and ceiling: the explicit "+ Add another speaker"
+  // row appears so the bishop can grow the roster past the typical
+  // count without first staring at empty slots.
+  it("is true between floor and ceiling", () => {
+    expect(canAddAnotherSpeaker(2)).toBe(true);
+    expect(canAddAnotherSpeaker(3)).toBe(true);
+  });
+
+  // At or above the ceiling: no add affordance — the card stops
+  // growing visually. (Existing rosters with more docs still render
+  // every speaker; the cap only governs the explicit add button.)
+  it("is false at or above the ceiling", () => {
+    expect(canAddAnotherSpeaker(4)).toBe(false);
+    expect(canAddAnotherSpeaker(5)).toBe(false);
+    expect(canAddAnotherSpeaker(7)).toBe(false);
+  });
+});

--- a/src/features/schedule/utils/speakerSlots.ts
+++ b/src/features/schedule/utils/speakerSlots.ts
@@ -1,0 +1,35 @@
+/** Floor for visible speaker rows on a Sunday card — the typical
+ *  ward floor. Below this, empty rows render as "Assign Speaker"
+ *  placeholders so a fresh card invites action rather than reading
+ *  as a single lonely row. */
+export const SPEAKER_SLOT_FLOOR = 2;
+
+/** Ceiling for visible speaker rows. Once the assigned count reaches
+ *  this, the "Add another speaker" affordance disappears and the
+ *  card stops growing. Mirrors the iOS app's `maxSpeakerSlots = 4`. */
+export const SPEAKER_SLOT_CEILING = 4;
+
+/** Whether to render the explicit "Add another speaker" affordance
+ *  below the last filled row. Only true when the assigned count is
+ *  at or above the floor (so empty placeholder rows aren't already
+ *  serving as the add invitation) AND below the ceiling (so there's
+ *  room to add another). Mirrors `Speaker.canAddMore` on iOS. */
+export function canAddAnotherSpeaker(
+  assignedCount: number,
+  floor: number = SPEAKER_SLOT_FLOOR,
+  ceiling: number = SPEAKER_SLOT_CEILING,
+): boolean {
+  return assignedCount >= floor && assignedCount < ceiling;
+}
+
+/** How many empty placeholder rows to render below the actual
+ *  speakers so the card meets the floor. Returns 0 once the assigned
+ *  count is at or above the floor — the card grows naturally beyond
+ *  that, capped only by the ceiling via the add affordance.
+ *  Mirrors `Speaker.slots(items, minSlotCount: 2)` on iOS. */
+export function speakerPlaceholderCount(
+  assignedCount: number,
+  floor: number = SPEAKER_SLOT_FLOOR,
+): number {
+  return Math.max(0, floor - assignedCount);
+}


### PR DESCRIPTION
## Summary

Ports the iOS app's speaker-slot rules to the web schedule. The web side used to render a fixed 4 speaker rows for every Sunday and pad short lists with "Assign Speaker" placeholders — a meeting with 1 speaker stacked three empty rows below it, which was both noisy and inconsistent with iOS.

New rules (mirroring `Speaker.slots` + `Speaker.canAddMore` in steward-ios):

| Assigned | Rendered |
|---:|---|
| 0 | 2 placeholder rows. No add button. |
| 1 | 1 filled + 1 placeholder. No add button. |
| 2 | 2 filled + "+ Add another speaker". |
| 3 | 3 filled + "+ Add another speaker". |
| 4 | 4 filled. No add button (ceiling). |
| 5+ | All filled. No add button (existing rosters still render every speaker — the cap only governs the explicit add affordance). |

The "+ Add another speaker" row is a separate affordance from the slot placeholders: no leading slot number, indented to align with the assignee-name column. Below the floor, the placeholder pills serve as the add invitation; at/above the ceiling, the card stops growing visually.

Applied symmetrically to desktop ([SundayCardBody](src/features/schedule/SundayCardBody.tsx)) and mobile ([MobileSundayBody](src/features/schedule/MobileSundayBody.tsx)).

## Test plan

- [ ] **0 speakers**: Sunday card shows exactly 2 "Assign Speaker" pills (was 4). No "Add another speaker" button.
- [ ] **1 speaker assigned**: 1 filled row + 1 placeholder. No "Add another" button.
- [ ] **2 speakers assigned**: both filled + "+ Add another speaker" row visible. Click → routes to `/week/{date}/speaker/new/assign`.
- [ ] **3 speakers**: same — 3 filled + "+ Add another speaker".
- [ ] **4 speakers**: all 4 filled, no "Add another speaker".
- [ ] **5+ speakers** (if seeded): all rows render; no "Add another" button.
- [ ] Verify on **mobile breakpoint** ([MobileSundayBody](src/features/schedule/MobileSundayBody.tsx)) and **desktop schedule grid** ([SundayCardBody](src/features/schedule/SundayCardBody.tsx)).
- [ ] Prayer rows (Opening, Closing) always render below the speaker section.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — 0 errors
- `pnpm format:check` — clean
- `pnpm test` — 478 passing (5 new from the slot-helper unit tests; existing SundayCard test updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)