### PR TITLE
feat: meeting form prayer rows mirror speakers + comment @mentions + schedule focus flash

### DIFF
--- a/src/features/comments/CommentForm.tsx
+++ b/src/features/comments/CommentForm.tsx
@@ -1,8 +1,19 @@
-import { useState } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 import { useWardMembers } from "@/hooks/useWardMembers";
 import { useAuthStore } from "@/stores/authStore";
+import type { WithId } from "@/hooks/_sub";
+import type { Member } from "@/lib/types";
+import { MentionSuggestList } from "./MentionSuggestList";
+import { useMentionSuggest } from "./hooks/useMentionSuggest";
 import { createComment } from "./utils/commentActions";
 import { extractMentions } from "./utils/extractMentions";
+import { applyMention } from "./utils/mentionToken";
+import { renderCommentBody } from "./utils/renderCommentBody";
+
+// Geometry shared between the textarea and the styled mirror behind
+// it so the rendered chips line up character-for-character with what
+// the user is typing. Any change here must touch both elements.
+const TEXT_GEOMETRY = "font-sans text-[14px] leading-[1.55] px-3 py-2.5 rounded-md";
 
 interface Props {
   wardId: string;
@@ -13,7 +24,48 @@ export function CommentForm({ wardId, date }: Props) {
   const user = useAuthStore((s) => s.user);
   const { data: members } = useWardMembers();
   const [body, setBody] = useState("");
+  const [caret, setCaret] = useState(0);
   const [busy, setBusy] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const mirrorRef = useRef<HTMLDivElement>(null);
+
+  const suggest = useMentionSuggest({ value: body, caret, members });
+
+  function selectMember(m: WithId<Member>) {
+    if (suggest.token === null) return;
+    const next = applyMention(body, caret, suggest.token, m.data.displayName);
+    setBody(next.value);
+    // Defer to the next frame so React commits the new value before
+    // we move the textarea selection — otherwise the browser's caret
+    // snaps back to wherever React's controlled re-render landed.
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (!el) return;
+      el.focus();
+      el.setSelectionRange(next.caret, next.caret);
+      setCaret(next.caret);
+    });
+  }
+
+  function onKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (!suggest.open) return;
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      suggest.setHighlight((h) => Math.min(suggest.matches.length - 1, h + 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      suggest.setHighlight((h) => Math.max(0, h - 1));
+    } else if (e.key === "Enter" || e.key === "Tab") {
+      const m = suggest.matches[suggest.highlight];
+      if (m) {
+        e.preventDefault();
+        selectMember(m);
+      }
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      suggest.dismiss();
+    }
+  }
 
   async function submit() {
     const trimmed = body.trim();
@@ -29,6 +81,7 @@ export function CommentForm({ wardId, date }: Props) {
         mentionedUids: extractMentions(trimmed, members),
       });
       setBody("");
+      setCaret(0);
     } finally {
       setBusy(false);
     }
@@ -42,13 +95,49 @@ export function CommentForm({ wardId, date }: Props) {
       }}
       className="flex flex-col gap-2"
     >
-      <textarea
-        value={body}
-        onChange={(e) => setBody(e.target.value)}
-        rows={3}
-        placeholder="Leave a note for the bishopric. Use @Name to mention a ward member."
-        className="font-sans text-[14px] leading-[1.55] px-3 py-2.5 bg-parchment border border-transparent rounded-md text-walnut min-h-17.5 w-full resize-y transition-colors placeholder:text-walnut-3 placeholder:italic hover:border-border-strong hover:bg-chalk focus:outline-none focus:border-bordeaux focus:bg-chalk focus:ring-2 focus:ring-bordeaux/15"
-      />
+      <div className="relative bg-parchment border border-transparent rounded-md transition-colors hover:border-border-strong hover:bg-chalk focus-within:border-bordeaux focus-within:bg-chalk focus-within:ring-2 focus-within:ring-bordeaux/15">
+        {/* Styled mirror — sits behind the textarea and renders the
+            same body with @Mention chips. Geometry classes match
+            the textarea exactly so each character lands on the same
+            pixel. The textarea on top carries `text-transparent` so
+            only the caret + selection show through. */}
+        <div
+          ref={mirrorRef}
+          aria-hidden
+          className={`${TEXT_GEOMETRY} pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap wrap-break-word text-walnut`}
+        >
+          {renderCommentBody(body, members)}
+          {/* Trailing newline-only bodies need a zero-width char so
+              the mirror's last line takes height. */}
+          {body.endsWith("\n") && "​"}
+        </div>
+        <textarea
+          ref={textareaRef}
+          value={body}
+          onChange={(e) => {
+            setBody(e.target.value);
+            setCaret(e.target.selectionStart);
+          }}
+          onSelect={(e) => setCaret(e.currentTarget.selectionStart)}
+          onKeyDown={onKeyDown}
+          onScroll={(e) => {
+            if (mirrorRef.current) {
+              mirrorRef.current.scrollTop = e.currentTarget.scrollTop;
+            }
+          }}
+          rows={3}
+          placeholder="Leave a note for the bishopric. Use @Name to mention a ward member."
+          className={`${TEXT_GEOMETRY} relative w-full min-h-17.5 resize-y bg-transparent border-0 text-transparent caret-walnut placeholder:text-walnut-3 placeholder:italic focus:outline-none`}
+        />
+        {suggest.open && (
+          <MentionSuggestList
+            matches={suggest.matches}
+            highlight={suggest.highlight}
+            onSelect={selectMember}
+            onHover={(i) => suggest.setHighlight(i)}
+          />
+        )}
+      </div>
       <div className="flex justify-end">
         <button
           type="submit"

