### PR TITLE
fix(schedule): pin prayers to card bottom + keep OP/CP labels when filled

### DIFF
--- a/src/features/schedule/PrayerRow.tsx
+++ b/src/features/schedule/PrayerRow.tsx
@@ -76,6 +76,9 @@ export function PrayerRow({ inlineName, role, date, hideEmpty = false }: Props) 
         to={`/week/${date}/prayer/${role}/assign`}
         className="flex items-center gap-3 flex-1 min-w-0 hover:bg-parchment-2 transition-colors -mx-1 px-1 rounded-sm"
       >
+        <div className="font-mono text-[10.5px] tracking-[0.08em] text-brass-deep w-6 shrink-0">
+          {ROLE_LABEL[role]}
+        </div>
         <div className="flex-1 min-w-0">
           <div className="font-sans text-sm font-semibold text-walnut truncate">{name}</div>
           <div className="font-serif italic text-sm text-walnut-2 truncate">

--- a/src/features/schedule/SundayCardBody.tsx
+++ b/src/features/schedule/SundayCardBody.tsx
@@ -41,7 +41,7 @@ export function SundayCardBody({ speakers, date, meeting }: Props) {
         })}
         {showAddAnother && <AddAnotherSpeakerRow date={date} />}
       </ul>
-      <ul className="list-none m-0 p-0 mb-2 border-t-2 border-walnut-3 pt-1">
+      <ul className="list-none m-0 p-0 mb-2 mt-auto border-t-2 border-walnut-3 pt-1">
         <PrayerRow
           role="opening"
           date={date}


### PR DESCRIPTION
## Summary
- Pin the prayers section to the bottom of each desktop Sunday card via `mt-auto` so adjacent cards keep their prayer rows visually aligned regardless of speaker count.
- Restore the mono `OP` / `CP` leading column on filled `PrayerRow`s — previously the leading column only appeared on the empty placeholder, so a filled "Test / Opening Prayer" lost its alignment with the speaker rows above.

## Test plan
- [ ] Desktop schedule grid: cards with different speaker counts (e.g. 2 vs 3 speakers, with/without "Add another speaker") show prayer rows aligned across columns
- [ ] Filled opening / closing prayer rows display the `OP` / `CP` leading label, aligned with `01`/`02` speaker numbers
- [ ] Empty prayer placeholder still renders the existing `OP Assign Opening Prayer` row
- [ ] Mobile schedule list (`MobileSundayBody`) is unaffected
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)