### PR TITLE
Release: v0.22.0 — dynamic speaker slots, prepare-invitation Save, shared close button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.22.0] — 2026-05-03
+
+UX-focused minor release. Sunday cards on the schedule now mirror the iOS app's dynamic speaker-slot rules, the prepare-invitation page gets an explicit Save with platform-aware export and a sent-letter download, and four close-button surfaces consolidate onto a single labeled primitive.
+
+### Added
+
+- **Dynamic speaker slots on the schedule.** Sunday cards previously rendered four fixed speaker rows and padded short lists with empty "Assign Speaker" pills. Slots are now driven by assignment count: 0 → two placeholders, 1 → one filled + one placeholder, 2–3 → all filled with an explicit "+ Add another speaker" affordance, 4 → all filled with no add button (ceiling). 5+ existing speakers still render in full — the cap only governs the explicit add control. Applied symmetrically on `SundayCardBody` (desktop) and `MobileSundayBody` (mobile). Mirrors `Speaker.slots` + `Speaker.canAddMore` in steward-ios. (#242)
+- **Explicit Save on the prepare-invitation page.** New toolbar Save button (lucide `Save`, enabled only when dirty). Cancel/X/Esc on a dirty draft opens a 3-button modal — *Cancel* / *Discard* / *Save & exit* — so closing the tab no longer silently drops every customization. Reload after Save now persists the edits. Same wiring on the parallel prayer prepare page. (#241)
+- **Sent-invitation download in the bishop chat overflow.** New "Download Sent Invitation Letter" item sourced from the immutable `speakerInvitations` snapshot and stamped "Sent {date · time}" from `createdAt`, so the bishop always retrieves the exact letter the speaker received — even if the ward template was edited afterward. (#241)
+- **`HeaderCloseButton` shared primitive.** Extracts the labeled Cancel control (X icon + visible label, 44 px hit target, focus ring, walnut → bordeaux hover) into `src/components/ui/HeaderCloseButton.tsx`. Replaces the tiny mono "Close" labels and icon-only `×` buttons across the speaker chat drawer, bishop invitation dialog, and the speaker + prayer prepare-invitation pages so all five surfaces stay locked together. (#240)
+
+### Changed
+
+- **Assign-slot Cancel is now an obvious affordance.** The 14 px walnut-3 `×` in the per-row Assign + Invite header is replaced with a labeled **Cancel** button (icon + text, walnut, 44 px hit target) on desktop and mobile. Esc binds at the form level so keyboard users land on the same exit path. When the form is dirty, Cancel + Esc open a 2-button `DiscardChangesConfirm` (Keep editing / Discard) — two-button instead of three because the form has two save actions (Save as Planned + Continue), so an in-prompt save would be ambiguous. (#239)
+- **Platform-aware export on the prepare-invitation page.** Desktop now shows **Download** and triggers a direct PDF download (no surprise share-sheet fallback); mobile keeps **Share** via the Web Share API. Both gate on Save with the tooltip "Save to download" / "Save to share" — what you save is what you share. PDF output carries a small mono "Saved {date · time}" reference stamp in the bottom margin, kept off the live editor preview so it's never mistaken for the bishop's message. (#241)
+- **"Resend via SMS" → "Resend Invite via SMS"** in the bishop chat overflow menu. Unambiguous wording — it rotates and redelivers the invitation link, not a chat reply. (#241)
+
+### Fixed
+
+- **Prayer rows pinned to the bottom of desktop Sunday cards.** Adjacent cards with different speaker counts now keep their prayer rows visually aligned via `mt-auto`. Filled `PrayerRow`s also restore the mono `OP` / `CP` leading column — previously only the empty placeholder rendered it, so a filled "Opening Prayer" row lost its alignment with the speaker numbers above. Mobile list is unaffected. (#243)
+
 ## [0.21.2] — 2026-05-03
 
 Patch release: precision tweak to the schedule countdown labels.
@@ -2520,7 +2541,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.21.2...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/aylabyuk/steward/releases/tag/v0.22.0
 [0.21.2]: https://github.com/aylabyuk/steward/releases/tag/v0.21.2
 [0.21.1]: https://github.com/aylabyuk/steward/releases/tag/v0.21.1
 [0.21.0]: https://github.com/aylabyuk/steward/releases/tag/v0.21.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.21.2",
+  "version": "0.22.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/app/routes/assign-prayer/AssignPrayerPage.tsx
+++ b/src/app/routes/assign-prayer/AssignPrayerPage.tsx
@@ -5,7 +5,6 @@ import {
   type AssignAction,
   type AssignSeed,
 } from "@/features/assign-slot/AssignSlotForm";
-import { AssignSlotHeader } from "@/features/assign-slot/AssignSlotHeader";
 import { persistAssignPrayer } from "@/features/assign-slot/utils/persistAssignPrayer";
 import {
   clearPrayerParticipant,
@@ -130,15 +129,13 @@ export function AssignPrayerPage() {
 
   return (
     <main className="min-h-dvh bg-parchment flex flex-col">
-      <AssignSlotHeader
-        eyebrow={`Assign ${role === "opening" ? "opening prayer" : "closing prayer"}`}
-        title={seedName.trim() ? seedName : ROLE_TITLE[role]}
-        subtitle={date ? formatShortSunday(date) : undefined}
-      />
       <AssignSlotForm
         seed={seed}
         busy={busy}
         error={error}
+        eyebrow={`Assign ${role === "opening" ? "opening prayer" : "closing prayer"}`}
+        title={seedName.trim() ? seedName : ROLE_TITLE[role]}
+        subtitle={date ? formatShortSunday(date) : undefined}
         onSubmit={onSubmit}
         {...(hasExistingPrayer
           ? {

--- a/src/app/routes/assign-speaker/AssignSpeakerPage.tsx
+++ b/src/app/routes/assign-speaker/AssignSpeakerPage.tsx
@@ -122,15 +122,13 @@ export function AssignSpeakerPage() {
 
   return (
     <main className="min-h-dvh bg-parchment flex flex-col">
-      <AssignSlotHeader
-        eyebrow={isNew ? "Assign speaker" : "Edit speaker"}
-        title={isNew ? "New speaker" : (existing?.data.name ?? "Speaker")}
-        subtitle={date ? formatShortSunday(date) : undefined}
-      />
       <AssignSlotForm
         seed={seed}
         busy={busy}
         error={error}
+        eyebrow={isNew ? "Assign speaker" : "Edit speaker"}
+        title={isNew ? "New speaker" : (existing?.data.name ?? "Speaker")}
+        subtitle={date ? formatShortSunday(date) : undefined}
         onSubmit={onSubmit}
         {...(existing
           ? {

--- a/src/app/routes/prepare-invitation/PrepareInvitationContent.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationContent.tsx
@@ -1,0 +1,111 @@
+import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
+import { UnsavedLetterConfirm } from "@/features/templates/UnsavedLetterConfirm";
+import { buildSavedVersionStamp } from "@/features/templates/utils/letterDates";
+import type { LetterVars } from "@/features/templates/utils/prepareInvitationVars";
+import type { Speaker } from "@/lib/types";
+import { PrepareInvitationHeader } from "./PrepareInvitationHeader";
+import { computeSendValidation } from "./utils/prepareInvitationValidation";
+
+interface FormState {
+  busy: boolean;
+  hydrated: boolean;
+  dirty: boolean;
+  letterHasOverride: boolean;
+  initialJson: string | null;
+  initialMarkdown: { bodyMarkdown: string; footerMarkdown: string };
+  letterStateJson: string | null;
+  letterBody: string;
+  letterFooter: string;
+  resetKey: number;
+  error: string | null;
+  savedAt: unknown;
+  setLetterStateJson: (json: string) => void;
+  captureInitial: (json: string) => void;
+  clearLetterOverride: () => Promise<void>;
+}
+
+interface ActionState {
+  save: () => Promise<void>;
+  send: (email?: string) => void;
+  sendSms: (phone?: string) => void;
+}
+
+interface ExitState {
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  busy: boolean;
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => Promise<void>;
+}
+
+interface Props {
+  date: string;
+  speaker: Speaker;
+  vars: LetterVars;
+  form: FormState;
+  actions: ActionState;
+  exit: ExitState;
+}
+
+/** Post-guard render shell for the speaker prepare page. Owns the
+ *  header + body layout, the editor mount, and the unsaved-changes
+ *  modal. Extracted so PrepareInvitationPage stays inside the
+ *  component-size budget while keeping the orchestration (hooks,
+ *  guards, embed branch) at the route level. */
+export function PrepareInvitationContent({ date, speaker, vars, form, actions, exit }: Props) {
+  const { email, hasEmail } = computeSendValidation(speaker);
+  const printVersionStamp = buildSavedVersionStamp(form.savedAt);
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PrepareInvitationHeader
+        email={email}
+        hasEmail={hasEmail}
+        busy={form.busy}
+        hasOverride={form.letterHasOverride}
+        dirty={form.dirty}
+        speakerName={speaker.name}
+        speakerEmail={speaker.email ?? ""}
+        speakerPhone={speaker.phone ?? ""}
+        assignedDate={date}
+        onCancel={exit.requestCancel}
+        onRevert={() => void form.clearLetterOverride()}
+        onSave={() => void actions.save().catch(() => {})}
+        onSend={actions.send}
+        onSendSms={actions.sendSms}
+      />
+      <div className="flex-1 min-h-0 lg:overflow-hidden">
+        {form.hydrated ? (
+          <PrepareInvitationLetterTab
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            liveStateJson={form.letterStateJson}
+            body={form.letterBody}
+            footer={form.letterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
+            vars={vars}
+            {...(printVersionStamp ? { printVersionStamp } : {})}
+          />
+        ) : (
+          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
+            Loading letter…
+          </p>
+        )}
+        {form.error && (
+          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
+        )}
+      </div>
+      <UnsavedLetterConfirm
+        open={exit.confirmOpen}
+        busy={exit.busy}
+        error={exit.error}
+        onKeepEditing={exit.onKeepEditing}
+        onDiscard={exit.onDiscard}
+        onSaveAndExit={() => void exit.onSaveAndExit()}
+      />
+    </main>
+  );
+}

--- a/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
@@ -1,4 +1,4 @@
-import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
 import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitationActionBar";
 
 interface Props {
@@ -51,7 +51,11 @@ export function PrepareInvitationHeader(props: Props) {
             onSendSms={props.onSendSms}
           />
         </div>
-        <CancelButton onClick={props.onCancel} />
+        <HeaderCloseButton
+          onClick={props.onCancel}
+          label="Cancel"
+          ariaLabel="Cancel and return to schedule"
+        />
       </div>
       <div className="lg:hidden flex justify-center">
         <PrepareInvitationActionBar
@@ -67,19 +71,5 @@ export function PrepareInvitationHeader(props: Props) {
         />
       </div>
     </header>
-  );
-}
-
-function CancelButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Cancel and return to schedule"
-      title="Cancel"
-      className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
-    >
-      <RemoveIcon />
-    </button>
   );
 }

--- a/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationHeader.tsx
@@ -9,11 +9,15 @@ interface Props {
   hasEmail: boolean;
   busy: boolean;
   hasOverride: boolean;
+  /** True when the editor state has unsaved edits — gates the action
+   *  bar's Save (enabled) and Share/Download (disabled) affordances. */
+  dirty: boolean;
   /** Meeting date (ISO YYYY-MM-DD) — threaded to the action bar's
    *  share path so the generated PDF filename includes it. */
   assignedDate: string;
   onCancel: () => void;
   onRevert: () => void;
+  onSave: () => void;
   onSend: (email: string) => void;
   onSendSms: (phone: string) => void;
 }
@@ -42,11 +46,13 @@ export function PrepareInvitationHeader(props: Props) {
           <PrepareInvitationActionBar
             busy={props.busy}
             hasOverride={props.hasOverride}
+            dirty={props.dirty}
             speakerName={props.speakerName}
             speakerEmail={props.speakerEmail}
             speakerPhone={props.speakerPhone}
             assignedDate={props.assignedDate}
             onRevert={props.onRevert}
+            onSave={props.onSave}
             onSend={props.onSend}
             onSendSms={props.onSendSms}
           />

--- a/src/app/routes/prepare-invitation/PrepareInvitationPage.tsx
+++ b/src/app/routes/prepare-invitation/PrepareInvitationPage.tsx
@@ -1,21 +1,20 @@
 import { useMemo, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
-import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
 import { EmbedLetterView } from "@/features/embed/EmbedLetterView";
 import { useEmbedAuthBootstrap } from "@/features/embed/useEmbedAuthBootstrap";
 import { useEmbedShareBridge } from "@/features/embed/useEmbedShareBridge";
-import { PrepareInvitationHeader } from "./PrepareInvitationHeader";
 import { formatAssignedDate, formatToday } from "@/features/templates/utils/letterDates";
 import { useSpeakerLetterTemplate } from "@/features/templates/hooks/useSpeakerLetterTemplate";
 import { usePrepareInvitation } from "@/features/templates/hooks/usePrepareInvitation";
 import { usePrepareInvitationActions } from "@/features/templates/hooks/usePrepareInvitationActions";
+import { useSavableExit } from "@/features/templates/hooks/useSavableExit";
 import { useAuthStore } from "@/stores/authStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { PrepareInvitationContent } from "./PrepareInvitationContent";
 import { PrepareInvitationPageMessage } from "../PrepareInvitationPageMessage";
-import { computeSendValidation } from "./utils/prepareInvitationValidation";
 
 export function PrepareInvitationPage() {
   const { date, speakerId } = useParams<{ date: string; speakerId: string }>();
@@ -23,7 +22,6 @@ export function PrepareInvitationPage() {
   const isEmbed = searchParams.get("embed") === "ios";
   const embedAuth = useEmbedAuthBootstrap();
   useEmbedShareBridge();
-  const navigate = useNavigate();
   const wardId = useCurrentWardStore((s) => s.wardId);
   const me = useCurrentMember();
   const authUser = useAuthStore((s) => s.user);
@@ -70,6 +68,8 @@ export function PrepareInvitationPage() {
     onDone: () => setDone(true),
   });
 
+  const exit = useSavableExit({ dirty: form.dirty, onSave: actions.save });
+
   if (!wardId || !date || !speakerId) {
     return (
       <PrepareInvitationPageMessage
@@ -105,50 +105,14 @@ export function PrepareInvitationPage() {
     return <EmbedLetterView authStatus={embedAuth} form={form} date={date} wardName={wardName} vars={vars} />;
   }
 
-  const { email, hasEmail } = computeSendValidation(speaker.data);
-
-  const toolbarProps = {
-    busy: form.busy,
-    hasOverride: form.letterHasOverride,
-    speakerName: speaker.data.name,
-    speakerEmail: speaker.data.email ?? "",
-    speakerPhone: speaker.data.phone ?? "",
-    assignedDate: date,
-    onRevert: () => void form.clearLetterOverride(),
-    onSend: actions.send,
-    onSendSms: actions.sendSms,
-  };
-
   return (
-    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
-      <PrepareInvitationHeader
-        email={email}
-        hasEmail={hasEmail}
-        onCancel={() => navigate("/schedule")}
-        {...toolbarProps}
-      />
-      <div className="flex-1 min-h-0 lg:overflow-hidden">
-        {form.hydrated ? (
-          <PrepareInvitationLetterTab
-            initialJson={form.initialJson}
-            initialMarkdown={form.initialMarkdown}
-            liveStateJson={form.letterStateJson}
-            body={form.letterBody}
-            footer={form.letterFooter}
-            onChange={form.setLetterStateJson}
-            onInitial={form.captureInitial}
-            resetKey={form.resetKey}
-            vars={vars}
-          />
-        ) : (
-          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
-            Loading letter…
-          </p>
-        )}
-        {form.error && (
-          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
-        )}
-      </div>
-    </main>
+    <PrepareInvitationContent
+      date={date}
+      speaker={speaker.data}
+      vars={vars}
+      form={form}
+      actions={actions}
+      exit={exit}
+    />
   );
 }

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationContent.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationContent.tsx
@@ -1,0 +1,123 @@
+import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
+import { UnsavedLetterConfirm } from "@/features/templates/UnsavedLetterConfirm";
+import { buildSavedVersionStamp } from "@/features/templates/utils/letterDates";
+import type { LetterVars } from "@/features/templates/utils/prepareInvitationVars";
+import { isValidEmail } from "@/lib/email";
+import type { PrayerRole } from "@/lib/types";
+import { PreparePrayerInvitationHeader } from "./PreparePrayerInvitationHeader";
+
+interface FormState {
+  busy: boolean;
+  hydrated: boolean;
+  dirty: boolean;
+  letterHasOverride: boolean;
+  initialJson: string | null;
+  initialMarkdown: { bodyMarkdown: string; footerMarkdown: string };
+  letterStateJson: string | null;
+  letterBody: string;
+  letterFooter: string;
+  resetKey: number;
+  error: string | null;
+  savedAt: unknown;
+  setLetterStateJson: (json: string) => void;
+  captureInitial: (json: string) => void;
+  clearLetterOverride: () => Promise<void>;
+}
+
+interface ActionState {
+  save: () => Promise<void>;
+  send: (email?: string) => void;
+  sendSms: (phone?: string) => void;
+}
+
+interface ExitState {
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  busy: boolean;
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => Promise<void>;
+}
+
+interface Props {
+  date: string;
+  role: PrayerRole;
+  prayerGiverName: string;
+  prayerGiverEmail: string;
+  prayerGiverPhone: string;
+  vars: LetterVars;
+  form: FormState;
+  actions: ActionState;
+  exit: ExitState;
+}
+
+/** Post-guard render shell for the prayer prepare page. Mirrors
+ *  PrepareInvitationContent for the speaker side; both stay just
+ *  separate enough that header / hook differences don't have to
+ *  branch inside one component. */
+export function PreparePrayerInvitationContent({
+  date,
+  role,
+  prayerGiverName,
+  prayerGiverEmail,
+  prayerGiverPhone,
+  vars,
+  form,
+  actions,
+  exit,
+}: Props) {
+  const printVersionStamp = buildSavedVersionStamp(form.savedAt);
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PreparePrayerInvitationHeader
+        role={role}
+        email={prayerGiverEmail}
+        hasEmail={isValidEmail(prayerGiverEmail)}
+        busy={form.busy}
+        hasOverride={form.letterHasOverride}
+        dirty={form.dirty}
+        speakerName={prayerGiverName}
+        speakerEmail={prayerGiverEmail}
+        speakerPhone={prayerGiverPhone}
+        assignedDate={date}
+        onCancel={exit.requestCancel}
+        onRevert={() => void form.clearLetterOverride()}
+        onSave={() => void actions.save().catch(() => {})}
+        onSend={actions.send}
+        onSendSms={actions.sendSms}
+      />
+      <div className="flex-1 min-h-0 lg:overflow-hidden">
+        {form.hydrated ? (
+          <PrepareInvitationLetterTab
+            initialJson={form.initialJson}
+            initialMarkdown={form.initialMarkdown}
+            liveStateJson={form.letterStateJson}
+            body={form.letterBody}
+            footer={form.letterFooter}
+            onChange={form.setLetterStateJson}
+            onInitial={form.captureInitial}
+            resetKey={form.resetKey}
+            vars={vars}
+            {...(printVersionStamp ? { printVersionStamp } : {})}
+          />
+        ) : (
+          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
+            Loading letter…
+          </p>
+        )}
+        {form.error && (
+          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
+        )}
+      </div>
+      <UnsavedLetterConfirm
+        open={exit.confirmOpen}
+        busy={exit.busy}
+        error={exit.error}
+        onKeepEditing={exit.onKeepEditing}
+        onDiscard={exit.onDiscard}
+        onSaveAndExit={() => void exit.onSaveAndExit()}
+      />
+    </main>
+  );
+}

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
@@ -1,4 +1,4 @@
-import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
 import type { PrayerRole } from "@/lib/types";
 import { PrepareInvitationActionBar } from "@/features/templates/PrepareInvitationActionBar";
 
@@ -54,25 +54,15 @@ export function PreparePrayerInvitationHeader(props: Props) {
         <div className="hidden lg:block shrink-0">
           <PrepareInvitationActionBar {...actionBarProps} />
         </div>
-        <CancelButton onClick={props.onCancel} />
+        <HeaderCloseButton
+          onClick={props.onCancel}
+          label="Cancel"
+          ariaLabel="Cancel and return to schedule"
+        />
       </div>
       <div className="lg:hidden flex justify-center">
         <PrepareInvitationActionBar {...actionBarProps} />
       </div>
     </header>
-  );
-}
-
-function CancelButton({ onClick }: { onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      aria-label="Cancel and return to schedule"
-      title="Cancel"
-      className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
-    >
-      <RemoveIcon />
-    </button>
   );
 }

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationHeader.tsx
@@ -11,11 +11,15 @@ interface Props {
   hasEmail: boolean;
   busy: boolean;
   hasOverride: boolean;
+  /** True when the editor state has unsaved edits — gates Save +
+   *  Share/Download in the action bar. */
+  dirty: boolean;
   /** Meeting date (ISO YYYY-MM-DD) — threaded to the action bar's
    *  share path so the generated PDF filename includes it. */
   assignedDate: string;
   onCancel: () => void;
   onRevert: () => void;
+  onSave: () => void;
   onSend: (email: string) => void;
   onSendSms: (phone: string) => void;
 }
@@ -29,11 +33,13 @@ export function PreparePrayerInvitationHeader(props: Props) {
   const actionBarProps = {
     busy: props.busy,
     hasOverride: props.hasOverride,
+    dirty: props.dirty,
     speakerName: props.speakerName,
     speakerEmail: props.speakerEmail,
     speakerPhone: props.speakerPhone,
     assignedDate: props.assignedDate,
     onRevert: props.onRevert,
+    onSave: props.onSave,
     onSend: props.onSend,
     onSendSms: props.onSendSms,
   };

--- a/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationPage.tsx
+++ b/src/app/routes/prepare-prayer-invitation/PreparePrayerInvitationPage.tsx
@@ -1,22 +1,21 @@
 import { useMemo, useState } from "react";
-import { useNavigate, useParams, useSearchParams } from "react-router";
+import { useParams, useSearchParams } from "react-router";
 import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useMeeting } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { usePrayerLetterTemplate } from "@/features/templates/hooks/usePrayerLetterTemplate";
-import { PrepareInvitationLetterTab } from "@/features/templates/PrepareInvitationLetterTab";
 import { EmbedLetterView } from "@/features/embed/EmbedLetterView";
 import { useEmbedAuthBootstrap } from "@/features/embed/useEmbedAuthBootstrap";
 import { useEmbedShareBridge } from "@/features/embed/useEmbedShareBridge";
 import { formatAssignedDate, formatToday } from "@/features/templates/utils/letterDates";
-import { isValidEmail } from "@/lib/email";
+import { useSavableExit } from "@/features/templates/hooks/useSavableExit";
 import { type PrayerRole, prayerRoleSchema } from "@/lib/types";
 import { useAuthStore } from "@/stores/authStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { usePrayerParticipant } from "@/features/prayers/hooks/usePrayerParticipant";
 import { usePreparePrayerInvitation } from "@/features/prayers/hooks/usePreparePrayerInvitation";
 import { usePreparePrayerActions } from "@/features/prayers/hooks/usePreparePrayerActions";
-import { PreparePrayerInvitationHeader } from "./PreparePrayerInvitationHeader";
+import { PreparePrayerInvitationContent } from "./PreparePrayerInvitationContent";
 import { PrepareInvitationPageMessage } from "../PrepareInvitationPageMessage";
 
 export function PreparePrayerInvitationPage() {
@@ -25,7 +24,6 @@ export function PreparePrayerInvitationPage() {
   const isEmbed = searchParams.get("embed") === "ios";
   const embedAuth = useEmbedAuthBootstrap();
   useEmbedShareBridge();
-  const navigate = useNavigate();
   const wardId = useCurrentWardStore((s) => s.wardId);
   const me = useCurrentMember();
   const authUser = useAuthStore((s) => s.user);
@@ -84,6 +82,8 @@ export function PreparePrayerInvitationPage() {
     onDone: () => setDone(true),
   });
 
+  const exit = useSavableExit({ dirty: form.dirty, onSave: actions.save });
+
   if (!wardId || !date || !role) {
     return (
       <PrepareInvitationPageMessage
@@ -115,51 +115,17 @@ export function PreparePrayerInvitationPage() {
     return <EmbedLetterView authStatus={embedAuth} form={form} date={date} wardName={wardName} vars={vars} />;
   }
 
-  const hasEmail = isValidEmail(prayerGiverEmail);
-
-  const toolbarProps = {
-    busy: form.busy,
-    hasOverride: form.letterHasOverride,
-    speakerName: prayerGiverName,
-    speakerEmail: prayerGiverEmail,
-    speakerPhone: prayerGiverPhone,
-    assignedDate: date,
-    onRevert: () => void form.clearLetterOverride(),
-    onSend: actions.send,
-    onSendSms: actions.sendSms,
-  };
-
   return (
-    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
-      <PreparePrayerInvitationHeader
-        role={role}
-        email={prayerGiverEmail}
-        hasEmail={hasEmail}
-        onCancel={() => navigate("/schedule")}
-        {...toolbarProps}
-      />
-      <div className="flex-1 min-h-0 lg:overflow-hidden">
-        {form.hydrated ? (
-          <PrepareInvitationLetterTab
-            initialJson={form.initialJson}
-            initialMarkdown={form.initialMarkdown}
-            liveStateJson={form.letterStateJson}
-            body={form.letterBody}
-            footer={form.letterFooter}
-            onChange={form.setLetterStateJson}
-            onInitial={form.captureInitial}
-            resetKey={form.resetKey}
-            vars={vars}
-          />
-        ) : (
-          <p className="px-5 sm:px-8 pt-5 pb-4 font-serif italic text-[14px] text-walnut-3">
-            Loading letter…
-          </p>
-        )}
-        {form.error && (
-          <p className="px-5 sm:px-8 mt-4 font-sans text-[12.5px] text-bordeaux">{form.error}</p>
-        )}
-      </div>
-    </main>
+    <PreparePrayerInvitationContent
+      date={date}
+      role={role}
+      prayerGiverName={prayerGiverName}
+      prayerGiverEmail={prayerGiverEmail}
+      prayerGiverPhone={prayerGiverPhone}
+      vars={vars}
+      form={form}
+      actions={actions}
+      exit={exit}
+    />
   );
 }

--- a/src/components/ui/HeaderCloseButton.tsx
+++ b/src/components/ui/HeaderCloseButton.tsx
@@ -1,0 +1,45 @@
+interface Props {
+  onClick: () => void;
+  /** Visible label. Defaults to "Close". Pages with a routing-style
+   *  cancel pass "Cancel" here. */
+  label?: string;
+  /** Defaults to the visible label. Override when more context helps
+   *  screen readers (e.g. "Close conversation"). */
+  ariaLabel?: string;
+}
+
+/** Labeled close affordance for sticky headers and drawer headers —
+ *  X icon + visible text, 44px hit target, focus ring. Replaces the
+ *  small icon-only or tiny-mono-text close patterns that users
+ *  couldn't find. */
+export function HeaderCloseButton({ onClick, label = "Close", ariaLabel }: Props) {
+  return (
+    <button type="button" onClick={onClick} aria-label={ariaLabel ?? label} className={CLASSES}>
+      <HeaderCloseIcon />
+      <span>{label}</span>
+    </button>
+  );
+}
+
+export const HEADER_CLOSE_BUTTON_CLASSES =
+  "shrink-0 inline-flex items-center gap-1.5 min-h-11 rounded-md px-2.5 py-2 font-sans text-[13px] font-medium text-walnut-2 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30";
+
+const CLASSES = HEADER_CLOSE_BUTTON_CLASSES;
+
+export function HeaderCloseIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
+  );
+}

--- a/src/features/assign-slot/AssignFields.tsx
+++ b/src/features/assign-slot/AssignFields.tsx
@@ -1,0 +1,42 @@
+import { AssignPrayerFields, AssignSpeakerFields } from "./AssignSlotFields";
+import type { AssignSeed } from "./types";
+
+interface Props {
+  draft: AssignSeed;
+  emailInvalid: boolean;
+  phoneInvalid: boolean;
+  disabled: boolean;
+  onChange: (patch: Partial<AssignSeed>) => void;
+}
+
+/** Dispatch wrapper — picks the speaker or prayer field set off the
+ *  draft's kind. Kept in its own file so the parent form stays under
+ *  the 150-LOC cap. */
+export function AssignFields({ draft, emailInvalid, phoneInvalid, disabled, onChange }: Props) {
+  if (draft.kind === "speaker") {
+    return (
+      <AssignSpeakerFields
+        name={draft.name}
+        topic={draft.topic}
+        role={draft.role}
+        email={draft.email}
+        phone={draft.phone}
+        emailInvalid={emailInvalid}
+        phoneInvalid={phoneInvalid}
+        disabled={disabled}
+        onChange={onChange}
+      />
+    );
+  }
+  return (
+    <AssignPrayerFields
+      name={draft.name}
+      email={draft.email}
+      phone={draft.phone}
+      emailInvalid={emailInvalid}
+      phoneInvalid={phoneInvalid}
+      disabled={disabled}
+      onChange={onChange}
+    />
+  );
+}

--- a/src/features/assign-slot/AssignSlotForm.tsx
+++ b/src/features/assign-slot/AssignSlotForm.tsx
@@ -3,44 +3,31 @@ import type { SubState } from "@/hooks/_sub";
 import { DeleteSpeakerConfirm } from "@/features/speakers/DeleteSpeakerConfirm";
 import { isValidEmail } from "@/lib/email";
 import { isE164 } from "@/features/templates/utils/smsInvitation";
-import type { Member, SpeakerRole, SpeakerStatus, WithId } from "@/lib/types";
+import type { Member, SpeakerStatus, WithId } from "@/lib/types";
 import type { StatusSource } from "@/lib/types/meeting";
 import { AssignSlotFooter } from "./AssignSlotFooter";
-import { AssignPrayerFields, AssignSpeakerFields } from "./AssignSlotFields";
+import { AssignSlotHeader } from "./AssignSlotHeader";
+import { AssignFields } from "./AssignFields";
 import { AssignSlotStatusRow } from "./AssignSlotStatusRow";
+import { DiscardChangesConfirm } from "./DiscardChangesConfirm";
+import { useDiscardableExit } from "./hooks/useDiscardableExit";
+import type { AssignAction, AssignSeed } from "./types";
+import { isDirty } from "./utils/isDirty";
 
-export type AssignAction = "save-and-continue" | "save-as-planned";
-
-export interface AssignSpeakerSeed {
-  kind: "speaker";
-  /** Existing speaker doc id when editing. `null` for new. */
-  speakerId: string | null;
-  name: string;
-  topic: string;
-  role: SpeakerRole;
-  email: string;
-  phone: string;
-  /** Status of an existing speaker — drives the delete confirm
-   *  dialog's invited/confirmed warning. */
-  status: SpeakerStatus;
-}
-
-export interface AssignPrayerSeed {
-  kind: "prayer";
-  name: string;
-  email: string;
-  phone: string;
-  /** Status of the prayer-giver — drives the field-locking rule
-   *  (anything other than "planned" locks all inputs). */
-  status: SpeakerStatus;
-}
-
-export type AssignSeed = AssignSpeakerSeed | AssignPrayerSeed;
+export type { AssignAction, AssignPrayerSeed, AssignSeed, AssignSpeakerSeed } from "./types";
 
 interface Props {
   seed: AssignSeed;
   busy: boolean;
   error: string | null;
+  /** Header copy — eyebrow ("Assign speaker"), title (speaker / prayer
+   *  name or "New speaker"), and the Sunday-date subtitle. The page
+   *  used to render the header itself; pulling it inside the form so
+   *  the cancel control can consult dirty-form state for the discard
+   *  confirm. */
+  eyebrow: string;
+  title: string;
+  subtitle?: string | undefined;
   /** Called with the action and the current draft values. */
   onSubmit: (action: AssignAction, draft: AssignSeed) => void;
   /** Edit-mode only — both speaker and prayer pages can pass a delete
@@ -70,6 +57,9 @@ export function AssignSlotForm({
   seed,
   busy,
   error,
+  eyebrow,
+  title,
+  subtitle,
   onSubmit,
   onDelete,
   deleting,
@@ -88,6 +78,8 @@ export function AssignSlotForm({
   // this rather than draft.status (status isn't editable here, so
   // they're identical, but seeding from seed makes intent obvious).
   const locked = seed.status !== "planned";
+  const dirty = !locked && isDirty(draft, seed);
+  const exit = useDiscardableExit({ dirty });
 
   const emailInvalid = draft.email.trim().length > 0 && !isValidEmail(draft.email.trim());
   const phoneInvalid = draft.phone.trim().length > 0 && !isE164(draft.phone.trim());
@@ -109,83 +101,80 @@ export function AssignSlotForm({
   const showDelete = Boolean(onDelete) && (isExistingSpeaker || isExistingPrayer);
 
   return (
-    <div className="flex-1 px-4 py-6 sm:px-8 sm:py-10">
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          submit("save-and-continue");
-        }}
-        className="flex flex-col gap-5 w-full max-w-xl mx-auto sm:bg-chalk sm:border sm:border-border-strong sm:rounded-[14px] sm:shadow-elev-2 sm:p-7"
-      >
-        {onStatusChange && (isExistingSpeaker || isExistingPrayer) && (
-          <AssignSlotStatusRow
-            status={seed.status}
-            kind={draft.kind === "speaker" ? "speaker" : "prayer"}
-            locked={locked}
-            onChange={onStatusChange}
-            {...(currentStatusSource ? { currentStatusSource } : {})}
-            {...(currentStatusSetBy ? { currentStatusSetBy } : {})}
-            {...(members ? { members } : {})}
-            {...(currentUserUid !== undefined ? { currentUserUid } : {})}
-          />
-        )}
+    <>
+      <AssignSlotHeader
+        eyebrow={eyebrow}
+        title={title}
+        subtitle={subtitle}
+        onCancel={exit.requestCancel}
+      />
+      <div className="flex-1 px-4 py-6 sm:px-8 sm:py-10">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            submit("save-and-continue");
+          }}
+          className="flex flex-col gap-5 w-full max-w-xl mx-auto sm:bg-chalk sm:border sm:border-border-strong sm:rounded-[14px] sm:shadow-elev-2 sm:p-7"
+        >
+          {onStatusChange && (isExistingSpeaker || isExistingPrayer) && (
+            <AssignSlotStatusRow
+              status={seed.status}
+              kind={draft.kind === "speaker" ? "speaker" : "prayer"}
+              locked={locked}
+              onChange={onStatusChange}
+              {...(currentStatusSource ? { currentStatusSource } : {})}
+              {...(currentStatusSetBy ? { currentStatusSetBy } : {})}
+              {...(members ? { members } : {})}
+              {...(currentUserUid !== undefined ? { currentUserUid } : {})}
+            />
+          )}
 
-        {draft.kind === "speaker" ? (
-          <AssignSpeakerFields
-            name={draft.name}
-            topic={draft.topic}
-            role={draft.role}
-            email={draft.email}
-            phone={draft.phone}
+          <AssignFields
+            draft={draft}
             emailInvalid={emailInvalid}
             phoneInvalid={phoneInvalid}
             disabled={locked}
-            onChange={(p) => patch(p)}
+            onChange={patch}
           />
-        ) : (
-          <AssignPrayerFields
-            name={draft.name}
-            email={draft.email}
-            phone={draft.phone}
-            emailInvalid={emailInvalid}
-            phoneInvalid={phoneInvalid}
-            disabled={locked}
-            onChange={(p) => patch(p)}
+
+          {error && (
+            <p className="font-sans text-[12.5px] text-bordeaux border border-bordeaux/40 bg-bordeaux/5 rounded-md px-3 py-2">
+              {error}
+            </p>
+          )}
+
+          <AssignSlotFooter
+            canSubmit={canSubmit}
+            busy={busy}
+            showDelete={showDelete}
+            deleteLabel={draft.kind === "prayer" ? "Remove" : "Delete"}
+            showSaveActions={!locked}
+            onDelete={() => setConfirmDelete(true)}
+            onContinue={() => submit("save-and-continue")}
+            onSavePlanned={() => submit("save-as-planned")}
           />
-        )}
 
-        {error && (
-          <p className="font-sans text-[12.5px] text-bordeaux border border-bordeaux/40 bg-bordeaux/5 rounded-md px-3 py-2">
-            {error}
-          </p>
-        )}
-
-        <AssignSlotFooter
-          canSubmit={canSubmit}
-          busy={busy}
-          showDelete={showDelete}
-          deleteLabel={draft.kind === "prayer" ? "Remove" : "Delete"}
-          showSaveActions={!locked}
-          onDelete={() => setConfirmDelete(true)}
-          onContinue={() => submit("save-and-continue")}
-          onSavePlanned={() => submit("save-as-planned")}
-        />
-
-        {showDelete && onDelete && (
-          <DeleteSpeakerConfirm
-            open={confirmDelete}
-            speakerName={draft.name}
-            speakerStatus={draft.status}
-            kind={draft.kind === "speaker" ? "speaker" : "prayer"}
-            busy={Boolean(deleting)}
-            onConfirm={() => {
-              onDelete();
-              setConfirmDelete(false);
-            }}
-            onCancel={() => setConfirmDelete(false)}
-          />
-        )}
-      </form>
-    </div>
+          {showDelete && onDelete && (
+            <DeleteSpeakerConfirm
+              open={confirmDelete}
+              speakerName={draft.name}
+              speakerStatus={draft.status}
+              kind={draft.kind === "speaker" ? "speaker" : "prayer"}
+              busy={Boolean(deleting)}
+              onConfirm={() => {
+                onDelete();
+                setConfirmDelete(false);
+              }}
+              onCancel={() => setConfirmDelete(false)}
+            />
+          )}
+        </form>
+      </div>
+      <DiscardChangesConfirm
+        open={exit.confirmOpen}
+        onKeepEditing={exit.onKeepEditing}
+        onDiscard={exit.onDiscard}
+      />
+    </>
   );
 }

--- a/src/features/assign-slot/AssignSlotHeader.tsx
+++ b/src/features/assign-slot/AssignSlotHeader.tsx
@@ -1,17 +1,23 @@
 import { Link } from "@/lib/nav";
-import { RemoveIcon } from "@/features/schedule/SpeakerInviteIcons";
 
 interface Props {
   eyebrow: string;
   title: string;
   subtitle?: string | undefined;
+  /** When provided, the cancel control fires this callback instead of
+   *  routing. AssignSlotForm wires it to gate close on dirty-form
+   *  discard confirm. Without it, the control falls back to a plain
+   *  Link to /schedule (used by the page's not-found / loading
+   *  branches where there's nothing to discard). */
+  onCancel?: () => void;
 }
 
 /** Sticky header for the per-row Assign + Invite pages. Eyebrow
- *  carries the slot context ("Assign speaker · 02"), title carries
- *  the action ("New speaker"), subtitle carries the meeting date.
- *  Cancel returns to the schedule. */
-export function AssignSlotHeader({ eyebrow, title, subtitle }: Props) {
+ *  carries the slot context ("Edit speaker"), title carries the
+ *  speaker / prayer-giver name, subtitle carries the meeting date.
+ *  Right side is the labeled Cancel control — replaces the prior
+ *  14px walnut-3 "×" that users couldn't find. */
+export function AssignSlotHeader({ eyebrow, title, subtitle, onCancel }: Props) {
   return (
     <header className="sticky top-0 z-20 shrink-0 flex items-start justify-between gap-3 border-b border-border bg-chalk px-4 sm:px-8 py-4">
       <div className="flex flex-col gap-0.5 min-w-0">
@@ -25,14 +31,44 @@ export function AssignSlotHeader({ eyebrow, title, subtitle }: Props) {
           <p className="font-serif italic text-[12.5px] text-walnut-3 truncate">{subtitle}</p>
         )}
       </div>
-      <Link
-        to="/schedule"
-        aria-label="Cancel and return to schedule"
-        title="Cancel"
-        className="shrink-0 -mr-1 rounded-md p-2 text-walnut-3 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30"
-      >
-        <RemoveIcon />
-      </Link>
+      {onCancel ? (
+        <button
+          type="button"
+          onClick={onCancel}
+          aria-label="Cancel and return to schedule"
+          aria-keyshortcuts="Escape"
+          className={CANCEL_CLASSES}
+        >
+          <CancelIcon />
+          <span>Cancel</span>
+        </button>
+      ) : (
+        <Link to="/schedule" aria-label="Cancel and return to schedule" className={CANCEL_CLASSES}>
+          <CancelIcon />
+          <span>Cancel</span>
+        </Link>
+      )}
     </header>
+  );
+}
+
+const CANCEL_CLASSES =
+  "shrink-0 inline-flex items-center gap-1.5 min-h-11 rounded-md px-2.5 py-2 font-sans text-[13px] font-medium text-walnut-2 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30";
+
+function CancelIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M18 6L6 18M6 6l12 12" />
+    </svg>
   );
 }

--- a/src/features/assign-slot/AssignSlotHeader.tsx
+++ b/src/features/assign-slot/AssignSlotHeader.tsx
@@ -1,3 +1,8 @@
+import {
+  HEADER_CLOSE_BUTTON_CLASSES,
+  HeaderCloseButton,
+  HeaderCloseIcon,
+} from "@/components/ui/HeaderCloseButton";
 import { Link } from "@/lib/nav";
 
 interface Props {
@@ -32,43 +37,21 @@ export function AssignSlotHeader({ eyebrow, title, subtitle, onCancel }: Props) 
         )}
       </div>
       {onCancel ? (
-        <button
-          type="button"
+        <HeaderCloseButton
           onClick={onCancel}
-          aria-label="Cancel and return to schedule"
-          aria-keyshortcuts="Escape"
-          className={CANCEL_CLASSES}
-        >
-          <CancelIcon />
-          <span>Cancel</span>
-        </button>
+          label="Cancel"
+          ariaLabel="Cancel and return to schedule"
+        />
       ) : (
-        <Link to="/schedule" aria-label="Cancel and return to schedule" className={CANCEL_CLASSES}>
-          <CancelIcon />
+        <Link
+          to="/schedule"
+          aria-label="Cancel and return to schedule"
+          className={HEADER_CLOSE_BUTTON_CLASSES}
+        >
+          <HeaderCloseIcon />
           <span>Cancel</span>
         </Link>
       )}
     </header>
-  );
-}
-
-const CANCEL_CLASSES =
-  "shrink-0 inline-flex items-center gap-1.5 min-h-11 rounded-md px-2.5 py-2 font-sans text-[13px] font-medium text-walnut-2 hover:text-bordeaux hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30";
-
-function CancelIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M18 6L6 18M6 6l12 12" />
-    </svg>
   );
 }

--- a/src/features/assign-slot/DiscardChangesConfirm.tsx
+++ b/src/features/assign-slot/DiscardChangesConfirm.tsx
@@ -1,0 +1,67 @@
+import { useEffect } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+interface Props {
+  open: boolean;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}
+
+/** Two-button "discard your changes?" prompt fired when the user
+ *  cancels the per-row Assign + Invite form with unsaved edits. The
+ *  templates editor has a richer 3-button variant (Save and exit /
+ *  Discard / Keep editing); here there are two save actions
+ *  (Save as Planned, Continue), so an in-prompt save is ambiguous. */
+export function DiscardChangesConfirm({ open, onKeepEditing, onDiscard }: Props) {
+  useLockBodyScroll(open);
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      onKeepEditing();
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, onKeepEditing]);
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="discard-changes-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onKeepEditing();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+        <h2
+          id="discard-changes-title"
+          className="font-display text-[19px] font-semibold text-walnut mb-1.5"
+        >
+          Discard your changes?
+        </h2>
+        <p className="font-serif text-[14px] text-walnut-2 leading-relaxed mb-5">
+          You have unsaved edits. Closing now will lose them.
+        </p>
+        <div className="flex flex-col-reverse sm:flex-row sm:justify-end gap-2">
+          <button
+            type="button"
+            onClick={onKeepEditing}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2"
+          >
+            Keep editing
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            className="rounded-md border border-bordeaux bg-bordeaux px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-bordeaux-deep"
+          >
+            Discard
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/assign-slot/hooks/useDiscardableExit.ts
+++ b/src/features/assign-slot/hooks/useDiscardableExit.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "@/lib/nav";
+
+interface Options {
+  dirty: boolean;
+}
+
+interface DiscardableExit {
+  /** Wire to the header cancel button. Opens the confirm when dirty,
+   *  otherwise navigates straight to /schedule. */
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+}
+
+/** Form-level "close with discard guard" — opens a confirm when there
+ *  are unsaved changes, otherwise navigates back to the schedule.
+ *  Also binds Esc to the same path so desktop keyboard users hit the
+ *  guard. The DiscardChangesConfirm + DeleteSpeakerConfirm modals own
+ *  their own Esc handlers with `stopImmediatePropagation`, so this
+ *  listener stays silent while either modal is open. */
+export function useDiscardableExit({ dirty }: Options): DiscardableExit {
+  const navigate = useNavigate();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const requestCancel = useCallback(() => {
+    if (dirty) setConfirmOpen(true);
+    else navigate("/schedule");
+  }, [dirty, navigate]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      requestCancel();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [requestCancel]);
+
+  return {
+    requestCancel,
+    confirmOpen,
+    onKeepEditing: () => setConfirmOpen(false),
+    onDiscard: () => {
+      setConfirmOpen(false);
+      navigate("/schedule");
+    },
+  };
+}

--- a/src/features/assign-slot/types.ts
+++ b/src/features/assign-slot/types.ts
@@ -1,0 +1,29 @@
+import type { SpeakerRole, SpeakerStatus } from "@/lib/types";
+
+export type AssignAction = "save-and-continue" | "save-as-planned";
+
+export interface AssignSpeakerSeed {
+  kind: "speaker";
+  /** Existing speaker doc id when editing. `null` for new. */
+  speakerId: string | null;
+  name: string;
+  topic: string;
+  role: SpeakerRole;
+  email: string;
+  phone: string;
+  /** Status of an existing speaker — drives the delete confirm
+   *  dialog's invited/confirmed warning. */
+  status: SpeakerStatus;
+}
+
+export interface AssignPrayerSeed {
+  kind: "prayer";
+  name: string;
+  email: string;
+  phone: string;
+  /** Status of the prayer-giver — drives the field-locking rule
+   *  (anything other than "planned" locks all inputs). */
+  status: SpeakerStatus;
+}
+
+export type AssignSeed = AssignSpeakerSeed | AssignPrayerSeed;

--- a/src/features/assign-slot/utils/isDirty.ts
+++ b/src/features/assign-slot/utils/isDirty.ts
@@ -1,0 +1,22 @@
+import type { AssignSeed } from "../types";
+
+/** Field-by-field compare of the in-progress draft against the seed.
+ *  Status is excluded — it has its own audit-stamping write path
+ *  (onStatusChange persists immediately) and isn't part of the form's
+ *  Save / Continue payload, so flipping it shouldn't make the form
+ *  read as "unsaved". */
+export function isDirty(draft: AssignSeed, seed: AssignSeed): boolean {
+  if (draft.kind === "speaker" && seed.kind === "speaker") {
+    return (
+      draft.name !== seed.name ||
+      draft.topic !== seed.topic ||
+      draft.role !== seed.role ||
+      draft.email !== seed.email ||
+      draft.phone !== seed.phone
+    );
+  }
+  if (draft.kind === "prayer" && seed.kind === "prayer") {
+    return draft.name !== seed.name || draft.email !== seed.email || draft.phone !== seed.phone;
+  }
+  return false;
+}

--- a/src/features/invitations/BishopInvitationDialog.tsx
+++ b/src/features/invitations/BishopInvitationDialog.tsx
@@ -1,5 +1,6 @@
 import { useRef } from "react";
 import { Drawer } from "vaul";
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
 import { useKeyboardAwareViewport } from "@/hooks/useKeyboardAwareViewport";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import type { Speaker, SpeakerInvitation } from "@/lib/types";
@@ -75,7 +76,7 @@ export function BishopInvitationDialog({
             <Drawer.Handle className="flex-none mx-auto mt-2 mb-1 h-1 w-10 rounded-full bg-walnut-2/40" />
           )}
           <Drawer.Title className="sr-only">Conversation with {speaker.name}</Drawer.Title>
-          <div className="flex items-start gap-3 px-5 py-3.5 border-b border-border bg-parchment">
+          <div className="flex items-center gap-3 px-5 py-3.5 border-b border-border bg-parchment">
             <div className="flex-1 min-w-0">
               <div className="font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep font-medium">
                 Conversation
@@ -91,14 +92,7 @@ export function BishopInvitationDialog({
                 invitation={invitation}
               />
             )}
-            <button
-              type="button"
-              onClick={onClose}
-              className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
-              aria-label="Close"
-            >
-              Close
-            </button>
+            <HeaderCloseButton onClick={onClose} />
           </div>
           {invitation && invitationId ? (
             <BishopInvitationChat

--- a/src/features/invitations/InvitationLinkActions/InvitationLinkActions.tsx
+++ b/src/features/invitations/InvitationLinkActions/InvitationLinkActions.tsx
@@ -3,6 +3,7 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog";
 import { OverflowMenu, type OverflowMenuItem } from "@/components/ui/OverflowMenu";
 import type { SpeakerInvitation } from "@/lib/types";
 import { callRotateInvitationLink } from "../utils/invitationsCallable";
+import { useDownloadSentLetter } from "./useDownloadSentLetter";
 
 interface Props {
   wardId: string;
@@ -32,6 +33,8 @@ export function InvitationLinkActions({
   const [status, setStatus] = useState<Status>({ kind: "idle" });
   const [confirmOpen, setConfirmOpen] = useState(false);
   const deliverable = availableChannels(invitation);
+  const downloadSent = useDownloadSentLetter(invitation, invitationId);
+  const canDownloadSent = Boolean(invitation.editorStateJson || invitation.bodyMarkdown);
 
   useEffect(() => {
     if (status.kind !== "sent") return;
@@ -63,8 +66,14 @@ export function InvitationLinkActions({
   const items: OverflowMenuItem[] = [];
   if (deliverable.length > 0) {
     items.push({
-      label: `Resend via ${formatChannels(deliverable)}`,
+      label: `Resend Invite via ${formatChannels(deliverable)}`,
       onSelect: () => setConfirmOpen(true),
+    });
+  }
+  if (canDownloadSent) {
+    items.push({
+      label: downloadSent.busy ? "Preparing…" : "Download Sent Invitation Letter",
+      onSelect: () => void downloadSent.trigger().catch(() => {}),
     });
   }
 
@@ -88,7 +97,7 @@ export function InvitationLinkActions({
         open={confirmOpen}
         title="Resend invitation link?"
         body={`A new invitation link will be delivered to ${invitation.speakerName} via ${formatChannels(deliverable)}. Any earlier link is invalidated.`}
-        confirmLabel={`Resend via ${formatChannels(deliverable)}`}
+        confirmLabel={`Resend Invite via ${formatChannels(deliverable)}`}
         busy={status.kind === "working"}
         onCancel={() => setConfirmOpen(false)}
         onConfirm={() => {
@@ -96,6 +105,7 @@ export function InvitationLinkActions({
           void resend();
         }}
       />
+      {downloadSent.portal}
     </div>
   );
 }

--- a/src/features/invitations/InvitationLinkActions/__tests__/InvitationLinkActions.test.tsx
+++ b/src/features/invitations/InvitationLinkActions/__tests__/InvitationLinkActions.test.tsx
@@ -57,7 +57,7 @@ describe("InvitationLinkActions", () => {
   it("Resend menu item shows both channels when invitation has email + phone", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    expect(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" })).toBeTruthy();
+    expect(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" })).toBeTruthy();
   });
 
   it("renders no overflow items when no delivery channel is available", () => {
@@ -70,7 +70,7 @@ describe("InvitationLinkActions", () => {
   it("selecting Resend opens a confirmation dialog instead of firing immediately", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" }));
     expect(screen.getByRole("dialog", { name: "Resend invitation link?" })).toBeTruthy();
     expect(mockFn).not.toHaveBeenCalled();
   });
@@ -78,7 +78,7 @@ describe("InvitationLinkActions", () => {
   it("Cancel on the confirm dialog does not fire the callable", () => {
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" }));
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockFn).not.toHaveBeenCalled();
     expect(screen.queryByRole("dialog")).toBeNull();
@@ -92,8 +92,8 @@ describe("InvitationLinkActions", () => {
     const inv = mkInvitation({ speakerEmail: undefined });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={inv} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via SMS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Resend via SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via SMS" }));
+    fireEvent.click(screen.getByRole("button", { name: "Resend Invite via SMS" }));
     await waitFor(() => expect(screen.getByText("Delivery failed.")).toBeTruthy());
   });
 
@@ -107,8 +107,8 @@ describe("InvitationLinkActions", () => {
     });
     render(<InvitationLinkActions wardId="w1" invitationId="i1" invitation={mkInvitation()} />);
     openMenu();
-    fireEvent.click(screen.getByRole("menuitem", { name: "Resend via EMAIL + SMS" }));
-    fireEvent.click(screen.getByRole("button", { name: "Resend via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: "Resend Invite via EMAIL + SMS" }));
+    fireEvent.click(screen.getByRole("button", { name: "Resend Invite via EMAIL + SMS" }));
     await waitFor(() => expect(screen.getByText("Sent via SMS")).toBeTruthy());
   });
 });

--- a/src/features/invitations/InvitationLinkActions/useDownloadSentLetter.tsx
+++ b/src/features/invitations/InvitationLinkActions/useDownloadSentLetter.tsx
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { letterCanvasToPdf } from "@/features/page-editor/utils/letterToPdf";
+import { downloadFile, shareLetterPdf } from "@/features/page-editor/utils/shareLetterPdf";
+import { LetterCanvas } from "@/features/templates/LetterCanvas";
+import { formatVersionTimestamp } from "@/features/templates/utils/letterDates";
+import type { SpeakerInvitation } from "@/lib/types";
+
+interface Result {
+  /** Fire to render the snapshot portal, capture the PDF, and hand it
+   *  to the platform-appropriate sink (Web Share on mobile, direct
+   *  download on desktop). Throws on capture failure. */
+  trigger: () => Promise<void>;
+  /** True while the PDF is being generated — disable any UI that
+   *  shouldn't fire a parallel capture. */
+  busy: boolean;
+  /** Render this in the host component to keep the transient portal
+   *  in the React tree. Returns null when no capture is in flight. */
+  portal: React.ReactNode;
+}
+
+const PORTAL_ATTR = "data-sent-invitation-portal";
+
+/** Captures the *originally sent* invitation letter as a PDF and
+ *  hands it to the OS share sheet (mobile) or downloads it (desktop).
+ *  Renders a transient hidden LetterCanvas portal sourced from the
+ *  frozen invitation snapshot — the bishop always sees what the
+ *  speaker actually received, even after the ward template was
+ *  edited downstream. The portal uses its own data attribute so it
+ *  never collides with the prepare page's `[data-print-only-letter]`
+ *  selector. */
+export function useDownloadSentLetter(invitation: SpeakerInvitation, invitationId: string): Result {
+  const isMobile = useIsMobile();
+  const [active, setActive] = useState(false);
+  const [busy, setBusy] = useState(false);
+  // Resolves once the off-screen portal has mounted into the DOM —
+  // letterCanvasToPdf needs an actual HTMLElement, and React doesn't
+  // give us a synchronous "node attached" callback otherwise.
+  const mountedResolverRef = useRef<(() => void) | null>(null);
+  const mountedPromiseRef = useRef<Promise<void> | null>(null);
+
+  const trigger = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    mountedPromiseRef.current = new Promise<void>((resolve) => {
+      mountedResolverRef.current = resolve;
+    });
+    setActive(true);
+    try {
+      await mountedPromiseRef.current;
+      const target = document.querySelector<HTMLElement>(`[${PORTAL_ATTR}]`);
+      if (!target) throw new Error("Couldn't render the sent letter for download.");
+      const filename = pdfFilename(invitation.speakerName, invitation.speakerRef.meetingDate);
+      const { file } = await letterCanvasToPdf(target, filename);
+      if (isMobile) {
+        await shareLetterPdf(file, filename, `Invitation for ${invitation.speakerName}`);
+      } else {
+        downloadFile(file, filename);
+      }
+    } finally {
+      setActive(false);
+      setBusy(false);
+      mountedResolverRef.current = null;
+      mountedPromiseRef.current = null;
+    }
+  }, [busy, invitation, isMobile]);
+
+  return {
+    trigger,
+    busy,
+    portal: active ? (
+      <SentLetterPortal
+        invitation={invitation}
+        invitationId={invitationId}
+        onMounted={() => mountedResolverRef.current?.()}
+      />
+    ) : null,
+  };
+}
+
+interface PortalProps {
+  invitation: SpeakerInvitation;
+  invitationId: string;
+  onMounted: () => void;
+}
+
+/** Off-screen rendered copy of the invitation snapshot. Stays in the
+ *  React tree only during a capture window; styled by the global
+ *  `[data-print-only-letter]` rule analogue applied via the portal
+ *  attribute so it never paints on screen — `letterCanvasToPdf`
+ *  parks it at `left: -100000px` for the duration of the html2canvas
+ *  call, then reverts. */
+function SentLetterPortal({ invitation, invitationId, onMounted }: PortalProps) {
+  useEffect(() => {
+    onMounted();
+  }, [onMounted]);
+  const stampText = formatVersionTimestamp(invitation.createdAt);
+  const versionStamp = stampText ? ({ label: "Sent", text: stampText } as const) : undefined;
+  return createPortal(
+    <div data-sent-invitation-portal={invitationId} style={{ display: "none" }}>
+      <LetterCanvas
+        wardName={invitation.wardName}
+        assignedDate={invitation.assignedDate}
+        today={invitation.sentOn}
+        bodyMarkdown={invitation.bodyMarkdown}
+        footerMarkdown={invitation.footerMarkdown}
+        {...(invitation.editorStateJson ? { editorStateJson: invitation.editorStateJson } : {})}
+        {...(versionStamp ? { versionStamp } : {})}
+      />
+    </div>,
+    document.body,
+  );
+}
+
+function pdfFilename(speakerName: string, date: string): string {
+  const slug = speakerName
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  return `invitation-${slug || "speaker"}-${date}.pdf`;
+}

--- a/src/features/invitations/SpeakerChatHeader.tsx
+++ b/src/features/invitations/SpeakerChatHeader.tsx
@@ -1,3 +1,5 @@
+import { HeaderCloseButton } from "@/components/ui/HeaderCloseButton";
+
 interface Props {
   onClose?: (() => void) | undefined;
 }
@@ -17,16 +19,7 @@ export function SpeakerChatHeader({ onClose }: Props) {
           This is a group conversation — the bishop, counselors, and clerks can all see and reply.
         </p>
       </div>
-      {onClose && (
-        <button
-          type="button"
-          onClick={onClose}
-          className="font-mono text-[11px] uppercase tracking-[0.14em] text-walnut-3 hover:text-walnut px-2 py-1 transition-colors"
-          aria-label="Close conversation"
-        >
-          Close
-        </button>
-      )}
+      {onClose && <HeaderCloseButton onClick={onClose} ariaLabel="Close conversation" />}
     </header>
   );
 }

--- a/src/features/page-editor/utils/shareLetterPdf.ts
+++ b/src/features/page-editor/utils/shareLetterPdf.ts
@@ -28,11 +28,14 @@ export async function shareLetterPdf(
       if (err instanceof DOMException && err.name === "AbortError") return "shared";
     }
   }
-  download(file, filename);
+  downloadFile(file, filename);
   return "downloaded";
 }
 
-function download(file: File, filename: string): void {
+/** Triggers a plain browser download. Exported so callers that
+ *  explicitly want a download (desktop "Download letter" affordance)
+ *  can bypass the share-sheet round-trip in `shareLetterPdf`. */
+export function downloadFile(file: File, filename: string): void {
   const url = URL.createObjectURL(file);
   const a = document.createElement("a");
   a.href = url;

--- a/src/features/prayers/hooks/usePreparePrayerActions.ts
+++ b/src/features/prayers/hooks/usePreparePrayerActions.ts
@@ -113,6 +113,21 @@ export function usePreparePrayerActions(args: Args) {
     });
   }
 
+  /** Persist the in-flight letter as a per-prayer-giver override
+   *  without triggering a send. Mirrors the speaker-side `save`. */
+  async function save(): Promise<void> {
+    form.setBusy(true);
+    form.setError(null);
+    try {
+      await form.persistOverrides();
+    } catch (e) {
+      form.setError(friendlyWriteError(e));
+      throw e;
+    } finally {
+      form.setBusy(false);
+    }
+  }
+
   return {
     markInvited: () =>
       void runAction(() =>
@@ -125,5 +140,6 @@ export function usePreparePrayerActions(args: Args) {
       void runAction(() => sendVia(["email"], email ? { email } : undefined)),
     sendSms: (phone?: string) =>
       void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
+    save,
   };
 }

--- a/src/features/prayers/hooks/usePreparePrayerInvitation.ts
+++ b/src/features/prayers/hooks/usePreparePrayerInvitation.ts
@@ -40,6 +40,7 @@ export function usePreparePrayerInvitation(args: Args) {
   });
   const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
   const [letterHasOverride, setLetterHasOverride] = useState(false);
+  const [savedAt, setSavedAt] = useState<unknown>(null);
   const [hydrated, setHydrated] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -67,6 +68,7 @@ export function usePreparePrayerInvitation(args: Args) {
       setInitialMarkdown(md);
       setLetterStateJson(json);
       setLetterHasOverride(Boolean(override));
+      setSavedAt(override?.updatedAt ?? null);
       setError(null);
       setHydrated(true);
     })();
@@ -103,6 +105,10 @@ export function usePreparePrayerInvitation(args: Args) {
     if (!letterStateJson) return;
     await savePrayerLetterOverride(wardId, date, role, { editorStateJson: letterStateJson });
     setLetterHasOverride(true);
+    // Mirror the speaker hook: advance the dirty baseline + the
+    // version-stamp timestamp on a successful save.
+    setInitialJson(letterStateJson);
+    setSavedAt(new Date());
   }
 
   function revertLetterToWardDefault() {
@@ -112,6 +118,7 @@ export function usePreparePrayerInvitation(args: Args) {
       bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_PRAYER_LETTER_BODY,
       footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_PRAYER_LETTER_FOOTER,
     });
+    setSavedAt(null);
     setResetKey((k) => k + 1);
   }
 
@@ -129,6 +136,8 @@ export function usePreparePrayerInvitation(args: Args) {
     }
   }
 
+  const dirty = letterStateJson !== null && letterStateJson !== initialJson;
+
   return {
     initialJson,
     initialMarkdown,
@@ -138,6 +147,8 @@ export function usePreparePrayerInvitation(args: Args) {
     letterBody,
     letterFooter,
     letterHasOverride,
+    savedAt,
+    dirty,
     hydrated,
     resetKey,
     error,

--- a/src/features/schedule/AddAnotherSpeakerRow.tsx
+++ b/src/features/schedule/AddAnotherSpeakerRow.tsx
@@ -1,0 +1,48 @@
+import { Link } from "@/lib/nav";
+
+interface Props {
+  /** Meeting date (ISO YYYY-MM-DD) — destination is the same
+   *  per-row Assign + Invite flow that empty placeholder rows use. */
+  date: string;
+}
+
+/** "+ Add another speaker" affordance shown below the filled
+ *  speaker rows when the count is at or above the floor but below
+ *  the ceiling. Visually distinct from a slot placeholder: no
+ *  numbered leading column (since this is an action, not a slot),
+ *  brass `+` glyph + walnut verb. Mirrors the iOS `addSpeakerRow`
+ *  pattern on `MeetingCardBody`. */
+export function AddAnotherSpeakerRow({ date }: Props) {
+  return (
+    <li className="border-b border-border last:border-b-0">
+      <Link
+        to={`/week/${date}/speaker/new/assign`}
+        className="flex items-center gap-3 h-12 group/add hover:bg-parchment-2 transition-colors"
+      >
+        {/* Spacer matching the leading-label column on the rows above
+            so the pill aligns with the assignee-name column. */}
+        <div className="w-6 shrink-0" aria-hidden="true" />
+        <div className="flex items-center gap-2">
+          <span className="inline-flex items-center justify-center w-5 h-5 rounded-full border border-brass bg-parchment-2 text-brass-deep shrink-0">
+            <svg
+              width="10"
+              height="10"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.25"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+            >
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+          </span>
+          <span className="font-sans text-[13px] text-walnut-2 group-hover/add:text-walnut">
+            Add another speaker
+          </span>
+        </div>
+      </Link>
+    </li>
+  );
+}

--- a/src/features/schedule/MobileSundayBody.tsx
+++ b/src/features/schedule/MobileSundayBody.tsx
@@ -1,10 +1,10 @@
 import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
-import { SpeakerRow } from "./SpeakerRow";
-import { PrayerRow } from "./PrayerRow";
+import { AddAnotherSpeakerRow } from "./AddAnotherSpeakerRow";
 import { EmptyRosterRow } from "./EmptyRosterRow";
-
-const SPEAKER_SLOT_COUNT = 4;
+import { PrayerRow } from "./PrayerRow";
+import { SpeakerRow } from "./SpeakerRow";
+import { canAddAnotherSpeaker, speakerPlaceholderCount } from "./utils/speakerSlots";
 
 interface Props {
   date: string;
@@ -12,14 +12,15 @@ interface Props {
   speakers: WithId<Speaker>[];
 }
 
-/** Mobile body for a regular Sunday. Always renders 4 speaker slots
- *  + 2 prayer slots — empty slots fall back to "Not assigned"
- *  placeholder rows. Mirrors the desktop card body's vertical rhythm
- *  so the list reads as a consistent table without requiring the
- *  user to count present-vs-missing. The kebab menu in the date row
- *  is the entry point for "Plan speakers" / "Plan prayers" actions. */
+/** Mobile body for a regular Sunday. Speaker rows render dynamically
+ *  (floor of 2 placeholder rows on a fresh card, ceiling of 4 visible
+ *  before the explicit "Add another speaker" affordance hides) so a
+ *  partially-filled meeting doesn't push prayers off the visible
+ *  list with empty noise. Prayer rows always render — bishops use
+ *  them as the implicit footer. */
 export function MobileSundayBody({ date, meeting, speakers }: Props) {
-  const placeholderCount = Math.max(0, SPEAKER_SLOT_COUNT - speakers.length);
+  const placeholderCount = speakerPlaceholderCount(speakers.length);
+  const showAddAnother = canAddAnotherSpeaker(speakers.length);
   return (
     <div className="px-4 pb-3">
       <ul className="list-none m-0 p-0">
@@ -37,6 +38,7 @@ export function MobileSundayBody({ date, meeting, speakers }: Props) {
             />
           );
         })}
+        {showAddAnother && <AddAnotherSpeakerRow date={date} />}
         <PrayerRow
           role="opening"
           date={date}

--- a/src/features/schedule/PrayerRow.tsx
+++ b/src/features/schedule/PrayerRow.tsx
@@ -76,6 +76,9 @@ export function PrayerRow({ inlineName, role, date, hideEmpty = false }: Props) 
         to={`/week/${date}/prayer/${role}/assign`}
         className="flex items-center gap-3 flex-1 min-w-0 hover:bg-parchment-2 transition-colors -mx-1 px-1 rounded-sm"
       >
+        <div className="font-mono text-[10.5px] tracking-[0.08em] text-brass-deep w-6 shrink-0">
+          {ROLE_LABEL[role]}
+        </div>
         <div className="flex-1 min-w-0">
           <div className="font-sans text-sm font-semibold text-walnut truncate">{name}</div>
           <div className="font-serif italic text-sm text-walnut-2 truncate">

--- a/src/features/schedule/SundayCard/__tests__/SundayCard.test.tsx
+++ b/src/features/schedule/SundayCard/__tests__/SundayCard.test.tsx
@@ -68,7 +68,11 @@ describe("SundayCard", () => {
 
   it("shows Assign Speaker pills on empty rows", () => {
     renderCard();
-    // 4 empty speaker slots all render as Assign pills.
-    expect(screen.getAllByText("Assign Speaker").length).toBeGreaterThan(0);
+    // Fresh card with no speakers shows the floor of 2 placeholder
+    // rows — not the old fixed 4 — so the meeting reads as an
+    // invitation to assign without padding the height with empty
+    // noise.
+    expect(screen.getAllByText("Assign Speaker")).toHaveLength(2);
+    expect(screen.queryByText("Add another speaker")).toBeNull();
   });
 });

--- a/src/features/schedule/SundayCardBody.tsx
+++ b/src/features/schedule/SundayCardBody.tsx
@@ -1,10 +1,10 @@
 import type { SacramentMeeting, Speaker } from "@/lib/types";
 import type { WithId } from "@/hooks/_sub";
+import { AddAnotherSpeakerRow } from "./AddAnotherSpeakerRow";
 import { EmptyRosterRow } from "./EmptyRosterRow";
 import { PrayerRow } from "./PrayerRow";
 import { SpeakerRow } from "./SpeakerRow";
-
-const SPEAKER_SLOT_COUNT = 4;
+import { canAddAnotherSpeaker, speakerPlaceholderCount } from "./utils/speakerSlots";
 
 interface Props {
   speakers: WithId<Speaker>[];
@@ -12,11 +12,16 @@ interface Props {
   meeting: SacramentMeeting | null;
 }
 
+/** Desktop schedule card body. Speaker rows render dynamically: the
+ *  card holds at least the floor (2) so a fresh card invites action,
+ *  grows naturally as speakers are added, and stops at the ceiling
+ *  (4) by hiding the explicit "Add another speaker" affordance —
+ *  rosters that legitimately need a 5th can still be backed by data,
+ *  but the typical card stays visually compact. Mirrors the iOS
+ *  `MeetingCardBody` slot rules. */
 export function SundayCardBody({ speakers, date, meeting }: Props) {
-  // Fixed slot count keeps every Sunday card the same height across
-  // the schedule grid — actual speakers fill the first slots, empty
-  // placeholder rows back-fill up to SPEAKER_SLOT_COUNT.
-  const placeholderCount = Math.max(0, SPEAKER_SLOT_COUNT - speakers.length);
+  const placeholderCount = speakerPlaceholderCount(speakers.length);
+  const showAddAnother = canAddAnotherSpeaker(speakers.length);
   return (
     <div className="flex flex-1 flex-col px-4 pb-4">
       <ul className="list-none m-0 p-0 mb-2">
@@ -34,6 +39,7 @@ export function SundayCardBody({ speakers, date, meeting }: Props) {
             />
           );
         })}
+        {showAddAnother && <AddAnotherSpeakerRow date={date} />}
       </ul>
       <ul className="list-none m-0 p-0 mb-2 border-t-2 border-walnut-3 pt-1">
         <PrayerRow

--- a/src/features/schedule/SundayCardBody.tsx
+++ b/src/features/schedule/SundayCardBody.tsx
@@ -41,7 +41,7 @@ export function SundayCardBody({ speakers, date, meeting }: Props) {
         })}
         {showAddAnother && <AddAnotherSpeakerRow date={date} />}
       </ul>
-      <ul className="list-none m-0 p-0 mb-2 border-t-2 border-walnut-3 pt-1">
+      <ul className="list-none m-0 p-0 mb-2 mt-auto border-t-2 border-walnut-3 pt-1">
         <PrayerRow
           role="opening"
           date={date}

--- a/src/features/schedule/utils/speakerSlots.test.ts
+++ b/src/features/schedule/utils/speakerSlots.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { canAddAnotherSpeaker, speakerPlaceholderCount } from "./speakerSlots";
+
+describe("speakerPlaceholderCount", () => {
+  // The card rests on a 2-row visual floor so a fresh meeting reads
+  // as "two slots inviting action" rather than a single lonely row.
+  it("pads up to the floor when the assigned count is below it", () => {
+    expect(speakerPlaceholderCount(0)).toBe(2);
+    expect(speakerPlaceholderCount(1)).toBe(1);
+  });
+
+  // Once the floor is met, no more padding — the card grows row-by-row
+  // with the actual speakers.
+  it("returns 0 when the assigned count is at or above the floor", () => {
+    expect(speakerPlaceholderCount(2)).toBe(0);
+    expect(speakerPlaceholderCount(3)).toBe(0);
+    expect(speakerPlaceholderCount(4)).toBe(0);
+    expect(speakerPlaceholderCount(7)).toBe(0);
+  });
+});
+
+describe("canAddAnotherSpeaker", () => {
+  // Below the floor the empty placeholder slots already invite the
+  // bishop to assign — a second add affordance would be redundant.
+  it("is false below the floor", () => {
+    expect(canAddAnotherSpeaker(0)).toBe(false);
+    expect(canAddAnotherSpeaker(1)).toBe(false);
+  });
+
+  // Between floor and ceiling: the explicit "+ Add another speaker"
+  // row appears so the bishop can grow the roster past the typical
+  // count without first staring at empty slots.
+  it("is true between floor and ceiling", () => {
+    expect(canAddAnotherSpeaker(2)).toBe(true);
+    expect(canAddAnotherSpeaker(3)).toBe(true);
+  });
+
+  // At or above the ceiling: no add affordance — the card stops
+  // growing visually. (Existing rosters with more docs still render
+  // every speaker; the cap only governs the explicit add button.)
+  it("is false at or above the ceiling", () => {
+    expect(canAddAnotherSpeaker(4)).toBe(false);
+    expect(canAddAnotherSpeaker(5)).toBe(false);
+    expect(canAddAnotherSpeaker(7)).toBe(false);
+  });
+});

--- a/src/features/schedule/utils/speakerSlots.ts
+++ b/src/features/schedule/utils/speakerSlots.ts
@@ -1,0 +1,35 @@
+/** Floor for visible speaker rows on a Sunday card — the typical
+ *  ward floor. Below this, empty rows render as "Assign Speaker"
+ *  placeholders so a fresh card invites action rather than reading
+ *  as a single lonely row. */
+export const SPEAKER_SLOT_FLOOR = 2;
+
+/** Ceiling for visible speaker rows. Once the assigned count reaches
+ *  this, the "Add another speaker" affordance disappears and the
+ *  card stops growing. Mirrors the iOS app's `maxSpeakerSlots = 4`. */
+export const SPEAKER_SLOT_CEILING = 4;
+
+/** Whether to render the explicit "Add another speaker" affordance
+ *  below the last filled row. Only true when the assigned count is
+ *  at or above the floor (so empty placeholder rows aren't already
+ *  serving as the add invitation) AND below the ceiling (so there's
+ *  room to add another). Mirrors `Speaker.canAddMore` on iOS. */
+export function canAddAnotherSpeaker(
+  assignedCount: number,
+  floor: number = SPEAKER_SLOT_FLOOR,
+  ceiling: number = SPEAKER_SLOT_CEILING,
+): boolean {
+  return assignedCount >= floor && assignedCount < ceiling;
+}
+
+/** How many empty placeholder rows to render below the actual
+ *  speakers so the card meets the floor. Returns 0 once the assigned
+ *  count is at or above the floor — the card grows naturally beyond
+ *  that, capped only by the ceiling via the add affordance.
+ *  Mirrors `Speaker.slots(items, minSlotCount: 2)` on iOS. */
+export function speakerPlaceholderCount(
+  assignedCount: number,
+  floor: number = SPEAKER_SLOT_FLOOR,
+): number {
+  return Math.max(0, floor - assignedCount);
+}

--- a/src/features/templates/LetterCanvas.tsx
+++ b/src/features/templates/LetterCanvas.tsx
@@ -27,6 +27,12 @@ interface Props {
    *  inside the settings page. The landing page + PDF paths skip this
    *  so the letter renders at true letter-sheet proportions. */
   compact?: boolean;
+  /** Reference-only metadata stamp rendered in the page's bottom
+   *  margin, visually outside the letter card. Captured in PDF export
+   *  so the holder of a printed copy knows which version they have.
+   *  Omitted on live preview / embed paths so the on-screen paper
+   *  stays clean while editing. */
+  versionStamp?: { label: "Saved" | "Sent"; text: string };
 }
 
 /**
@@ -44,10 +50,12 @@ export function LetterCanvas({
   footerMarkdown,
   editorStateJson,
   compact,
+  versionStamp,
 }: Props) {
   const rendered = editorStateJson ? renderLetterState(editorStateJson, { assignedDate }) : null;
   return (
     <div
+      data-letter-page
       className={cn(
         // Typography rules mirror the editor's contenteditable
         // (`prose prose-sm font-serif text-[16.5px] leading-[1.65]
@@ -90,6 +98,32 @@ export function LetterCanvas({
           </div>
         </>
       )}
+
+      {versionStamp && <VersionStamp stamp={versionStamp} compact={compact === true} />}
+    </div>
+  );
+}
+
+/** Reference-only metadata, sitting in the page's bottom margin so
+ *  the holder of a printed copy can identify which version they have.
+ *  Visually + structurally separate from the letter content above. */
+function VersionStamp({
+  stamp,
+  compact,
+}: {
+  stamp: { label: "Saved" | "Sent"; text: string };
+  compact: boolean;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute left-0 right-0 text-center",
+        "font-mono text-[8.5px] tracking-[0.18em] uppercase text-walnut-3/60",
+        compact ? "bottom-2" : "bottom-[0.3in]",
+      )}
+    >
+      {stamp.label} {stamp.text}
     </div>
   );
 }

--- a/src/features/templates/PrepareInvitationActionBar/PrepareInvitationActionBar.tsx
+++ b/src/features/templates/PrepareInvitationActionBar/PrepareInvitationActionBar.tsx
@@ -1,13 +1,19 @@
 import { useState } from "react";
-import { RotateCcw, Send, Share } from "lucide-react";
+import { Download, RotateCcw, Send, Share } from "lucide-react";
+import { useIsMobile } from "@/hooks/useMediaQuery";
 import { letterCanvasToPdf } from "@/features/page-editor/utils/letterToPdf";
-import { shareLetterPdf } from "@/features/page-editor/utils/shareLetterPdf";
+import { downloadFile, shareLetterPdf } from "@/features/page-editor/utils/shareLetterPdf";
 import { PrepareInvitationDialogs } from "../PrepareInvitationDialogs";
 import { PrepareInvitationGroupBtn as GroupBtn } from "../PrepareInvitationGroupBtn";
+import { ToolbarSaveButton } from "./ToolbarSaveButton";
 
 interface Props {
   busy: boolean;
   hasOverride: boolean;
+  /** True when the editor state has unsaved edits. Gates the
+   *  Download/Share button (must save first so the PDF + Firestore
+   *  agree on what's "the letter"). */
+  dirty: boolean;
   speakerName: string;
   /** Current email / phone on file for the speaker. Used to prefill
    *  the Send-channel dialog; empty strings are handled (the dialog
@@ -17,6 +23,7 @@ interface Props {
   /** Meeting date (ISO YYYY-MM-DD) — used for the shared PDF filename. */
   assignedDate: string;
   onRevert: () => void;
+  onSave: () => void;
   /** Called with the final email the bishop confirmed in the dialog.
    *  The parent is responsible for persisting it to the speaker doc
    *  when it differs from what was on file. */
@@ -30,42 +37,52 @@ type PendingSend = "email" | "sms" | null;
 const ICON_SIZE = 14;
 const ICON_STROKE = 1.75;
 
-/** Top-of-page action toolbar for the Prepare Invitation page. Two
- *  icon-only buttons in a connected group (Revert · Share), then
- *  text-labelled Send Email + Send SMS buttons. Share renders the
- *  LetterCanvas portal to a PDF and hands it to the OS share sheet
- *  (Web Share API, with download fallback) so the bishop can route
- *  the letter through any installed app — same path as the speaker
- *  invite landing page. Sharing never flips status; the bishop
- *  controls status explicitly via the menu on the assign page. */
+/** Top-of-page action toolbar for the Prepare Invitation page.
+ *  Three groups: [Revert | Share/Download], [Save], [Send Email,
+ *  Send SMS]. The Share/Download split picks Share on touch viewports
+ *  (Web Share API → OS share sheet) and Download on desktop (direct
+ *  PDF download — no surprising "I clicked Share but got a download"
+ *  fallback). Both paths are gated on `!dirty` so the artifact the
+ *  bishop hands out always matches what's persisted in Firestore. */
 export function PrepareInvitationActionBar({
   busy,
   hasOverride,
+  dirty,
   speakerName,
   speakerEmail,
   speakerPhone,
   assignedDate,
   onRevert,
+  onSave,
   onSend,
   onSendSms,
 }: Props) {
   const [pending, setPending] = useState<PendingConfirm>(null);
   const [pendingSend, setPendingSend] = useState<PendingSend>(null);
-  const [sharing, setSharing] = useState(false);
+  const [exporting, setExporting] = useState(false);
+  const isMobile = useIsMobile();
 
-  async function doShare() {
-    if (sharing) return;
+  async function doExport() {
+    if (exporting) return;
     const target = document.querySelector<HTMLElement>("[data-print-only-letter]");
     if (!target) return;
-    setSharing(true);
+    setExporting(true);
     try {
       const filename = pdfFilename(speakerName, assignedDate);
       const { file } = await letterCanvasToPdf(target, filename);
-      await shareLetterPdf(file, filename, `Invitation for ${speakerName}`);
+      if (isMobile) {
+        await shareLetterPdf(file, filename, `Invitation for ${speakerName}`);
+      } else {
+        downloadFile(file, filename);
+      }
     } finally {
-      setSharing(false);
+      setExporting(false);
     }
   }
+
+  const exportLabel = isMobile ? "Share letter" : "Download letter";
+  const exportDisabledLabel = dirty ? `Save to ${isMobile ? "share" : "download"}` : exportLabel;
+  const ExportIcon = isMobile ? Share : Download;
 
   return (
     <div className="flex flex-col items-center">
@@ -82,13 +99,14 @@ export function PrepareInvitationActionBar({
           </GroupBtn>
           <GroupBtn
             position="last"
-            label="Share letter"
-            onClick={() => void doShare()}
-            disabled={busy || sharing}
+            label={dirty ? exportDisabledLabel : exportLabel}
+            onClick={() => void doExport()}
+            disabled={busy || exporting || dirty}
           >
-            <Share size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+            <ExportIcon size={ICON_SIZE} strokeWidth={ICON_STROKE} />
           </GroupBtn>
         </div>
+        <ToolbarSaveButton dirty={dirty} busy={busy} onSave={onSave} />
         <button
           type="button"
           onClick={() => setPendingSend("email")}

--- a/src/features/templates/PrepareInvitationActionBar/ToolbarSaveButton.tsx
+++ b/src/features/templates/PrepareInvitationActionBar/ToolbarSaveButton.tsx
@@ -1,0 +1,34 @@
+import { Save } from "lucide-react";
+
+interface Props {
+  /** True when the editor state differs from the last saved/initial
+   *  snapshot. Drives the disabled state. */
+  dirty: boolean;
+  busy: boolean;
+  onSave: () => void;
+}
+
+const ICON_SIZE = 14;
+const ICON_STROKE = 1.75;
+
+/** Save the current letter as a per-speaker override without sending.
+ *  Disabled when there's nothing to save (so the bishop never wonders
+ *  "did anything happen?" after clicking) or while another action is
+ *  in flight. Same neutral chrome as Send Email so the eye groups
+ *  Save / Send Email / Send SMS as the three terminal actions. */
+export function ToolbarSaveButton({ dirty, busy, onSave }: Props) {
+  const disabled = !dirty || busy;
+  return (
+    <button
+      type="button"
+      onClick={onSave}
+      disabled={disabled}
+      aria-label={dirty ? "Save changes" : "No changes to save"}
+      title={dirty ? "Save changes" : "No changes to save"}
+      className="inline-flex items-center gap-2 rounded-md border border-border-strong bg-chalk px-3.5 sm:px-4 h-9 sm:h-10 text-walnut font-sans text-[13px] font-semibold tracking-[0.01em] transition-colors hover:bg-parchment-2 focus:outline-none focus:ring-2 focus:ring-bordeaux/30 disabled:opacity-60 disabled:cursor-not-allowed disabled:hover:bg-chalk"
+    >
+      <Save size={ICON_SIZE} strokeWidth={ICON_STROKE} />
+      <span>Save</span>
+    </button>
+  );
+}

--- a/src/features/templates/PrepareInvitationLetterTab.tsx
+++ b/src/features/templates/PrepareInvitationLetterTab.tsx
@@ -22,6 +22,11 @@ interface Props {
   onInitial: (json: string) => void;
   resetKey: number;
   vars: LetterVars;
+  /** Reference-only metadata stamp threaded into the off-screen
+   *  PrintOnlyLetter portal so the PDF export carries it. The on-
+   *  screen editor + mobile preview deliberately omit it — pure
+   *  reference metadata, not part of the letter content. */
+  printVersionStamp?: { label: "Saved" | "Sent"; text: string };
 }
 
 /** Per-speaker letter editor on the prepare-invitation route — same
@@ -39,6 +44,7 @@ export function PrepareInvitationLetterTab({
   onInitial,
   resetKey,
   vars,
+  printVersionStamp,
 }: Props) {
   const isMobile = useIsMobile();
   const renderedBody = useMemo(() => interpolate(body, vars), [body, vars]);
@@ -58,6 +64,7 @@ export function PrepareInvitationLetterTab({
         bodyMarkdown={renderedBody}
         footerMarkdown={renderedFooter}
         {...(printEditorStateJson ? { editorStateJson: printEditorStateJson } : {})}
+        {...(printVersionStamp ? { versionStamp: printVersionStamp } : {})}
       />
       <div className="relative h-full">
         {isMobile ? (

--- a/src/features/templates/PrintOnlyLetter.tsx
+++ b/src/features/templates/PrintOnlyLetter.tsx
@@ -9,6 +9,9 @@ interface Props {
   bodyMarkdown: string;
   footerMarkdown: string;
   editorStateJson?: string;
+  /** Reference-only metadata stamp captured by the PDF export but
+   *  hidden from the live editor preview. */
+  versionStamp?: { label: "Saved" | "Sent"; text: string };
 }
 
 /** Portals a print-only `<LetterCanvas>` into `document.body` so the

--- a/src/features/templates/UnsavedLetterConfirm.tsx
+++ b/src/features/templates/UnsavedLetterConfirm.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from "react";
+import { useLockBodyScroll } from "@/hooks/useLockBodyScroll";
+
+interface Props {
+  open: boolean;
+  /** True while the Save & exit path is in flight. Disables every
+   *  button so a double-click can't queue two saves. */
+  busy: boolean;
+  /** Surface a save failure inline so the bishop sees the reason
+   *  instead of the modal silently staying open. */
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => void;
+}
+
+/** Three-button exit guard for the Prepare Invitation editor.
+ *  Save & exit / Discard / Cancel — explicit choices so the bishop
+ *  always knows what happens to in-flight edits. Modeled on the
+ *  assign-slot DiscardChangesConfirm but adds the Save path the
+ *  letter editor needs.
+ *
+ *  Esc keeps editing (capture-phase + `stopImmediatePropagation` so
+ *  the page's exit-guard Esc handler doesn't reopen this same
+ *  modal). Backdrop click also keeps editing — accidental dismissals
+ *  shouldn't navigate away. */
+export function UnsavedLetterConfirm({
+  open,
+  busy,
+  error,
+  onKeepEditing,
+  onDiscard,
+  onSaveAndExit,
+}: Props) {
+  useLockBodyScroll(open);
+  useEffect(() => {
+    if (!open) return;
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      e.stopImmediatePropagation();
+      if (!busy) onKeepEditing();
+    }
+    document.addEventListener("keydown", handleEsc, true);
+    return () => document.removeEventListener("keydown", handleEsc, true);
+  }, [open, busy, onKeepEditing]);
+  if (!open) return null;
+  return (
+    <div
+      className="fixed inset-0 z-[60] grid place-items-center bg-black/40 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="unsaved-letter-confirm-title"
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) onKeepEditing();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-[14px] border border-border-strong bg-chalk p-6 shadow-elev-3">
+        <h2
+          id="unsaved-letter-confirm-title"
+          className="font-display text-[19px] font-semibold text-walnut mb-1.5"
+        >
+          Unsaved changes
+        </h2>
+        <p className="font-serif text-[14px] text-walnut-2 leading-relaxed mb-5">
+          You have unsaved edits to this letter. Save them before leaving so the next download or
+          send uses your latest copy?
+        </p>
+        {error && (
+          <p className="font-sans text-[12.5px] text-bordeaux mb-4" role="alert">
+            {error}
+          </p>
+        )}
+        <div className="flex flex-wrap justify-end gap-2">
+          <button
+            type="button"
+            onClick={onKeepEditing}
+            disabled={busy}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-walnut hover:bg-parchment-2 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onDiscard}
+            disabled={busy}
+            className="rounded-md border border-border-strong bg-chalk px-3.5 py-2 font-sans text-[13px] font-semibold text-bordeaux hover:bg-bordeaux/5 disabled:opacity-60"
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            onClick={onSaveAndExit}
+            disabled={busy}
+            className="rounded-md border border-walnut bg-walnut px-3.5 py-2 font-sans text-[13px] font-semibold text-chalk hover:bg-walnut-2 disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {busy ? "Saving…" : "Save & exit"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/templates/hooks/usePrepareInvitation.ts
+++ b/src/features/templates/hooks/usePrepareInvitation.ts
@@ -48,6 +48,7 @@ export function usePrepareInvitation(args: Args) {
   });
   const [letterStateJson, setLetterStateJson] = useState<string | null>(null);
   const [letterHasOverride, setLetterHasOverride] = useState(false);
+  const [savedAt, setSavedAt] = useState<unknown>(null);
   const [hydrated, setHydrated] = useState(false);
   const [resetKey, setResetKey] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -75,6 +76,7 @@ export function usePrepareInvitation(args: Args) {
       setInitialMarkdown(md);
       setLetterStateJson(json);
       setLetterHasOverride(Boolean(override));
+      setSavedAt(override?.updatedAt ?? null);
       setError(null);
       setHydrated(true);
     })();
@@ -111,6 +113,13 @@ export function usePrepareInvitation(args: Args) {
     if (!letterStateJson) return;
     await saveSpeakerLetterOverride(wardId, date, speakerId, { editorStateJson: letterStateJson });
     setLetterHasOverride(true);
+    // Advance the dirty baseline so the toolbar Save button + exit
+    // guard reflect the freshly-persisted state. `serverTimestamp()`
+    // resolves on the server; mirroring with `new Date()` locally is
+    // a near-enough approximation for the version stamp without a
+    // round-trip read.
+    setInitialJson(letterStateJson);
+    setSavedAt(new Date());
   }
 
   function revertLetterToWardDefault() {
@@ -120,6 +129,7 @@ export function usePrepareInvitation(args: Args) {
       bodyMarkdown: letterTemplate?.bodyMarkdown ?? DEFAULT_SPEAKER_LETTER_BODY,
       footerMarkdown: letterTemplate?.footerMarkdown ?? DEFAULT_SPEAKER_LETTER_FOOTER,
     });
+    setSavedAt(null);
     setResetKey((k) => k + 1);
   }
 
@@ -137,6 +147,8 @@ export function usePrepareInvitation(args: Args) {
     }
   }
 
+  const dirty = letterStateJson !== null && letterStateJson !== initialJson;
+
   return {
     initialJson,
     initialMarkdown,
@@ -146,6 +158,8 @@ export function usePrepareInvitation(args: Args) {
     letterBody,
     letterFooter,
     letterHasOverride,
+    savedAt,
+    dirty,
     hydrated,
     resetKey,
     error,

--- a/src/features/templates/hooks/usePrepareInvitationActions.ts
+++ b/src/features/templates/hooks/usePrepareInvitationActions.ts
@@ -126,6 +126,22 @@ export function usePrepareInvitationActions(args: Args) {
     await updateSpeaker(args.wardId, args.date, args.speakerId, { status: "invited" });
   }
 
+  /** Save the in-flight letter as a per-speaker override without
+   *  triggering a send. Surfaces busy/error through the same form
+   *  channels as Send so the toolbar disables consistently. */
+  async function save(): Promise<void> {
+    form.setBusy(true);
+    form.setError(null);
+    try {
+      await form.persistOverrides();
+    } catch (e) {
+      form.setError(friendlyWriteError(e));
+      throw e;
+    } finally {
+      form.setBusy(false);
+    }
+  }
+
   return {
     markInvited: () =>
       void runAction(() =>
@@ -135,5 +151,6 @@ export function usePrepareInvitationActions(args: Args) {
       void runAction(() => sendVia(["email"], email ? { email } : undefined)),
     sendSms: (phone?: string) =>
       void runAction(() => sendVia(["sms"], phone ? { phone } : undefined)),
+    save,
   };
 }

--- a/src/features/templates/hooks/useSavableExit.ts
+++ b/src/features/templates/hooks/useSavableExit.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, useState } from "react";
+import { useNavigate } from "@/lib/nav";
+
+interface Options {
+  /** True when the editor has unsaved changes. When false the
+   *  Cancel/Esc path navigates straight to /schedule with no
+   *  confirmation. */
+  dirty: boolean;
+  /** Persist the in-flight letter. Returns/awaits a promise so the
+   *  modal can show a busy state and avoid navigating on save
+   *  failure. Throws on failure — caller surfaces the error. */
+  onSave: () => Promise<void>;
+}
+
+interface SavableExit {
+  /** Wire to the header Cancel/X button. Opens the confirm modal
+   *  when there are unsaved edits, otherwise navigates straight to
+   *  /schedule. */
+  requestCancel: () => void;
+  confirmOpen: boolean;
+  busy: boolean;
+  error: string | null;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+  onSaveAndExit: () => Promise<void>;
+}
+
+/** Three-way exit guard for editors with explicit Save (Prepare
+ *  Invitation, Prepare Prayer Invitation). When `dirty`, opens a
+ *  modal offering Save & exit / Discard / Cancel. Mirrors
+ *  `useDiscardableExit` in the assign-slot feature but adds the
+ *  Save path and the busy/error bookkeeping it needs.
+ *
+ *  Esc routes through `requestCancel` so desktop keyboard users hit
+ *  the same guard. The host modal owns its own Esc handler with
+ *  `stopImmediatePropagation`, so this listener stays silent while
+ *  the modal is already open. */
+export function useSavableExit({ dirty, onSave }: Options): SavableExit {
+  const navigate = useNavigate();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const requestCancel = useCallback(() => {
+    if (dirty) {
+      setError(null);
+      setConfirmOpen(true);
+    } else {
+      navigate("/schedule");
+    }
+  }, [dirty, navigate]);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key !== "Escape") return;
+      requestCancel();
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [requestCancel]);
+
+  return {
+    requestCancel,
+    confirmOpen,
+    busy,
+    error,
+    onKeepEditing: () => {
+      if (busy) return;
+      setConfirmOpen(false);
+    },
+    onDiscard: () => {
+      setConfirmOpen(false);
+      navigate("/schedule");
+    },
+    onSaveAndExit: async () => {
+      if (busy) return;
+      setBusy(true);
+      setError(null);
+      try {
+        await onSave();
+        setConfirmOpen(false);
+        navigate("/schedule");
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Couldn't save. Try again.");
+      } finally {
+        setBusy(false);
+      }
+    },
+  };
+}

--- a/src/features/templates/utils/letterDates.ts
+++ b/src/features/templates/utils/letterDates.ts
@@ -21,3 +21,50 @@ export function formatToday(): string {
     year: "numeric",
   });
 }
+
+/** Convenience for the prepare pages: turn the persisted `savedAt`
+ *  Firestore Timestamp into the `versionStamp` prop shape consumed by
+ *  PrintOnlyLetter, or `null` when there's no parseable timestamp.
+ *  Returning the discriminated shape directly keeps the per-page glue
+ *  one inlinable expression. */
+export function buildSavedVersionStamp(savedAt: unknown): { label: "Saved"; text: string } | null {
+  const text = formatVersionTimestamp(savedAt);
+  return text ? { label: "Saved", text } : null;
+}
+
+/** Renders a short reference timestamp for the bottom-of-page version
+ *  stamp on PDF exports — e.g. "May 2, 2026 · 2:23 PM". Accepts a
+ *  Date, ISO string, or a Firestore Timestamp-shaped object with
+ *  `toDate()`. Returns `null` when the value is missing or unparseable
+ *  so callers can omit the stamp without rendering "Saved Invalid Date". */
+export function formatVersionTimestamp(value: unknown): string | null {
+  const date = coerceDate(value);
+  if (!date) return null;
+  const d = date.toLocaleDateString(undefined, {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+  const t = date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+  return `${d} · ${t}`;
+}
+
+function coerceDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  if (typeof value === "string") {
+    const d = new Date(value);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+  if (typeof value === "object" && value !== null && "toDate" in value) {
+    const fn = (value as { toDate: () => Date }).toDate;
+    if (typeof fn === "function") {
+      const d = fn.call(value);
+      return d instanceof Date && !Number.isNaN(d.getTime()) ? d : null;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
Promotes `develop` → `main` for the v0.22.0 release. UX-focused minor.

## What's in this release

### Added

- **Dynamic speaker slots on the schedule** (#242) — Sunday cards now follow the iOS app's slot rules. 0 → two placeholders, 1 → one filled + one placeholder, 2–3 → all filled with `+ Add another speaker`, 4 → ceiling (no add button). Existing rosters of 5+ still render in full.
- **Explicit Save on the prepare-invitation page** (#241) — toolbar Save button (enabled only when dirty), 3-button modal (`Cancel` / `Discard` / `Save & exit`) on Cancel/X/Esc with a dirty draft, reload now persists edits. Same wiring on the prayer prepare page.
- **Sent-invitation download in the bishop chat overflow** (#241) — pulls the immutable `speakerInvitations` snapshot stamped "Sent {date · time}" so the bishop always retrieves the exact letter the speaker received.
- **`HeaderCloseButton` shared primitive** (#240) — labeled X + text, 44 px hit target, applied across speaker chat drawer, bishop invitation dialog, and the speaker + prayer prepare-invitation pages.

### Changed

- **Assign-slot Cancel is now an obvious affordance** (#239) — labeled `Cancel`, 44 px hit target, Esc binding, 2-button `DiscardChangesConfirm` when dirty.
- **Platform-aware export on the prepare-invitation page** (#241) — desktop `Download` (direct PDF), mobile `Share` (Web Share API). Both gate on Save. PDF carries a "Saved {date · time}" reference stamp in the bottom margin.
- **"Resend via SMS" → "Resend Invite via SMS"** (#241) — unambiguous wording in the bishop chat overflow.

### Fixed

- **Prayer rows pinned to the bottom of desktop Sunday cards** (#243) — adjacent cards stay aligned regardless of speaker count; filled `PrayerRow`s restore the mono `OP` / `CP` leading column.

## Post-merge automation

`.github/workflows/release.yml` will tag `v0.22.0`, publish the GitHub Release, and deploy Firestore rules + indexes + Cloud Functions to `steward-prod-65a36`. Vercel handles the frontend redeploy.

## Test plan

- [ ] CI green on this PR before merge
- [ ] After merge: Release workflow finishes (Actions → Release)
- [ ] Production URL loads, sign-in works, schedule renders
- [ ] One write (e.g. edit a meeting field) lands, confirming rules accept legitimate writes
- [ ] Firestore Console → Indexes — any new entries reach Enabled within a few minutes

https://claude.ai/code/session_0154zCtqwXgqHc2ntdsn9Zaw

---
_Generated by [Claude Code](https://claude.ai/code/session_0154zCtqwXgqHc2ntdsn9Zaw)_