--- a/src/features/comments/CommentItem.tsx
+++ b/src/features/comments/CommentItem.tsx
@@ -6,6 +6,7 @@ import type { Comment } from "@/lib/types";
 import { useAuthStore } from "@/stores/authStore";
 import { editComment, softDeleteComment } from "./utils/commentActions";
 import { extractMentions } from "./utils/extractMentions";
+import { renderCommentBody } from "./utils/renderCommentBody";
 
 interface Props {
   wardId: string;
@@ -87,7 +88,7 @@ export function CommentItem({ wardId, date, comment }: Props) {
         />
       ) : (
         <p className="whitespace-pre-wrap font-sans text-[13.5px] text-walnut leading-relaxed">
-          {comment.data.body}
+          {renderCommentBody(comment.data.body, members)}
         </p>
       )}
 

--- a/src/features/comments/MentionSuggestList.tsx
+++ b/src/features/comments/MentionSuggestList.tsx
@@ -1,0 +1,74 @@
+import type { WithId } from "@/hooks/_sub";
+import type { Member } from "@/lib/types";
+import { cn } from "@/lib/cn";
+
+interface Props {
+  matches: readonly WithId<Member>[];
+  highlight: number;
+  onSelect: (member: WithId<Member>) => void;
+  onHover: (index: number) => void;
+}
+
+/** Popover for the @-mention autosuggest in `CommentForm`. Anchored
+ *  below the textarea (full width). Click selects, hover updates the
+ *  highlight (so click + arrow stay in sync). Keyboard handling
+ *  lives on the textarea — see `CommentForm`'s onKeyDown. */
+export function MentionSuggestList({ matches, highlight, onSelect, onHover }: Props) {
+  return (
+    <ul
+      role="listbox"
+      aria-label="Mention suggestions"
+      className="absolute left-0 right-0 top-full mt-1 z-30 max-h-56 overflow-y-auto rounded-md border border-border bg-chalk shadow-elev-2 list-none m-0 p-1"
+    >
+      {matches.map((m, i) => (
+        <li key={m.id}>
+          <button
+            type="button"
+            role="option"
+            aria-selected={i === highlight}
+            onMouseDown={(e) => {
+              // mousedown so the button steals focus from the textarea
+              // synchronously — but preventDefault keeps the textarea
+              // focused so the inserted caret position sticks.
+              e.preventDefault();
+              onSelect(m);
+            }}
+            onMouseEnter={() => onHover(i)}
+            className={cn(
+              "w-full text-left flex items-center gap-2.5 px-2.5 py-2 rounded-sm transition-colors",
+              i === highlight ? "bg-parchment-2" : "bg-transparent hover:bg-parchment",
+            )}
+          >
+            <Avatar photoURL={m.data.photoURL} displayName={m.data.displayName} />
+            <span className="font-sans text-[14px] text-walnut truncate">{m.data.displayName}</span>
+            <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-walnut-3 ml-auto">
+              {m.data.role}
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function Avatar({ photoURL, displayName }: { photoURL?: string; displayName: string }) {
+  if (photoURL) {
+    return (
+      <img
+        src={photoURL}
+        alt=""
+        aria-hidden
+        className="w-6 h-6 rounded-full object-cover shrink-0"
+      />
+    );
+  }
+  const initial = displayName.trim().charAt(0).toUpperCase() || "?";
+  return (
+    <span
+      aria-hidden
+      className="w-6 h-6 rounded-full bg-parchment-2 border border-border flex items-center justify-center font-mono text-[11px] text-walnut shrink-0"
+    >
+      {initial}
+    </span>
+  );
+}

--- a/src/features/comments/hooks/useMentionSuggest.ts
+++ b/src/features/comments/hooks/useMentionSuggest.ts
@@ -1,0 +1,64 @@
+import { useEffect, useMemo, useState } from "react";
+import type { WithId } from "@/hooks/_sub";
+import type { Member } from "@/lib/types";
+import { activeMentionToken } from "../utils/mentionToken";
+
+const MAX_MATCHES = 6;
+
+interface Args {
+  value: string;
+  caret: number;
+  members: readonly WithId<Member>[];
+}
+
+interface Result {
+  /** True when the popover should render — there's an active token
+   *  AND filtered matches AND the user hasn't dismissed the current
+   *  token via Escape. */
+  open: boolean;
+  /** The active partial token (`""` when the user just typed `@`),
+   *  or `null` when no token is active. Returned for `applyMention`. */
+  token: string | null;
+  matches: readonly WithId<Member>[];
+  highlight: number;
+  setHighlight: (next: number | ((prev: number) => number)) => void;
+  /** Suppress the popover for the current token until a fresh `@` is
+   *  typed. Wired to Escape in the form. */
+  dismiss: () => void;
+}
+
+/** Drives the @-mention autosuggest in `CommentForm`. Pure state —
+ *  the caller threads `value` + `caret` from the textarea. Members
+ *  filter case-insensitively against displayName via `includes`, so
+ *  typing `@yeng` matches "Sister Yeng Const". */
+export function useMentionSuggest({ value, caret, members }: Args): Result {
+  const token = activeMentionToken(value, caret);
+  const matches = useMemo<readonly WithId<Member>[]>(() => {
+    if (token === null) return [];
+    const q = token.trim().toLowerCase();
+    return members
+      .filter((m) => m.data.active)
+      .filter((m) => (q ? m.data.displayName.toLowerCase().includes(q) : true))
+      .slice(0, MAX_MATCHES);
+  }, [members, token]);
+
+  const [highlight, setHighlight] = useState(0);
+  const [dismissed, setDismissed] = useState(false);
+
+  // Reset highlight + dismissed flag whenever the active token
+  // changes (or disappears) — typing `@a` then `@b` should re-open
+  // the popover, and the highlight should land on the first match.
+  useEffect(() => {
+    setHighlight(0);
+    if (token === null) setDismissed(false);
+  }, [token]);
+
+  return {
+    open: !dismissed && matches.length > 0,
+    token,
+    matches,
+    highlight,
+    setHighlight,
+    dismiss: () => setDismissed(true),
+  };
+}

--- a/src/features/comments/utils/__tests__/mentionToken.test.ts
+++ b/src/features/comments/utils/__tests__/mentionToken.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { activeMentionToken, applyMention } from "../mentionToken";
+
+describe("activeMentionToken", () => {
+  it("returns null when there is no @ before the caret", () => {
+    expect(activeMentionToken("hello world", 11)).toBeNull();
+  });
+
+  it("returns the empty token immediately after typing @", () => {
+    expect(activeMentionToken("hello @", 7)).toBe("");
+  });
+
+  it("returns the partial token while the user is typing", () => {
+    expect(activeMentionToken("hello @al", 9)).toBe("al");
+  });
+
+  it("returns the @-rooted token at the start of the body", () => {
+    expect(activeMentionToken("@bo", 3)).toBe("bo");
+  });
+
+  it("ends the token at the first whitespace", () => {
+    // Caret is past the space — token closed.
+    expect(activeMentionToken("hello @al ", 10)).toBeNull();
+  });
+
+  it("ignores @ that is part of an email address", () => {
+    expect(activeMentionToken("ping me@b.com", 13)).toBeNull();
+  });
+
+  it("respects the caret when there's later text", () => {
+    // "hello @al rest" — caret right after "@al", with " rest" trailing.
+    expect(activeMentionToken("hello @al rest", 9)).toBe("al");
+  });
+});
+
+describe("applyMention", () => {
+  it("replaces the partial token with the full display name + space", () => {
+    const result = applyMention("hi @al", 6, "al", "Alice");
+    expect(result.value).toBe("hi @Alice ");
+    expect(result.caret).toBe("hi @Alice ".length);
+  });
+
+  it("preserves text after the caret", () => {
+    // Caret in the middle of the body, partial @token before it.
+    const result = applyMention("hi @al rest", 6, "al", "Alice");
+    expect(result.value).toBe("hi @Alice  rest");
+    expect(result.caret).toBe("hi @Alice ".length);
+  });
+
+  it("handles the empty-token case (just typed @)", () => {
+    const result = applyMention("hi @", 4, "", "Alice");
+    expect(result.value).toBe("hi @Alice ");
+    expect(result.caret).toBe("hi @Alice ".length);
+  });
+
+  it("returns the original value when the caret/token alignment is off", () => {
+    // Caret says "@al" but the body says "hi al"; defensive no-op.
+    const result = applyMention("hi al", 5, "al", "Alice");
+    expect(result.value).toBe("hi al");
+    expect(result.caret).toBe(5);
+  });
+});

--- a/src/features/comments/utils/__tests__/renderCommentBody.test.tsx
+++ b/src/features/comments/utils/__tests__/renderCommentBody.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { isValidElement, type ReactNode } from "react";
+import type { WithId } from "@/hooks/_sub";
+import type { Member } from "@/lib/types";
+import { renderCommentBody } from "../renderCommentBody";
+
+function mk(id: string, displayName: string, active = true): WithId<Member> {
+  return {
+    id,
+    data: {
+      email: `${id}@x.com`,
+      displayName,
+      calling: "bishop",
+      role: "bishopric",
+      active,
+      ccOnEmails: true,
+      fcmTokens: [],
+    },
+  };
+}
+
+function nodeText(n: ReactNode): string {
+  if (typeof n === "string") return n;
+  if (isValidElement<{ children?: ReactNode }>(n)) {
+    const child = n.props.children;
+    return Array.isArray(child) ? child.map(nodeText).join("") : nodeText(child);
+  }
+  return "";
+}
+
+function nodeIsMention(n: ReactNode): boolean {
+  return isValidElement(n) && (n.type as unknown) === "span";
+}
+
+describe("renderCommentBody", () => {
+  it("returns the raw body when there are no members or mentions", () => {
+    expect(renderCommentBody("hi", [])).toEqual(["hi"]);
+    expect(renderCommentBody("hi", [mk("u1", "Alice")])).toEqual(["hi"]);
+  });
+
+  it("wraps a simple @Name in a styled span", () => {
+    const out = renderCommentBody("hi @Alice!", [mk("u1", "Alice")]);
+    expect(out.map(nodeText).join("")).toBe("hi @Alice!");
+    expect(out.filter(nodeIsMention)).toHaveLength(1);
+  });
+
+  it("prefers the longer match when names overlap", () => {
+    const members = [mk("u1", "Alice"), mk("u2", "Alice Smith")];
+    const out = renderCommentBody("@Alice Smith said hi", members);
+    const mentions = out.filter(nodeIsMention);
+    expect(mentions).toHaveLength(1);
+    expect(nodeText(mentions[0]!)).toBe("@Alice Smith");
+  });
+
+  it("highlights multiple mentions in one body", () => {
+    const out = renderCommentBody("@Alice and @Bob agree.", [mk("u1", "Alice"), mk("u2", "Bob")]);
+    const mentions = out.filter(nodeIsMention);
+    expect(mentions.map(nodeText)).toEqual(["@Alice", "@Bob"]);
+  });
+
+  it("ignores inactive members", () => {
+    const out = renderCommentBody("@Alice ?", [mk("u1", "Alice", false)]);
+    expect(out.filter(nodeIsMention)).toHaveLength(0);
+  });
+});

--- a/src/features/comments/utils/mentionToken.ts
+++ b/src/features/comments/utils/mentionToken.ts
@@ -1,0 +1,45 @@
+/** Walks the comment body backwards from the caret to find an active
+ *  `@token` — the partial display-name the user is currently typing.
+ *  An active token must:
+ *    - sit immediately to the left of the caret with no whitespace
+ *      between the `@` and the caret,
+ *    - have its `@` either at the start of the body or preceded by
+ *      whitespace (so we don't trigger on email addresses).
+ *
+ *  Returns the substring after `@` (may be empty when the user just
+ *  typed the `@`), or `null` when no active token exists.
+ *
+ *  Tokens are single-word — typing a space ends the token. The
+ *  filtered display-name list still matches multi-word names via
+ *  `includes()` in the suggest hook. */
+export function activeMentionToken(value: string, caret: number): string | null {
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = value[i];
+    if (ch === "@") {
+      const beforeOk = i === 0 || /\s/.test(value[i - 1] ?? "");
+      if (!beforeOk) return null;
+      return value.slice(i + 1, caret);
+    }
+    if (ch === undefined || /\s/.test(ch)) return null;
+  }
+  return null;
+}
+
+/** Replaces the active `@token` immediately before `caret` with a
+ *  full `@DisplayName ` (trailing space), returning the new body and
+ *  caret position. The caller is responsible for syncing the
+ *  textarea's selection range to the returned caret. */
+export function applyMention(
+  value: string,
+  caret: number,
+  token: string,
+  displayName: string,
+): { value: string; caret: number } {
+  // Caret − 1 (= len(token)) − 1 (= the '@') puts us at the '@'.
+  const atIndex = caret - token.length - 1;
+  if (atIndex < 0 || value[atIndex] !== "@") return { value, caret };
+  const before = value.slice(0, atIndex);
+  const after = value.slice(caret);
+  const inserted = `@${displayName} `;
+  return { value: before + inserted + after, caret: before.length + inserted.length };
+}

--- a/src/features/comments/utils/renderCommentBody.tsx
+++ b/src/features/comments/utils/renderCommentBody.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+import type { WithId } from "@/hooks/_sub";
+import type { Member } from "@/lib/types";
+
+function escapeRegex(s: string): string {
+  return s.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+/** Turns a comment body into a sequence of plain-text segments and
+ *  styled `@Mention` spans by scanning for any active ward member's
+ *  displayName preceded by `@` and bounded on the right by
+ *  whitespace, sentence punctuation, or end-of-string. Mirrors
+ *  `extractMentions`'s match rules so the visual highlight stays in
+ *  lockstep with the notification fan-out. Names are tried longest
+ *  first so e.g. `@Alice Smith` wins over `@Alice`. */
+export function renderCommentBody(body: string, members: readonly WithId<Member>[]): ReactNode[] {
+  const names = members
+    .filter((m) => m.data.active)
+    .map((m) => m.data.displayName.trim())
+    .filter((n) => n.length > 0)
+    .toSorted((a, b) => b.length - a.length);
+
+  if (names.length === 0 || body.length === 0) return [body];
+
+  const alternation = names.map(escapeRegex).join("|");
+  const pattern = new RegExp(`@(${alternation})(?=[\\s.,!?;:]|$)`, "giu");
+
+  const out: ReactNode[] = [];
+  let cursor = 0;
+  let key = 0;
+  for (const match of body.matchAll(pattern)) {
+    const start = match.index;
+    if (start > cursor) out.push(body.slice(cursor, start));
+    out.push(
+      <span
+        key={`m-${key++}`}
+        className="font-semibold text-bordeaux-deep bg-bordeaux/8 rounded-sm px-0.5"
+      >
+        {match[0]}
+      </span>,
+    );
+    cursor = start + match[0].length;
+  }
+  if (cursor < body.length) out.push(body.slice(cursor));
+  return out;
+}

--- a/src/features/meetings/WeekEditor.tsx
+++ b/src/features/meetings/WeekEditor.tsx
@@ -4,10 +4,8 @@ import { TwilioAutoConnect } from "@/features/invitations/TwilioAutoConnect";
 import { TwilioChatProvider } from "@/features/invitations/TwilioChatProvider";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
-import { useAuthStore } from "@/stores/authStore";
 import { useCommentReadStore } from "@/stores/commentReadStore";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
-import { CancelDialog } from "./CancelDialog";
 import { CancellationBanner } from "./CancellationBanner";
 import { defaultMeetingType, ensureMeetingDoc } from "./utils/ensureMeetingDoc";
 import { HistoryModal } from "./HistoryModal";
@@ -23,7 +21,6 @@ import { ResetToDraftDialog } from "./program/ResetToDraftDialog";
 import { StatusLegend } from "./program/StatusLegend";
 import { buildRailSections } from "./program/utils/railSections";
 import { useApprovalActions } from "./program/hooks/useApprovalActions";
-import { cancelMeeting } from "./utils/updateMeeting";
 
 interface Props {
   date: string;
@@ -31,11 +28,9 @@ interface Props {
 
 export function WeekEditor({ date }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId);
-  const authUid = useAuthStore((s) => s.user?.uid);
   const settings = useWardSettings();
   const meeting = useMeeting(date);
   const speakers = useSpeakers(date);
-  const [confirmingCancel, setConfirmingCancel] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
   const markRead = useCommentReadStore((s) => s.markRead);
   const approval = useApprovalActions({
@@ -61,19 +56,13 @@ export function WeekEditor({ date }: Props) {
   const type = meeting.data?.meetingType ?? defaultMeetingType(date, nonMeeting);
   const cancellation = meeting.data?.cancellation;
   const isNonMeeting = NO_MEETING_TYPES.has(type);
-  const canCancel = !isNonMeeting && !cancellation?.cancelled;
   const report = checkMeetingReadiness(meeting.data, speakers.data, type);
   const rail = buildRailSections(meeting.data, speakers.data, type, report);
   const currentStatus = meeting.data?.status ?? "draft";
   const liveApprovals = (meeting.data?.approvals ?? []).filter((a) => !a.invalidated).length;
   const isLocked = !isNonMeeting && currentStatus !== "draft" && currentStatus !== "published";
 
-  const menuItems = [
-    { label: "History", onSelect: () => setHistoryOpen(true) },
-    ...(canCancel
-      ? [{ label: "Cancel meeting…", onSelect: () => setConfirmingCancel(true), destructive: true }]
-      : []),
-  ];
+  const menuItems = [{ label: "History", onSelect: () => setHistoryOpen(true) }];
 
   return (
     <TwilioChatProvider>
@@ -84,14 +73,6 @@ export function WeekEditor({ date }: Props) {
             <ProgramHead date={date} type={type} rightSlot={<OverflowMenu items={menuItems} />} />
 
             <CancellationBanner wardId={wardId} date={date} cancellation={cancellation} />
-            <CancelDialog
-              open={confirmingCancel}
-              onClose={() => setConfirmingCancel(false)}
-              onConfirm={async (reason) => {
-                if (!authUid) return;
-                await cancelMeeting(wardId, date, reason, authUid, nonMeeting);
-              }}
-            />
 
             {isNonMeeting ? (
               <div className="rounded-xl border border-border bg-parchment-2 p-5 text-sm text-walnut-2">

--- a/src/features/meetings/program/ProgramSections.tsx
+++ b/src/features/meetings/program/ProgramSections.tsx
@@ -29,7 +29,7 @@ export function ProgramSections({
     <>
       <LeadersSection {...sectionProps} />
       <BusinessSection {...sectionProps} />
-      <PrayersSection {...sectionProps} />
+      <PrayersSection wardId={wardId} date={date} meeting={meeting} />
       <SacramentSection {...sectionProps} />
       {type === "regular" && (
         <SpeakersSection

--- a/src/features/meetings/sections/PrayersSection.tsx
+++ b/src/features/meetings/sections/PrayersSection.tsx
@@ -1,105 +1,107 @@
-import type { Assignment, NonMeetingSunday, PrayerRole, SacramentMeeting } from "@/lib/types";
+import type { PrayerRole, SacramentMeeting, SpeakerStatus } from "@/lib/types";
 import { PrayerChatLauncher } from "@/features/invitations/PrayerChatLauncher";
 import { SpeakerStatusChip } from "@/features/speakers/SpeakerStatusChip";
 import { usePrayerParticipant } from "@/features/prayers/hooks/usePrayerParticipant";
-import { AssignRow } from "../program/AssignRow";
+import { Link } from "@/lib/nav";
+import { cn } from "@/lib/cn";
 import { ProgramSection } from "../program/ProgramSection";
-import { updateMeetingField } from "../utils/updateMeeting";
 
 interface Props {
   wardId: string;
   date: string;
   meeting: SacramentMeeting | null;
-  nonMeetingSundays: readonly NonMeetingSunday[];
 }
 
-export function PrayersSection({ wardId, date, meeting, nonMeetingSundays }: Props) {
-  async function set(field: "openingPrayer" | "benediction", next: Assignment) {
-    await updateMeetingField(wardId, date, nonMeetingSundays, { [field]: next });
-  }
-
+export function PrayersSection({ wardId, date, meeting }: Props) {
   return (
-    <ProgramSection id="sec-prayers" label="Prayers">
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-x-7 gap-y-1">
-        <PrayerRowGroup
-          label="Opening Prayer"
+    <ProgramSection
+      id="sec-prayers"
+      label="Prayers"
+      rightSlot={
+        <Link
+          to={`/schedule?focus=${date}`}
+          className="ml-auto font-serif italic text-[12.5px] text-walnut-3 underline decoration-dotted decoration-walnut-3/60 underline-offset-2 hover:text-bordeaux hover:decoration-bordeaux transition-colors"
+        >
+          Edit from the schedule view
+        </Link>
+      }
+    >
+      <div className="grid grid-cols-1 lg:grid-cols-2 -mx-5">
+        <PrayerListRow
           role="opening"
           wardId={wardId}
           date={date}
-          placeholder="Who will give the opening prayer?"
-          assignment={meeting?.openingPrayer}
-          onChange={(a) => void set("openingPrayer", a)}
+          inlineName={meeting?.openingPrayer?.person?.name ?? ""}
         />
-        <PrayerRowGroup
-          label="Closing Prayer"
+        <PrayerListRow
           role="benediction"
           wardId={wardId}
           date={date}
-          placeholder="Who will give the closing prayer?"
-          assignment={meeting?.benediction}
-          onChange={(a) => void set("benediction", a)}
+          inlineName={meeting?.benediction?.person?.name ?? ""}
         />
       </div>
     </ProgramSection>
   );
 }
 
-interface RowGroupProps {
-  label: string;
+const ROLE_LABEL: Record<PrayerRole, string> = {
+  opening: "OP",
+  benediction: "CP",
+};
+
+const ROLE_SUBTITLE: Record<PrayerRole, string> = {
+  opening: "Opening Prayer",
+  benediction: "Closing Prayer",
+};
+
+interface RowProps {
   role: PrayerRole;
   wardId: string;
   date: string;
-  placeholder: string;
-  assignment: Assignment | undefined;
-  onChange: (a: Assignment) => void;
+  /** Lightweight inline name from `meeting.{role}.person.name`. The
+   *  participant doc's `name` takes precedence when present. */
+  inlineName: string;
 }
 
-/** Per-prayer row in the meeting editor. The Invite/Resend trigger
- *  has moved to the schedule's "+ Plan prayers" entry point — the
- *  meeting editor stays focused on quick name capture. The status
- *  chip + chat launcher mirror the speaker rows so the bishop can
- *  open the prayer-giver chat from this surface too. */
-function PrayerRowGroup({
-  label,
-  role,
-  wardId,
-  date,
-  placeholder,
-  assignment,
-  onChange,
-}: RowGroupProps) {
-  const participant = usePrayerParticipant(date, role);
-  const status = participant.data?.status ?? null;
-  const inlineName = assignment?.person?.name?.trim() ?? "";
-  const hasName = Boolean(inlineName || participant.data?.name?.trim());
-  const showChip = participant.data && status && status !== "planned";
-  const showLauncher = hasName && participant.data?.invitationId;
-
+/** Per-prayer row in the meeting editor. Mirrors `SpeakerListRow`'s
+ *  rhythm so the form reads as one coherent list — leading mono
+ *  column (OP/CP), name + role subtitle, status chip, chat launcher.
+ *  Read-only: speakers + prayers are both edited from the schedule
+ *  view, so the body is a static row, not a link. The chat launcher
+ *  is the only interactive surface here. */
+function PrayerListRow({ role, wardId, date, inlineName }: RowProps) {
+  const { data: participant } = usePrayerParticipant(date, role);
+  const name = participant?.name?.trim() || inlineName.trim();
+  const status: SpeakerStatus = participant?.status ?? "planned";
   return (
-    <div>
-      <AssignRow
-        label={label}
-        placeholder={placeholder}
-        assignment={assignment}
-        // Once a prayer participant doc exists, the structured status
-        // chip + chat launcher take over from the legacy "confirmed"
-        // toggle so the row reads like a speaker row.
-        showStatus={!participant.data}
-        onChange={onChange}
-      />
-      {(showChip || showLauncher) && (
-        <div className="flex items-center justify-end gap-2 pl-24.5 pr-2 -mt-1 mb-2">
-          {showChip && status && <SpeakerStatusChip status={status} />}
-          {showLauncher && (
-            <PrayerChatLauncher
-              wardId={wardId}
-              date={date}
-              role={role}
-              participant={participant.data ?? null}
-              fallbackName={inlineName}
-            />
-          )}
+    <div className="flex items-center gap-2.5 py-2.5 px-5 border-b border-dashed border-border last:border-b-0 lg:nth-last-2:border-b-0">
+      <div className="flex items-center gap-3 flex-1 min-w-0">
+        <span className="font-mono text-[10.5px] tracking-[0.08em] text-brass-deep w-7 shrink-0">
+          {ROLE_LABEL[role]}
+        </span>
+        <div className="min-w-0">
+          <div
+            className={cn(
+              "font-sans text-[14.5px] leading-tight truncate",
+              name ? "font-semibold text-walnut" : "italic font-medium text-walnut-3",
+            )}
+          >
+            {name || "Unassigned"}
+          </div>
+          <div className="font-serif italic text-[13px] text-walnut-2 mt-0.5 truncate">
+            {ROLE_SUBTITLE[role]}
+          </div>
         </div>
+      </div>
+      <SpeakerStatusChip status={status} />
+      {name && (
+        <PrayerChatLauncher
+          wardId={wardId}
+          date={date}
+          role={role}
+          participant={participant ?? null}
+          fallbackName={inlineName}
+        />
       )}
     </div>
   );

--- a/src/features/meetings/sections/SpeakersSection.tsx
+++ b/src/features/meetings/sections/SpeakersSection.tsx
@@ -2,10 +2,14 @@ import { useMemo, useState } from "react";
 import type { WithId } from "@/hooks/_sub";
 import type { MidItem as MidItemType, NonMeetingSunday, Speaker } from "@/lib/types";
 import { reorderSpeakers } from "@/features/speakers/utils/speakerActions";
+import { Link } from "@/lib/nav";
 import { ProgramSection } from "../program/ProgramSection";
 import { updateMeetingField } from "../utils/updateMeeting";
 import { MidPlaceholderRow, SpeakerListRow } from "./SpeakerListRow";
 import { buildItems, formatMidLabel, sortByOrder, type Item } from "./utils/speakerListItems";
+
+const SCHEDULE_LINK_CLS =
+  "font-serif italic text-[12.5px] text-walnut-3 underline decoration-dotted decoration-walnut-3/60 underline-offset-2 hover:text-bordeaux hover:decoration-bordeaux transition-colors";
 
 interface Props {
   wardId: string;
@@ -51,7 +55,14 @@ export function SpeakersSection({ wardId, date, speakers, mid, nonMeetingSundays
     return (
       <ProgramSection id="sec-speakers" label="Speakers">
         <p className="font-serif italic text-[13.5px] text-walnut-3 py-1">
-          No speakers yet. Add them from the schedule view.
+          No speakers yet. Add them from the{" "}
+          <Link
+            to={`/schedule?focus=${date}`}
+            className="underline decoration-dotted decoration-walnut-3/60 underline-offset-2 hover:text-bordeaux hover:decoration-bordeaux transition-colors"
+          >
+            schedule view
+          </Link>
+          .
         </p>
       </ProgramSection>
     );
@@ -64,8 +75,12 @@ export function SpeakersSection({ wardId, date, speakers, mid, nonMeetingSundays
       label="Speakers"
       count={ordered.length}
       rightSlot={
-        <span className="ml-auto font-serif italic text-[12.5px] text-walnut-3">
-          Drag to reorder
+        <span className="ml-auto inline-flex items-center gap-2 font-serif italic text-[12.5px] text-walnut-3">
+          <span>Drag to reorder</span>
+          <span aria-hidden>·</span>
+          <Link to={`/schedule?focus=${date}`} className={SCHEDULE_LINK_CLS}>
+            Edit from the schedule view
+          </Link>
         </span>
       }
     >

--- a/src/features/schedule/MobileScheduleList.tsx
+++ b/src/features/schedule/MobileScheduleList.tsx
@@ -9,6 +9,9 @@ interface Props {
   monthGroups: readonly MonthGroup[];
   leadTimeDays: number;
   nonMeetingSundays: readonly NonMeetingSunday[];
+  /** Date matching `?focus=<date>` on the schedule route. The block
+   *  whose date matches scroll-flashes itself on mount. */
+  focusDate?: string | null;
 }
 
 /** Mobile schedule list. The first card across all month groups gets
@@ -16,7 +19,12 @@ interface Props {
  *  kind-aware confirmed-rollup line). When the hero scrolls out of
  *  view, a Messages-style floating jump-back button fades in so the
  *  bishop can return to "this Sunday" with one tap. */
-export function MobileScheduleList({ monthGroups, leadTimeDays, nonMeetingSundays }: Props) {
+export function MobileScheduleList({
+  monthGroups,
+  leadTimeDays,
+  nonMeetingSundays,
+  focusDate = null,
+}: Props) {
   const firstDate = monthGroups[0]?.sundays[0]?.date ?? null;
   const [heroEl, setHeroEl] = useState<HTMLElement | null>(null);
   const [heroVisible, setHeroVisible] = useState(true);
@@ -49,6 +57,7 @@ export function MobileScheduleList({ monthGroups, leadTimeDays, nonMeetingSunday
                 leadTimeDays={leadTimeDays}
                 nonMeetingSundays={nonMeetingSundays}
                 isHero={isHero}
+                focused={sunday.date === focusDate}
               />
             );
             return isHero ? (

--- a/src/features/schedule/MobileSundayBlock.tsx
+++ b/src/features/schedule/MobileSundayBlock.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { useSpeakers } from "@/hooks/useMeeting";
 import { leadTimeSeverity } from "@/features/speakers/utils/leadTime";
 import type { MeetingType, NonMeetingSunday, SacramentMeeting } from "@/lib/types";
@@ -29,6 +30,11 @@ interface Props {
    *  bordeaux stroke on the chalk surface. Only mobile passes this —
    *  desktop has no equivalent affordance. */
   isHero?: boolean;
+  /** Set when this block matches `?focus=<date>` on the schedule
+   *  route. Triggers a smooth scrollIntoView + a one-shot ring flash
+   *  so the bishop's eye lands on the right card after arriving from
+   *  the meeting program form. */
+  focused?: boolean;
 }
 
 export function MobileSundayBlock({
@@ -38,6 +44,7 @@ export function MobileSundayBlock({
   leadTimeDays,
   nonMeetingSundays,
   isHero = false,
+  focused = false,
 }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId) ?? "";
   const type = meeting?.meetingType ?? fallbackType;
@@ -47,14 +54,28 @@ export function MobileSundayBlock({
   const urgent = leadTimeSeverity(new Date(), date, leadTimeDays) === "urgent";
   const hasConfirmedSpeaker = speakers.some((s) => s.data.status === "confirmed");
   const countdown = cancelled ? "Cancelled" : formatCountdownCompact(date);
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!focused) return;
+    const el = ref.current;
+    if (!el) return;
+    const id = requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [focused]);
 
   return (
     <article
+      ref={ref}
+      id={`sunday-${date}`}
       className={cn(
         "rounded-lg overflow-hidden border shadow-[0_1px_2px_rgba(58,37,25,0.06)]",
         ROW_BG[kind.variant],
         isHero ? "border-bordeaux/70 border-[1.5px]" : "border-border",
       )}
+      style={focused ? { animation: "scheduleFocusFlash 1.6s ease-out 1" } : undefined}
     >
       <MobileSundayHeader
         date={date}

--- a/src/features/schedule/ScheduleView.tsx
+++ b/src/features/schedule/ScheduleView.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
 import { TwilioAutoConnect } from "@/features/invitations/TwilioAutoConnect";
 import { TwilioChatProvider } from "@/features/invitations/TwilioChatProvider";
@@ -24,7 +25,12 @@ const MOBILE_STEP_WEEKS = 4;
 const MOBILE_MAX_WEEKS = 16;
 
 export function ScheduleView() {
-  useScrollRestore("schedule");
+  const [searchParams] = useSearchParams();
+  const focusDate = searchParams.get("focus");
+  // When the bishop arrives via "Edit from the schedule view", we
+  // drive the scroll ourselves to land on the matching card —
+  // turn off scroll-restore for this mount so it doesn't fight us.
+  useScrollRestore("schedule", { enabled: !focusDate });
   const wardId = useCurrentWardStore((s) => s.wardId);
   const settingsState = useWardSettings();
   const defaultHorizon = settingsState.data?.settings.scheduleHorizonWeeks ?? 8;
@@ -82,6 +88,7 @@ export function ScheduleView() {
               monthGroups={monthGroups}
               leadTimeDays={leadTimeDays}
               nonMeetingSundays={nonMeeting}
+              focusDate={focusDate}
             />
             {mobileHorizon < MOBILE_MAX_WEEKS && (
               <div
@@ -113,6 +120,7 @@ export function ScheduleView() {
                     fallbackType={defaultMeetingType(sunday.date, nonMeeting)}
                     leadTimeDays={leadTimeDays}
                     nonMeetingSundays={nonMeeting}
+                    focused={sunday.date === focusDate}
                   />
                 ))}
               </QuarterSection>

--- a/src/features/schedule/SundayCard/SundayCard.tsx
+++ b/src/features/schedule/SundayCard/SundayCard.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import type { MeetingType, NonMeetingSunday, SacramentMeeting } from "@/lib/types";
 import { useSpeakers } from "@/hooks/useMeeting";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
@@ -29,6 +30,11 @@ interface Props {
   fallbackType: MeetingType;
   leadTimeDays: number;
   nonMeetingSundays: readonly NonMeetingSunday[];
+  /** Set when this card matches `?focus=<date>` on the schedule
+   *  route. Triggers a smooth scroll-into-view + a one-shot ring
+   *  flash so the bishop's eye lands on the right card after
+   *  arriving from the meeting program form. */
+  focused?: boolean;
 }
 
 export function SundayCard({
@@ -37,6 +43,7 @@ export function SundayCard({
   fallbackType,
   leadTimeDays,
   nonMeetingSundays,
+  focused = false,
 }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId) ?? "";
   const type = meeting?.meetingType ?? fallbackType;
@@ -45,6 +52,19 @@ export function SundayCard({
   const { data: speakers } = useSpeakers(date);
   const severity = leadTimeSeverity(new Date(), date, leadTimeDays);
   const hasConfirmedSpeaker = speakers.some((s) => s.data.status === "confirmed");
+  const ref = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (!focused) return;
+    const el = ref.current;
+    if (!el) return;
+    // Defer one frame so layout/data has settled before we scroll —
+    // matches the pattern used by useScrollRestore for the same reason.
+    const id = requestAnimationFrame(() => {
+      el.scrollIntoView({ behavior: "smooth", block: "center" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [focused]);
 
   if (cancelled) {
     return (
@@ -58,10 +78,13 @@ export function SundayCard({
   return (
     <div className="relative h-full">
       <article
+        ref={ref}
+        id={`sunday-${date}`}
         className={cn(
           "group relative flex h-full flex-col rounded-lg border border-border shadow-elev-1",
           CARD_BG[kind.variant],
         )}
+        style={focused ? { animation: "scheduleFocusFlash 1.6s ease-out 1" } : undefined}
       >
         <SundayCardHeader
           date={date}

--- a/src/hooks/useScrollRestore.ts
+++ b/src/hooks/useScrollRestore.ts
@@ -9,9 +9,16 @@ import { useEffect } from "react";
  *  Picks the right scroll source automatically: AppShell's inner
  *  scroll container on desktop (marked with `data-app-scroll`),
  *  falling back to the window when no container is present (mobile,
- *  or modal pages with their own layout). */
-export function useScrollRestore(key: string): void {
+ *  or modal pages with their own layout).
+ *
+ *  Pass `{ enabled: false }` to fully no-op (no restore, no save) —
+ *  used by routes that drive scroll themselves on mount (e.g.
+ *  schedule's `?focus=<date>` flash) so the saved position isn't
+ *  poisoned by the deliberate scroll. */
+export function useScrollRestore(key: string, options?: { enabled?: boolean }): void {
+  const enabled = options?.enabled ?? true;
   useEffect(() => {
+    if (!enabled) return;
     const storageKey = `scroll-restore:${key}`;
     const saved = sessionStorage.getItem(storageKey);
     const target = pickScrollTarget();
@@ -29,7 +36,7 @@ export function useScrollRestore(key: string): void {
     return () => {
       sessionStorage.setItem(storageKey, String(getScroll(target)));
     };
-  }, [key]);
+  }, [key, enabled]);
 }
 
 type Target = HTMLElement | Window;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -300,6 +300,22 @@
   }
 }
 
+/* One-shot bordeaux ring flash. Played on the Sunday card matching
+   `?focus=<date>` when the bishop arrives from the meeting program
+   form so the eye lands on the right card. Pairs with a smooth
+   scrollIntoView in the card's mount effect. */
+@keyframes scheduleFocusFlash {
+  0% {
+    box-shadow: 0 0 0 0 rgba(139, 46, 42, 0);
+  }
+  15% {
+    box-shadow: 0 0 0 6px rgba(139, 46, 42, 0.45);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(139, 46, 42, 0);
+  }
+}
+
 /* --------------------------------------------------------------------
    Native-stack page transitions. The body wrapper inside <AppShell>
    carries `view-transition-name: shell-content`, so route swaps


### PR DESCRIPTION
## Summary

Three coherent UX improvements bundled on this branch:

- **Prayer rows mirror the speakers section.** `PrayersSection` now reads like the speakers list — mono OP/CP column, name + role subtitle, status chip, chat launcher. Inline name editing is gone from this surface (planning happens from the schedule); the chat launcher stays. Both prayer and speaker sections gain an *Edit from the schedule view* link back to the focused card.
- **Schedule focus flash.** Navigating back to the schedule with `?focus=<date>` now smooth-scrolls to the matching Sunday card and plays a one-shot bordeaux ring flash. `useScrollRestore` gains an `enabled` flag so the deliberate scroll doesn't poison the saved position.
- **Comment @mention autocomplete.** Composer gets a keyboard + mouse navigable suggestion popover and a textarea-mirror layout so chips render in lockstep with what the user types. Posted comments highlight mentions using the same match rules as the notification fan-out — what's visually highlighted matches who actually got pinged.

Drive-by: removes the unused *Cancel meeting…* overflow item from `WeekEditor` (cancellation flows through the schedule).

## Test plan

- [ ] `pnpm typecheck && pnpm lint && pnpm test` clean
- [ ] **Prayers**: open `/week/<sunday>`. Confirm the OP and CP rows render with the same rhythm as speaker rows (mono label, name, role subtitle, status chip). The *Edit from the schedule view* link in the section header navigates to `/schedule?focus=<date>`.
- [ ] **Schedule focus flash**: from the editor, click *Edit from the schedule view*. The matching Sunday card scrolls into view and flashes a bordeaux ring once. Saved scroll position isn't clobbered after a normal back-nav.
- [ ] **Mention autocomplete**: in a comment composer, type `@`. Suggest popover opens with up to 6 active members. Arrow keys move highlight, `Enter`/`Tab` selects, `Escape` dismisses. Selected name inserts as `@DisplayName ` and the caret lands after the trailing space.
- [ ] **Mention rendering**: post a comment with `@Alice and @Bob`. Both names render as bordeaux chips. An inactive member's name does not get chipped. Multi-word names (`@Alice Smith`) win over a substring (`@Alice`).
- [ ] **WeekEditor menu**: confirm only *History* appears in the overflow menu (cancel-meeting item removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)