### PR TITLE
fix(meetings): surface meeting init/load failures instead of silent placeholder

### DIFF
--- a/src/features/meetings/MeetingInitErrorBanner.tsx
+++ b/src/features/meetings/MeetingInitErrorBanner.tsx
@@ -1,0 +1,62 @@
+interface Props {
+  error: Error;
+  /** Where the error came from — drives the headline copy. `init`
+   *  means `ensureMeetingDoc` threw (most often a rules denial on
+   *  the meeting/history transaction). `subscription` means the live
+   *  meeting doc subscription failed — usually a Zod parse error
+   *  against an existing-but-malformed doc, or a permission denial
+   *  on the read. */
+  source: "init" | "subscription";
+  onRetry: () => void;
+}
+
+const HEADLINE: Record<Props["source"], string> = {
+  init: "Couldn't initialize this Sunday's meeting.",
+  subscription: "Couldn't load this Sunday's meeting.",
+};
+
+/** Surfaces silent failures on the week editor so the bishop sees
+ *  what went wrong instead of an indefinite "Meeting not created
+ *  yet" placeholder. */
+export function MeetingInitErrorBanner({ error, source, onRetry }: Props) {
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex flex-wrap items-center gap-3 rounded-xl border border-bordeaux/40 bg-bordeaux/5 px-4 py-3"
+    >
+      <WarnIcon />
+      <div className="flex-1 min-w-0">
+        <p className="font-sans text-[13.5px] font-semibold text-bordeaux">{HEADLINE[source]}</p>
+        <p className="font-sans text-[12.5px] text-walnut-2 mt-1 break-words">{error.message}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="font-sans text-[13px] font-semibold px-3 py-1.5 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors whitespace-nowrap"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+function WarnIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-bordeaux shrink-0"
+      aria-hidden
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}

--- a/src/features/meetings/WeekEditor.tsx
+++ b/src/features/meetings/WeekEditor.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/cn";
 import { CancellationBanner } from "./CancellationBanner";
 import { defaultMeetingType, ensureMeetingDoc } from "./utils/ensureMeetingDoc";
 import { HistoryModal } from "./HistoryModal";
+import { MeetingInitErrorBanner } from "./MeetingInitErrorBanner";
 import { NO_MEETING_TYPES, TYPE_LABELS } from "./utils/meetingLabels";
 import { checkMeetingReadiness } from "./utils/readiness";
 import { PrintReadinessPanel } from "./program/PrintReadinessPanel";
@@ -44,6 +45,9 @@ export function WeekEditor({ date }: Props) {
   const upcoming = getUpcomingSundayIso(new Date(), timezone);
   const editable = date === upcoming;
 
+  const [initError, setInitError] = useState<Error | null>(null);
+  const [initRetryKey, setInitRetryKey] = useState(0);
+
   useEffect(() => {
     // Don't seed a meeting doc for a Sunday that isn't currently open
     // for planning — past meetings shouldn't be auto-created when a
@@ -51,8 +55,15 @@ export function WeekEditor({ date }: Props) {
     // when their week arrives.
     if (!wardId || !settingsLoaded || !editable) return;
     const nonMeetingSundays = settings.data?.settings.nonMeetingSundays ?? [];
-    void ensureMeetingDoc(wardId, date, nonMeetingSundays);
-  }, [wardId, date, settingsLoaded, editable, settings.data]);
+    setInitError(null);
+    ensureMeetingDoc(wardId, date, nonMeetingSundays).catch((err: unknown) => {
+      // Surface the failure to the bishop — without this, a denied
+      // permission or transaction error leaves the readiness panel
+      // stuck at "Meeting not created yet" with no way to recover.
+      console.error("ensureMeetingDoc failed", err);
+      setInitError(err instanceof Error ? err : new Error(String(err)));
+    });
+  }, [wardId, date, settingsLoaded, editable, settings.data, initRetryKey]);
 
   if (!wardId) return null;
 
@@ -82,6 +93,13 @@ export function WeekEditor({ date }: Props) {
               </div>
             ) : (
               <>
+                {(initError || meeting.error) && (
+                  <MeetingInitErrorBanner
+                    error={initError ?? meeting.error!}
+                    source={initError ? "init" : "subscription"}
+                    onRetry={() => setInitRetryKey((k) => k + 1)}
+                  />
+                )}
                 <PrintReadinessPanel date={date} report={report} />
                 <div className="flex justify-center mb-4 lg:hidden">
                   <StatusLegend />

--- a/src/features/prayers/utils/prayerActions.ts
+++ b/src/features/prayers/utils/prayerActions.ts
@@ -1,4 +1,4 @@
-import { deleteField, doc, serverTimestamp, setDoc, writeBatch } from "firebase/firestore";
+import { doc, serverTimestamp, setDoc, writeBatch } from "firebase/firestore";
 import { ensureMeetingDoc } from "@/features/meetings/utils/ensureMeetingDoc";
 import { db } from "@/lib/firebase";
 import type { InvitationStatus, NonMeetingSunday, PrayerRole } from "@/lib/types";
@@ -128,9 +128,13 @@ export async function clearPrayerParticipant(
     const meetingRef = doc(db, "wards", wardId, "meetings", date);
     const batch = writeBatch(db);
     batch.delete(participantRef);
+    // Use `person: null` rather than `deleteField()` so the resulting
+    // assignment object stays parseable by `assignmentSchema` — a
+    // missing `person` key produces a doc that fails Zod parse and
+    // surfaces as "Meeting not created yet" on the week editor.
     batch.set(
       meetingRef,
-      { [MEETING_FIELD[role]]: { person: deleteField(), confirmed: false } },
+      { [MEETING_FIELD[role]]: { person: null, confirmed: false } },
       { merge: true },
     );
     await batch.commit();

--- a/src/lib/types/person.ts
+++ b/src/lib/types/person.ts
@@ -7,8 +7,14 @@ export const personSchema = z.object({
 });
 export type Person = z.infer<typeof personSchema>;
 
+// `person` accepts present-as-object, present-as-null, AND absent. The
+// missing-key variant happens when a clear path uses Firestore's
+// `deleteField()` to wipe the person — the resulting doc has the
+// assignment object but no `person` key, which Zod's `nullable()`
+// rejects. Tolerating absence here keeps existing meetings parseable;
+// new writes should still prefer `person: null` (see `clearPrayerParticipant`).
 export const assignmentSchema = z.object({
-  person: personSchema.nullable(),
+  person: personSchema.nullish(),
   confirmed: z.boolean().default(false),
 });
 export type Assignment = z.infer<typeof assignmentSchema>;


### PR DESCRIPTION
## Summary
- Clearing a prayer participant wrote `person: deleteField()` into the meeting doc, producing an assignment object that failed `assignmentSchema.parse`. The week editor then stalled at "Meeting not created yet" with no error and no way back.
- Switch `clearPrayerParticipant` to `person: null` so new writes match the schema.
- Make `assignmentSchema.person` `nullish()` so legacy docs already missing the key still parse.
- Catch `ensureMeetingDoc` rejections and surface both the init error and the live `useMeeting` subscription error via a new `MeetingInitErrorBanner` with a Try-again button.

## Test plan
- [ ] Open a week, clear a prayer participant — week editor stays usable, no "Meeting not created yet" stall.
- [ ] Force a rules denial on the meeting/history transaction — banner appears with the error message and "Try again" re-runs `ensureMeetingDoc`.
- [ ] Existing meeting docs with the absent `person` key still load (no Zod parse error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)