### PR TITLE
Release: v0.23.1 — mobile planning banner fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.23.1] — 2026-05-03
+
+Patch release: mobile layout fix for the schedule's planning-open banner.
+
+### Fixed
+
+- **Schedule planning-open banner squeezed text on mobile.** The "Plan program" button sat next to the message at all widths, forcing the body copy into a narrow 5-line column on phones. The banner now stacks the icon + text on one row and the button on its own row below the small breakpoint, so the message reads as one or two lines on mobile; the inline row layout is preserved at `sm:` and up. (#252)
+
 ## [0.23.0] — 2026-05-03
 
 Three-PR planning rethink. The two-bishopric approval workflow is gone — printing is gated on a live readiness check instead. Sacrament meeting program planning is now scoped to the upcoming Sunday only (speakers and prayers stay plannable ahead on any Sunday). And the escalating Wed/Fri/Sat finalization nudges are replaced by a single Monday-morning "planning is open" push.
@@ -2567,7 +2575,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.23.0...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.23.1...HEAD
+[0.23.1]: https://github.com/aylabyuk/steward/releases/tag/v0.23.1
 [0.23.0]: https://github.com/aylabyuk/steward/releases/tag/v0.23.0
 [0.22.0]: https://github.com/aylabyuk/steward/releases/tag/v0.22.0
 [0.21.2]: https://github.com/aylabyuk/steward/releases/tag/v0.21.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/features/schedule/UpcomingPlanningBanner.tsx
+++ b/src/features/schedule/UpcomingPlanningBanner.tsx
@@ -13,16 +13,18 @@ interface Props {
  *  of having a schedule. Sits under PageHead. */
 export function UpcomingPlanningBanner({ upcoming }: Props) {
   return (
-    <div className="my-5 flex flex-wrap items-center gap-3 rounded-xl border border-bordeaux-soft bg-[linear-gradient(180deg,rgba(139,46,42,0.06),rgba(139,46,42,0.01))] px-4 py-3">
-      <CalendarIcon />
-      <p className="font-sans text-[13.5px] text-walnut flex-1 min-w-0 leading-snug">
-        Sacrament meeting program planning is open for{" "}
-        <strong className="font-semibold">{formatShortSunday(upcoming)}</strong>. Speakers and
-        prayers can still be planned ahead from any card on the schedule.
-      </p>
+    <div className="my-5 flex flex-col sm:flex-row sm:flex-wrap sm:items-center gap-3 rounded-xl border border-bordeaux-soft bg-[linear-gradient(180deg,rgba(139,46,42,0.06),rgba(139,46,42,0.01))] px-4 py-3">
+      <div className="flex items-start sm:items-center gap-3 flex-1 min-w-0">
+        <CalendarIcon />
+        <p className="font-sans text-[13.5px] text-walnut flex-1 min-w-0 leading-snug">
+          Sacrament meeting program planning is open for{" "}
+          <strong className="font-semibold">{formatShortSunday(upcoming)}</strong>. Speakers and
+          prayers can still be planned ahead from any card on the schedule.
+        </p>
+      </div>
       <Link
         to={`/week/${upcoming}`}
-        className="font-sans text-[13px] font-semibold px-3 py-1.5 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors whitespace-nowrap"
+        className="font-sans text-[13px] font-semibold px-3 py-1.5 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors whitespace-nowrap self-end sm:self-auto"
       >
         Plan program →
       </Link>


### PR DESCRIPTION
## Summary

Patch release on top of v0.23.0.

### Fixed

- **Schedule planning-open banner squeezed text on mobile.** The "Plan program" button sat next to the message at all widths, forcing the body copy into a narrow 5-line column on phones. The banner now stacks the icon + text on one row and the button on its own row below the small breakpoint; the inline row layout is preserved at `sm:` and up. (#252)

## Test plan

- [x] CI green on develop (lint · format · typecheck · test · build · e2e + firestore rules)
- [ ] Post-merge: `release.yml` workflow tags `v0.23.1`, publishes the release, deploys Firestore rules + Cloud Functions
- [ ] Vercel auto-deploys frontend from `main`
- [ ] Smoke: load `/schedule` on a mobile viewport and confirm the planning banner reads as 1–2 lines with the button on its own row

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKbBqhAcehzjuvwkfukLPd)_