### PR TITLE
feat: prepare-to-print + congregation bulletin layout

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -20,6 +20,7 @@ import { ProgramTemplatesPage } from "./routes/templates-programs";
 import { SpeakerLetterTemplatePage } from "./routes/templates-speaker-letter";
 import { WardSettingsPage } from "./routes/ward-settings";
 import { Week } from "./routes/week";
+import { PreparePrintRoute } from "./routes/week-prepare";
 
 export const router = createBrowserRouter([
   {
@@ -61,6 +62,7 @@ export const router = createBrowserRouter([
       },
       { path: "/print/:date/congregation", element: <CongregationProgram /> },
       { path: "/print/:date/conducting", element: <ConductingProgram /> },
+      { path: "/week/:date/prepare", element: <PreparePrintRoute /> },
       {
         path: "/settings/templates/speaker-letter",
         element: <SpeakerLetterTemplatePage />,

--- a/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
+++ b/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
@@ -1,95 +1,32 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
-import { SaveBar } from "@/components/ui/SaveBar";
-import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useCurrentWardStore } from "@/stores/currentWardStore";
-import { friendlyWriteError } from "@/stores/saveStatusStore";
-import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
-import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
-import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
-import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { writeProgramTemplate } from "@/features/program-templates/utils/writeProgramTemplate";
+import type { ProgramTemplateKey } from "@/lib/types";
+import { CongregationTemplateTab } from "@/features/print/CongregationTemplateTab";
+import { ConductingTemplateTab } from "@/features/program-templates/ConductingTemplateTab";
 import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
-import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
 
 const TABS: { key: ProgramTemplateKey; label: string }[] = [
   { key: "conductingProgram", label: "Conducting copy" },
   { key: "congregationProgram", label: "Congregation copy" },
 ];
 
-/** /settings/templates/programs — WYSIWYG editor for both program
- *  copies. The editor IS the page; chrome (eyebrow + paper frame)
- *  renders around a single contenteditable. Tab switches between
- *  conducting + congregation copies, each with its own draft state. */
+/** /settings/templates/programs — chrome + tab switcher. The
+ *  conducting tab hosts a Lexical WYSIWYG editor (variable chips +
+ *  free-form layout); the congregation tab hosts a form-and-preview
+ *  editor for the bulletin's editable bits (cover image URL +
+ *  program footer note). Each tab manages its own dirty/save state
+ *  and SaveBar. */
 export function ProgramTemplatesPage(): React.ReactElement {
   useFullViewportLayout();
   const isMobile = useIsMobile();
-  const wardId = useCurrentWardStore((s) => s.wardId);
-  const me = useCurrentMember();
-  const canEdit = Boolean(me?.data.active);
-
   const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
-  const conducting = useProgramTemplate("conductingProgram");
-  const congregation = useProgramTemplate("congregationProgram");
-  const activeDoc = activeKey === "conductingProgram" ? conducting.data : congregation.data;
-  const initialJson = activeDoc?.editorStateJson ?? defaultProgramTemplate(activeKey);
-  const usingDefault = !activeDoc?.editorStateJson;
-
-  const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
-    conductingProgram: null,
-    congregationProgram: null,
-  });
-  const [pageStyleDraft, setPageStyleDraft] = useState<
-    Record<ProgramTemplateKey, LetterPageStyle | null>
-  >({ conductingProgram: null, congregationProgram: null });
-  const [editorKey, setEditorKey] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedAt, setSavedAt] = useState<string | null>(null);
-
-  // Reset the editor's mount key whenever the active tab flips so
-  // Lexical hydrates from the new tab's initial state.
-  useEffect(() => {
-    setEditorKey((k) => k + 1);
-  }, [activeKey]);
-
-  const editorJson = draft[activeKey] ?? initialJson;
-  const activePageStyle = pageStyleDraft[activeKey] ?? activeDoc?.pageStyle ?? null;
-  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
-  const styleDirty =
-    pageStyleDraft[activeKey] !== null &&
-    JSON.stringify(pageStyleDraft[activeKey]) !== JSON.stringify(activeDoc?.pageStyle ?? null);
-  const dirty = jsonDirty || styleDirty;
-
-  async function save() {
-    if (!wardId) return;
-    const jsonToSave = draft[activeKey] ?? initialJson;
-    const margins = activeDoc?.margins ?? DEFAULT_MARGINS[activeKey];
-    const pageStyleToSave = activePageStyle ?? null;
-    setSaving(true);
-    setError(null);
-    try {
-      await writeProgramTemplate(wardId, activeKey, jsonToSave, margins, pageStyleToSave);
-      setDraft((d) => ({ ...d, [activeKey]: null }));
-      setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
-    } catch (e) {
-      setError(friendlyWriteError(e));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function discard() {
-    setDraft((d) => ({ ...d, [activeKey]: null }));
-    setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-    setEditorKey((k) => k + 1);
-    setError(null);
-  }
+  const [conductingUsingDefault, setConductingUsingDefault] = useState(false);
 
   if (isMobile) return <DesktopOnlyNotice title="Program templates" />;
+
+  const showSystemDefaultPill = activeKey === "conductingProgram" && conductingUsingDefault;
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
@@ -106,7 +43,7 @@ export function ProgramTemplatesPage(): React.ReactElement {
           </h1>
         </div>
         <div className="flex items-center gap-2">
-          {usingDefault && (
+          {showSystemDefaultPill && (
             <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-brass-soft bg-brass-soft/30 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep">
               <span aria-hidden>★</span>
               System default — save to lock in
@@ -132,30 +69,11 @@ export function ProgramTemplatesPage(): React.ReactElement {
         ))}
       </nav>
 
-      <div className="flex-1 min-h-0 pb-16">
-        <ProgramPageEditor
-          key={`${activeKey}-${editorKey}`}
-          variant={activeKey}
-          initialJson={editorJson}
-          pageStyle={activePageStyle}
-          showSampleNotice
-          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
-          onPageStyleChange={
-            canEdit ? (next) => setPageStyleDraft((d) => ({ ...d, [activeKey]: next })) : undefined
-          }
-          ariaLabel={TABS.find((t) => t.key === activeKey)!.label}
-          editorDisabled={!canEdit}
-        />
-      </div>
-
-      <SaveBar
-        dirty={dirty && canEdit}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={discard}
-        onSave={() => void save()}
-      />
+      {activeKey === "conductingProgram" ? (
+        <ConductingTemplateTab onUsingDefaultChange={setConductingUsingDefault} />
+      ) : (
+        <CongregationTemplateTab />
+      )}
     </main>
   );
 }

--- a/src/app/routes/week-prepare/PreparePrintRoute.tsx
+++ b/src/app/routes/week-prepare/PreparePrintRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate, useParams } from "react-router";
+import { PreparePrintView } from "@/features/print/PreparePrintView";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function PreparePrintRoute() {
+  const { date } = useParams<{ date: string }>();
+  if (!date || !ISO_DATE.test(date)) {
+    return <Navigate to="/schedule" replace />;
+  }
+  return <PreparePrintView date={date} />;
+}

--- a/src/app/routes/week-prepare/index.tsx
+++ b/src/app/routes/week-prepare/index.tsx
@@ -1,0 +1,1 @@
+export * from "./PreparePrintRoute";

--- a/src/features/meetings/program/PrintReadinessPanel.tsx
+++ b/src/features/meetings/program/PrintReadinessPanel.tsx
@@ -17,7 +17,7 @@ const PATH_PRINTER = "M6 9V2h12v7";
 const PATH_PRINTER_TRAY = "M6 14h12v7H6z";
 
 /** Top-of-editor panel that drives printing. When ready, it surfaces
- *  the two print-nav links front and centre; when not, it lists what
+ *  the Prepare-to-print CTA front and centre; when not, it lists what
  *  still needs filling so the bishop knows where to look. There's no
  *  approval workflow — readiness alone gates print. */
 export function PrintReadinessPanel({ date, report }: Props) {
@@ -61,18 +61,19 @@ function ReadyBody({ date }: { date: string }) {
       <p className="font-display text-[17px] font-semibold text-walnut tracking-[-0.005em] m-0 mb-2.5">
         All items assigned and confirmed.
       </p>
-      <div className="mt-1 flex flex-col sm:flex-row gap-2.5 flex-wrap">
-        <PrintLink
-          href={`/print/${date}/congregation`}
-          title="Congregation"
-          subtitle="Hand out to attendees — hymns, prayers, speakers with topics."
-        />
-        <PrintLink
-          href={`/print/${date}/conducting`}
-          title="Conducting"
-          subtitle="Conductor's desk copy — script cues + ward / stake business space."
-        />
-      </div>
+      <p className="font-serif italic text-[12.5px] text-walnut-3 m-0 mb-3">
+        Review both programs side-by-side, then print each one.
+      </p>
+      <Link
+        to={`/week/${date}/prepare`}
+        className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors font-sans text-[13px] font-semibold"
+      >
+        <Icon paths={[PATH_PRINTER, PATH_PRINTER_TRAY]} rect />
+        Prepare to print
+        <span aria-hidden className="ml-0.5">
+          →
+        </span>
+      </Link>
     </>
   );
 }
@@ -98,21 +99,6 @@ function MissingBody({ missing, unconfirmed }: { missing: string[]; unconfirmed:
         ))}
       </ul>
     </>
-  );
-}
-
-function PrintLink({ href, title, subtitle }: { href: string; title: string; subtitle: string }) {
-  return (
-    <Link
-      to={href}
-      className="flex-1 inline-flex flex-col gap-0.5 px-3.5 py-2.5 rounded-md border border-border-strong bg-chalk text-walnut hover:bg-parchment-2 hover:border-walnut-3 transition-colors"
-    >
-      <span className="font-sans text-[13px] font-semibold inline-flex items-center gap-1.5">
-        <Icon paths={[PATH_PRINTER, PATH_PRINTER_TRAY]} rect />
-        Print {title.toLowerCase()} program
-      </span>
-      <span className="font-serif italic text-[12px] text-walnut-3 leading-snug">{subtitle}</span>
-    </Link>
   );
 }
 

--- a/src/features/meetings/program/ProgramSaveBar.tsx
+++ b/src/features/meetings/program/ProgramSaveBar.tsx
@@ -6,63 +6,39 @@ interface Props {
   date: string;
   ready: boolean;
   remaining: number;
-  onPreview?: () => void;
 }
 
-/** Floating bottom save bar. Left: save indicator. Right: print
- *  shortcuts. Print buttons are always visible — disabled with a
+/** Floating bottom save bar. Left: save indicator. Right: prepare-to-
+ *  print shortcut. The button is always visible — disabled with a
  *  tooltip when the meeting still has unfilled items, so the bishop
  *  knows the action exists and what's blocking it. */
-export function ProgramSaveBar({ date, ready, remaining, onPreview }: Props) {
+export function ProgramSaveBar({ date, ready, remaining }: Props) {
   const blockedTitle = ready
     ? undefined
     : `Finish ${remaining} item${remaining === 1 ? "" : "s"} to print`;
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-30 bg-chalk border-t border-border shadow-[0_-6px_20px_rgba(35,24,21,0.08)]">
-      {/* Mobile: stack the indicator above the buttons so a long error
+      {/* Mobile: stack the indicator above the button so a long error
           message ("Couldn't save — Connection failed…") doesn't wrap
           inside a cramped row next to a big CTA. Desktop: everything
           on one line. */}
       <div className="flex flex-col gap-2 px-4 py-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))] sm:flex-row sm:items-center sm:gap-3.5 sm:px-8 sm:py-3 sm:pb-[max(0.75rem,env(safe-area-inset-bottom))]">
         <SaveIndicator />
         <span className="hidden sm:block sm:flex-1" />
-        <div className="flex items-center gap-2.5">
-          {onPreview && (
-            <button
-              type="button"
-              onClick={onPreview}
-              className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-transparent text-walnut-2 hover:bg-parchment-2 hover:text-walnut transition-colors"
-            >
-              Preview print
-            </button>
-          )}
-          <PrintLink
-            href={`/print/${date}/congregation`}
-            label="Congregation"
-            ready={ready}
-            blockedTitle={blockedTitle}
-          />
-          <PrintLink
-            href={`/print/${date}/conducting`}
-            label="Conducting"
-            ready={ready}
-            blockedTitle={blockedTitle}
-          />
-        </div>
+        <PrepareLink date={date} ready={ready} blockedTitle={blockedTitle} />
       </div>
     </div>
   );
 }
 
 interface LinkProps {
-  href: string;
-  label: string;
+  date: string;
   ready: boolean;
   blockedTitle: string | undefined;
 }
 
-function PrintLink({ href, label, ready, blockedTitle }: LinkProps) {
+function PrepareLink({ date, ready, blockedTitle }: LinkProps) {
   const className = cn(
     "font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border inline-flex items-center gap-1.5 transition-colors",
     ready
@@ -73,14 +49,14 @@ function PrintLink({ href, label, ready, blockedTitle }: LinkProps) {
     return (
       <span className={className} aria-disabled="true" title={blockedTitle}>
         <PrinterIcon />
-        Print {label.toLowerCase()}
+        Prepare to print
       </span>
     );
   }
   return (
-    <Link to={href} className={className}>
+    <Link to={`/week/${date}/prepare`} className={className}>
       <PrinterIcon />
-      Print {label.toLowerCase()}
+      Prepare to print
     </Link>
   );
 }

--- a/src/features/print/ConductingPrepareTab.tsx
+++ b/src/features/print/ConductingPrepareTab.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useMeeting } from "@/hooks/useMeeting";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
+import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
+import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
+import type { LetterPageStyle } from "@/lib/types";
+import { writeMeetingProgram } from "./utils/writeMeetingProgram";
+
+interface Props {
+  date: string;
+  onUsingOverrideChange?: (using: boolean) => void;
+}
+
+const KEY = "conductingProgram";
+
+/** Conducting tab on /week/:date/prepare. WYSIWYG Lexical editor with
+ *  per-Sunday save under `meeting.programs.conducting`. Initial state
+ *  cascades: per-Sunday saved → ward template → built-in default. */
+export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const meeting = useMeeting(date);
+  const tpl = useProgramTemplate(KEY);
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [pageStyleDraft, setPageStyleDraft] = useState<LetterPageStyle | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const override = meeting.data?.programs?.conducting;
+  const initialJson =
+    override?.editorStateJson ?? tpl.data?.editorStateJson ?? defaultProgramTemplate(KEY);
+  const initialPageStyle = override?.pageStyle ?? tpl.data?.pageStyle ?? null;
+  const margins = override?.margins ?? tpl.data?.margins ?? DEFAULT_MARGINS[KEY];
+
+  useEffect(() => {
+    onUsingOverrideChange?.(Boolean(override));
+  }, [override, onUsingOverrideChange]);
+
+  const editorJson = draft ?? initialJson;
+  const activePageStyle = pageStyleDraft ?? initialPageStyle;
+  const jsonDirty = draft !== null && draft !== initialJson;
+  const styleDirty =
+    pageStyleDraft !== null && JSON.stringify(pageStyleDraft) !== JSON.stringify(initialPageStyle);
+  const dirty = jsonDirty || styleDirty;
+
+  async function save() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMeetingProgram(wardId, date, KEY, draft ?? initialJson, margins, activePageStyle);
+      setDraft(null);
+      setPageStyleDraft(null);
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setDraft(null);
+    setPageStyleDraft(null);
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="flex-1 min-h-0 pb-16">
+        <ProgramPageEditor
+          key={`conducting-${editorKey}`}
+          variant={KEY}
+          initialJson={editorJson}
+          pageStyle={activePageStyle}
+          onChange={setDraft}
+          onPageStyleChange={setPageStyleDraft}
+          ariaLabel="Conducting copy"
+        />
+      </div>
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </>
+  );
+}

--- a/src/features/print/ConductingProgram.tsx
+++ b/src/features/print/ConductingProgram.tsx
@@ -1,15 +1,13 @@
-import { useParams, Navigate, Link } from "react-router";
+import { useParams, Navigate } from "react-router";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
-import { checkMeetingReadiness, type ReadinessReport } from "@/features/meetings/utils/readiness";
+import { checkMeetingReadiness } from "@/features/meetings/utils/readiness";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import { ConductingProgramBody } from "./ConductingProgramBody";
+import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
-import { buildMeetingVariables } from "./utils/buildMeetingVariables";
-import { LegacyConductingCopy } from "./LegacyConductingCopy";
-import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -30,86 +28,29 @@ export function ConductingProgram() {
   const meetingType = m?.meetingType ?? defaultMeetingType(date, nonMeeting);
   const report = checkMeetingReadiness(m, speakers.data, meetingType);
 
-  if (ready && !report.ready) return <NotReady date={date} report={report} />;
-
-  const wardName = ward.data?.name ?? "our ward";
-  const dateLong = formatLongDate(date);
-
-  const header = (
-    <header className="mb-3 border-b-2 border-walnut pb-2">
-      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
-        Conductor's copy · {wardName}
-      </div>
-      <h1 className="font-display text-[22px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
-        {dateLong}
-      </h1>
-    </header>
-  );
-
-  // Template-driven rendering closes the loop between the WYSIWYG
-  // editor and the printed output. Falls back to the hardcoded
-  // layout for wards that haven't customized yet.
-  if (template.data?.editorStateJson) {
-    const variables = buildMeetingVariables({
-      date,
-      meeting: m ?? null,
-      speakers: speakers.data,
-      ward: ward.data ?? null,
-    });
+  if (ready && !report.ready) {
     return (
-      <PrintLayout ready={ready && report.ready} dense>
-        {header}
-        {renderProgramState(template.data.editorStateJson, variables)}
-      </PrintLayout>
+      <div className="min-h-screen grid place-items-center bg-parchment p-8">
+        <NotReadyBlock date={date} report={report} />
+      </div>
     );
   }
 
-  const speakerList = orderedSpeakers(speakers.data);
-  const sequence = speakerSequence(speakerList, m?.mid);
-  const visitors = (m?.visitors ?? []).filter((v) => v.name.trim().length > 0);
+  // Per-Sunday override (saved from /week/:date/prepare) takes
+  // precedence over the ward-level template — the bishopric tailored
+  // this Sunday's program for this meeting.
+  const override = m?.programs?.conducting;
+  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
 
   return (
     <PrintLayout ready={ready && report.ready} dense>
-      {header}
-      <LegacyConductingCopy
-        m={m ?? null}
-        wardName={wardName}
-        dateLong={dateLong}
-        speakerList={speakerList}
-        sequence={sequence}
-        visitors={visitors}
+      <ConductingProgramBody
+        date={date}
+        meeting={m ?? null}
+        speakers={speakers.data}
+        ward={ward.data ?? null}
+        templateJson={templateJson}
       />
     </PrintLayout>
-  );
-}
-
-function NotReady({ date, report }: { date: string; report: ReadinessReport }) {
-  const remaining = report.missing.length + report.unconfirmed.length;
-  return (
-    <div className="min-h-screen grid place-items-center bg-parchment p-8 text-center">
-      <div className="max-w-lg">
-        <p className="font-display text-[20px] text-walnut mb-2">Not ready to print</p>
-        <p className="font-serif italic text-[13.5px] text-walnut-2 mb-4">
-          The program for <strong>{formatLongDate(date)}</strong> still has {remaining} item
-          {remaining === 1 ? "" : "s"} to fill before it's ready.
-        </p>
-        <ul className="text-left inline-block list-disc text-[13.5px] text-walnut-2 mb-4 max-h-60 overflow-y-auto">
-          {report.missing.map((m) => (
-            <li key={`m-${m}`}>{m}</li>
-          ))}
-          {report.unconfirmed.map((u) => (
-            <li key={`u-${u}`}>{u}</li>
-          ))}
-        </ul>
-        <div>
-          <Link
-            to={`/week/${date}`}
-            className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep transition-colors"
-          >
-            Back to the program
-          </Link>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/src/features/print/ConductingProgramBody.tsx
+++ b/src/features/print/ConductingProgramBody.tsx
@@ -1,0 +1,62 @@
+import type { WithId } from "@/hooks/_sub";
+import type { SacramentMeeting, Speaker, Ward } from "@/lib/types";
+import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
+import { LegacyConductingCopy } from "./LegacyConductingCopy";
+import { buildMeetingVariables } from "./utils/buildMeetingVariables";
+import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
+
+interface Props {
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: readonly WithId<Speaker>[];
+  ward: Ward | null;
+  templateJson: string | null;
+}
+
+/** Pure rendering of the conducting copy: header + (template path |
+ *  legacy fallback). No data loading, no readiness gate, no print
+ *  trigger. Both the print route and the on-screen prepare-to-print
+ *  preview render through this. */
+export function ConductingProgramBody({ date, meeting, speakers, ward, templateJson }: Props) {
+  const wardName = ward?.name ?? "our ward";
+  const dateLong = formatLongDate(date);
+
+  const header = (
+    <header className="mb-3 border-b-2 border-walnut pb-2">
+      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        Conductor's copy · {wardName}
+      </div>
+      <h1 className="font-display text-[22px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
+        {dateLong}
+      </h1>
+    </header>
+  );
+
+  if (templateJson) {
+    const variables = buildMeetingVariables({ date, meeting, speakers, ward });
+    return (
+      <>
+        {header}
+        {renderProgramState(templateJson, variables)}
+      </>
+    );
+  }
+
+  const speakerList = orderedSpeakers(speakers);
+  const sequence = speakerSequence(speakerList, meeting?.mid);
+  const visitors = (meeting?.visitors ?? []).filter((v) => v.name.trim().length > 0);
+
+  return (
+    <>
+      {header}
+      <LegacyConductingCopy
+        m={meeting}
+        wardName={wardName}
+        dateLong={dateLong}
+        speakerList={speakerList}
+        sequence={sequence}
+        visitors={visitors}
+      />
+    </>
+  );
+}

--- a/src/features/print/CongregationCoverForm.tsx
+++ b/src/features/print/CongregationCoverForm.tsx
@@ -1,0 +1,74 @@
+import { DEFAULT_PROGRAM_FOOTER_NOTE } from "./utils/programFooter";
+
+interface Props {
+  imageUrl: string;
+  announcements: string;
+  footerNote: string;
+  onImageChange: (next: string) => void;
+  onAnnouncementsChange: (next: string) => void;
+  onFooterNoteChange: (next: string) => void;
+}
+
+/** Inline form for the editable bits of the congregation prepare
+ *  page — rendered above the live preview. Cover image + announcements
+ *  populate the left panel; footer note prints at the bottom of the
+ *  right (program) panel. */
+export function CongregationCoverForm({
+  imageUrl,
+  announcements,
+  footerNote,
+  onImageChange,
+  onAnnouncementsChange,
+  onFooterNoteChange,
+}: Props) {
+  return (
+    <div className="mx-auto max-w-[11in] grid gap-4 mb-1 rounded-md border border-border bg-chalk px-4 py-3 sm:grid-cols-2">
+      <Field label="Cover image URL">
+        <input
+          type="url"
+          value={imageUrl}
+          onChange={(e) => onImageChange(e.target.value)}
+          placeholder="https://… (optional)"
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+      <Field label="Announcements">
+        <textarea
+          value={announcements}
+          onChange={(e) => onAnnouncementsChange(e.target.value)}
+          rows={3}
+          placeholder="One announcement per line."
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 resize-y focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+      <Field label="Program footer note" className="sm:col-span-2">
+        <input
+          type="text"
+          value={footerNote}
+          onChange={(e) => onFooterNoteChange(e.target.value)}
+          placeholder={DEFAULT_PROGRAM_FOOTER_NOTE}
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className={`flex flex-col gap-1 ${className ?? ""}`}>
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/src/features/print/CongregationCoverPanel.tsx
+++ b/src/features/print/CongregationCoverPanel.tsx
@@ -1,0 +1,65 @@
+interface Props {
+  wardName: string;
+  dateLong: string;
+  announcements: string;
+  imageUrl: string | null;
+}
+
+/** Left half of the printed congregation bulletin. Pairs with
+ *  `LegacyCongregationCopy` (the program panel on the right). The
+ *  bulletin folds down the middle — this panel becomes the cover
+ *  when folded. Uses a vertical flex column so the image expands to
+ *  fill the page height, anchoring the header at the top and
+ *  announcements at the bottom. Requires the parent grid item to
+ *  have an explicit height (set in the print route + prepare page). */
+export function CongregationCoverPanel({ wardName, dateLong, announcements, imageUrl }: Props) {
+  const trimmed = announcements.trim();
+  return (
+    <div className="flex flex-col h-full">
+      <header className="text-center mb-4 shrink-0">
+        <p className="font-mono text-[9.5px] uppercase tracking-[0.18em] text-walnut-3 m-0">
+          The Church of Jesus Christ of Latter-day Saints
+        </p>
+        <h2 className="font-display text-[24px] font-semibold text-walnut tracking-[-0.01em] m-0 mt-1">
+          {wardName}
+        </h2>
+        <p className="font-serif italic text-[12px] text-walnut-3 m-0 mt-1">{dateLong}</p>
+      </header>
+
+      <CoverImage imageUrl={imageUrl} />
+
+      <section className="mt-4 shrink-0">
+        <h3 className="font-display text-[13px] font-semibold text-walnut border-b border-brass-soft pb-1 mb-2">
+          Announcements
+        </h3>
+        {trimmed.length > 0 ? (
+          <p className="font-serif text-[12.5px] text-walnut-2 whitespace-pre-wrap leading-relaxed m-0">
+            {trimmed}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <span className="print-blank block w-full" />
+            <span className="print-blank block w-full" />
+            <span className="print-blank block w-full" />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function CoverImage({ imageUrl }: { imageUrl: string | null }) {
+  if (imageUrl) {
+    return (
+      <div className="flex-1 min-h-0 flex items-center justify-center my-3">
+        {/* biome-ignore lint/performance/noImgElement: print output, not Next.js */}
+        <img src={imageUrl} alt="" className="max-w-full max-h-full object-contain" />
+      </div>
+    );
+  }
+  return (
+    <div className="flex-1 min-h-0 grid place-items-center my-3 border border-dashed border-walnut-3/40 rounded-md bg-parchment-2/30 print:bg-transparent">
+      <span className="font-serif italic text-[12px] text-walnut-3">Image (optional)</span>
+    </div>
+  );
+}

--- a/src/features/print/CongregationPrepareTab.tsx
+++ b/src/features/print/CongregationPrepareTab.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
+import { CongregationCoverForm } from "./CongregationCoverForm";
+import { CongregationCoverPanel } from "./CongregationCoverPanel";
+import { CongregationProgramBody } from "./CongregationProgramBody";
+import { formatLongDate } from "./utils/programData";
+import { DEFAULT_PROGRAM_FOOTER_NOTE } from "./utils/programFooter";
+import { writeMeetingCover } from "./utils/writeMeetingCover";
+
+interface Props {
+  date: string;
+}
+
+/** Congregation tab on /week/:date/prepare. Live preview of what
+ *  prints — cover panel on the left, program panel on the right —
+ *  with two inline form controls for the editable bits: cover image
+ *  URL and announcements. Everything else (presiding, hymns, etc.)
+ *  is auto-populated from the meeting doc and edited back in
+ *  /week/:date. */
+export function CongregationPrepareTab({ date }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const ward = useWardSettings();
+  const meeting = useMeeting(date);
+  const speakers = useSpeakers(date);
+  const template = useProgramTemplate("congregationProgram");
+
+  const [imageDraft, setImageDraft] = useState<string | null>(null);
+  const [announceDraft, setAnnounceDraft] = useState<string | null>(null);
+  const [footerDraft, setFooterDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const initialImage = meeting.data?.coverImageUrl ?? "";
+  const initialAnnounce = meeting.data?.announcements ?? "";
+  // Pre-fill with the built-in default when nothing's saved — gives
+  // the bishop concrete text to tweak instead of an empty box. The
+  // form stays "clean" (dirty stays false) until they actually edit.
+  const initialFooter = meeting.data?.programFooterNote ?? DEFAULT_PROGRAM_FOOTER_NOTE;
+  const imageUrl = imageDraft ?? initialImage;
+  const announcements = announceDraft ?? initialAnnounce;
+  const footerNote = footerDraft ?? initialFooter;
+  const dirty = imageDraft !== null || announceDraft !== null || footerDraft !== null;
+
+  const wardName = ward.data?.name ?? "Ward";
+  const dateLong = formatLongDate(date);
+  const override = meeting.data?.programs?.congregation;
+  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
+
+  async function save() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMeetingCover(wardId, date, {
+        coverImageUrl: imageUrl.trim().length > 0 ? imageUrl.trim() : null,
+        announcements,
+        programFooterNote: footerNote.trim().length > 0 ? footerNote.trim() : null,
+      });
+      setImageDraft(null);
+      setAnnounceDraft(null);
+      setFooterDraft(null);
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setImageDraft(null);
+    setAnnounceDraft(null);
+    setFooterDraft(null);
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="flex-1 min-h-0 overflow-auto bg-parchment py-6 px-4 sm:px-8 pb-24">
+        <CongregationCoverForm
+          imageUrl={imageUrl}
+          announcements={announcements}
+          footerNote={footerNote}
+          onImageChange={(v) => setImageDraft(v)}
+          onAnnouncementsChange={(v) => setAnnounceDraft(v)}
+          onFooterNoteChange={(v) => setFooterDraft(v)}
+        />
+
+        {/* Page sheet — letter landscape (11" × 8.5") at print scale.
+            What you see here is what the printer puts on the paper. */}
+        <div
+          className="mx-auto mt-6 bg-chalk shadow-[0_4px_24px_rgba(35,24,21,0.08)] border border-border rounded-sm"
+          style={{ width: "11in", height: "8.5in" }}
+        >
+          <div className="relative grid grid-cols-2 h-full">
+            <div className="px-[0.35in] py-[0.35in]">
+              <CongregationCoverPanel
+                wardName={wardName}
+                dateLong={dateLong}
+                announcements={announcements}
+                imageUrl={imageUrl.trim().length > 0 ? imageUrl.trim() : null}
+              />
+            </div>
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 left-1/2 border-l border-dashed border-walnut-3"
+            />
+            <div className="px-[0.35in] py-[0.35in]">
+              <CongregationProgramBody
+                date={date}
+                meeting={meeting.data ?? null}
+                speakers={speakers.data}
+                ward={ward.data ?? null}
+                templateJson={templateJson}
+                footerNoteOverride={footerNote}
+              />
+            </div>
+          </div>
+        </div>
+        <p className="mt-2 mb-3 text-center font-serif italic text-[11px] text-walnut-3">
+          Letter, landscape · 11" × 8.5" · fold down the middle — cover on the left, program on the
+          right.
+        </p>
+      </div>
+
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </>
+  );
+}

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -1,15 +1,13 @@
-import { useParams, Navigate, Link } from "react-router";
+import { useParams, Navigate } from "react-router";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
-import { checkMeetingReadiness, type ReadinessReport } from "@/features/meetings/utils/readiness";
+import { checkMeetingReadiness } from "@/features/meetings/utils/readiness";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import { CongregationProgramBody } from "./CongregationProgramBody";
+import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
-import { buildMeetingVariables } from "./utils/buildMeetingVariables";
-import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
-import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -30,36 +28,26 @@ export function CongregationProgram() {
   const meetingType = m?.meetingType ?? defaultMeetingType(date, nonMeeting);
   const report = checkMeetingReadiness(m, speakers.data, meetingType);
 
-  if (ready && !report.ready) return <NotReady date={date} report={report} />;
+  if (ready && !report.ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-parchment p-8">
+        <NotReadyBlock date={date} report={report} />
+      </div>
+    );
+  }
 
-  const speakerList = orderedSpeakers(speakers.data);
-  const sequence = speakerSequence(speakerList, m?.mid);
-  const visitors = (m?.visitors ?? []).filter((v) => v.name.trim().length > 0);
-  const wardName = ward.data?.name ?? "Ward";
-  const dateLong = formatLongDate(date);
-  const visitorText = visitors
-    .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
-    .join(", ");
+  // Per-Sunday override (saved from /week/:date/prepare) takes
+  // precedence over the ward-level template.
+  const override = m?.programs?.congregation;
+  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
 
-  const copy = template.data?.editorStateJson ? (
-    <TemplateCopy
-      wardName={wardName}
-      dateLong={dateLong}
-      json={template.data.editorStateJson}
-      variables={buildMeetingVariables({
-        date,
-        meeting: m ?? null,
-        speakers: speakers.data,
-        ward: ward.data ?? null,
-      })}
-    />
-  ) : (
-    <LegacyCongregationCopy
-      m={m ?? null}
-      wardName={wardName}
-      dateLong={dateLong}
-      sequence={sequence}
-      visitorText={visitorText}
+  const copy = (
+    <CongregationProgramBody
+      date={date}
+      meeting={m ?? null}
+      speakers={speakers.data}
+      ward={ward.data ?? null}
+      templateJson={templateJson}
     />
   );
 
@@ -77,62 +65,5 @@ export function CongregationProgram() {
         Two copies per page — cut down the middle.
       </p>
     </PrintLayout>
-  );
-}
-
-function TemplateCopy({
-  wardName,
-  dateLong,
-  json,
-  variables,
-}: {
-  wardName: string;
-  dateLong: string;
-  json: string;
-  variables: Record<string, string>;
-}) {
-  return (
-    <>
-      <header className="mb-3 border-b-2 border-walnut pb-2">
-        <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
-          Sacrament meeting · {wardName}
-        </div>
-        <h1 className="font-display text-[17px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
-          {dateLong}
-        </h1>
-      </header>
-      {renderProgramState(json, variables)}
-    </>
-  );
-}
-
-function NotReady({ date, report }: { date: string; report: ReadinessReport }) {
-  const remaining = report.missing.length + report.unconfirmed.length;
-  return (
-    <div className="min-h-screen grid place-items-center bg-parchment p-8 text-center">
-      <div className="max-w-lg">
-        <p className="font-display text-[20px] text-walnut mb-2">Not ready to print</p>
-        <p className="font-serif italic text-[13.5px] text-walnut-2 mb-4">
-          The program for <strong>{formatLongDate(date)}</strong> still has {remaining} item
-          {remaining === 1 ? "" : "s"} to fill before it's ready.
-        </p>
-        <ul className="text-left inline-block list-disc text-[13.5px] text-walnut-2 mb-4 max-h-60 overflow-y-auto">
-          {report.missing.map((m) => (
-            <li key={`m-${m}`}>{m}</li>
-          ))}
-          {report.unconfirmed.map((u) => (
-            <li key={`u-${u}`}>{u}</li>
-          ))}
-        </ul>
-        <div>
-          <Link
-            to={`/week/${date}`}
-            className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep transition-colors"
-          >
-            Back to the program
-          </Link>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -10,6 +10,7 @@ import { CongregationProgramBody } from "./CongregationProgramBody";
 import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
 import { formatLongDate } from "./utils/programData";
+import { resolveCoverImageUrl } from "./utils/programFooter";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -44,6 +45,10 @@ export function CongregationProgram() {
   const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
   const wardName = ward.data?.name ?? "Ward";
   const dateLong = formatLongDate(date);
+  const coverImageUrl = resolveCoverImageUrl(
+    m?.coverImageUrl,
+    ward.data?.congregationDefaults?.coverImageUrl,
+  );
 
   return (
     <PrintLayout ready={ready && report.ready} dense landscape>
@@ -53,7 +58,7 @@ export function CongregationProgram() {
             wardName={wardName}
             dateLong={dateLong}
             announcements={m?.announcements ?? ""}
-            imageUrl={m?.coverImageUrl ?? null}
+            imageUrl={coverImageUrl}
           />
         </div>
         <div

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -5,9 +5,11 @@ import { useAuthStore } from "@/stores/authStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
 import { checkMeetingReadiness } from "@/features/meetings/utils/readiness";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import { CongregationCoverPanel } from "./CongregationCoverPanel";
 import { CongregationProgramBody } from "./CongregationProgramBody";
 import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
+import { formatLongDate } from "./utils/programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -40,29 +42,36 @@ export function CongregationProgram() {
   // precedence over the ward-level template.
   const override = m?.programs?.congregation;
   const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
-
-  const copy = (
-    <CongregationProgramBody
-      date={date}
-      meeting={m ?? null}
-      speakers={speakers.data}
-      ward={ward.data ?? null}
-      templateJson={templateJson}
-    />
-  );
+  const wardName = ward.data?.name ?? "Ward";
+  const dateLong = formatLongDate(date);
 
   return (
     <PrintLayout ready={ready && report.ready} dense landscape>
-      <div className="relative grid grid-cols-2 print:-mx-2">
-        <div className="px-[0.35in]">{copy}</div>
+      <div className="relative grid grid-cols-2 print:h-screen">
+        <div className="px-[0.35in] py-[0.1in]">
+          <CongregationCoverPanel
+            wardName={wardName}
+            dateLong={dateLong}
+            announcements={m?.announcements ?? ""}
+            imageUrl={m?.coverImageUrl ?? null}
+          />
+        </div>
         <div
           aria-hidden
           className="pointer-events-none absolute inset-y-0 left-1/2 border-l border-dashed border-walnut-3"
         />
-        <div className="px-[0.35in]">{copy}</div>
+        <div className="px-[0.35in] py-[0.1in]">
+          <CongregationProgramBody
+            date={date}
+            meeting={m ?? null}
+            speakers={speakers.data}
+            ward={ward.data ?? null}
+            templateJson={templateJson}
+          />
+        </div>
       </div>
       <p className="mt-4 text-center font-serif italic text-[11px] text-walnut-3 print-hidden">
-        Two copies per page — cut down the middle.
+        Fold down the middle — cover on the left, program on the right.
       </p>
     </PrintLayout>
   );

--- a/src/features/print/CongregationProgramBody.tsx
+++ b/src/features/print/CongregationProgramBody.tsx
@@ -1,0 +1,62 @@
+import type { WithId } from "@/hooks/_sub";
+import type { SacramentMeeting, Speaker, Ward } from "@/lib/types";
+import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
+import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
+import { buildMeetingVariables } from "./utils/buildMeetingVariables";
+import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
+
+interface Props {
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: readonly WithId<Speaker>[];
+  ward: Ward | null;
+  templateJson: string | null;
+}
+
+/** Pure rendering of one congregation copy (with its own header). The
+ *  print route emits this twice in a two-column landscape grid; the
+ *  prepare-to-print preview emits it once. */
+export function CongregationProgramBody({ date, meeting, speakers, ward, templateJson }: Props) {
+  const wardName = ward?.name ?? "Ward";
+  const dateLong = formatLongDate(date);
+
+  if (templateJson) {
+    const variables = buildMeetingVariables({ date, meeting, speakers, ward });
+    return (
+      <>
+        <CopyHeader wardName={wardName} dateLong={dateLong} />
+        {renderProgramState(templateJson, variables)}
+      </>
+    );
+  }
+
+  const speakerList = orderedSpeakers(speakers);
+  const sequence = speakerSequence(speakerList, meeting?.mid);
+  const visitors = (meeting?.visitors ?? []).filter((v) => v.name.trim().length > 0);
+  const visitorText = visitors
+    .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
+    .join(", ");
+
+  return (
+    <LegacyCongregationCopy
+      m={meeting}
+      wardName={wardName}
+      dateLong={dateLong}
+      sequence={sequence}
+      visitorText={visitorText}
+    />
+  );
+}
+
+function CopyHeader({ wardName, dateLong }: { wardName: string; dateLong: string }) {
+  return (
+    <header className="mb-3 border-b-2 border-walnut pb-2">
+      <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
+        Sacrament meeting · {wardName}
+      </div>
+      <h1 className="font-display text-[17px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
+        {dateLong}
+      </h1>
+    </header>
+  );
+}

--- a/src/features/print/CongregationProgramBody.tsx
+++ b/src/features/print/CongregationProgramBody.tsx
@@ -4,6 +4,7 @@ import { renderProgramState } from "@/features/program-templates/utils/programTe
 import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
 import { buildMeetingVariables } from "./utils/buildMeetingVariables";
 import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
+import { resolveProgramFooterNote } from "./utils/programFooter";
 
 interface Props {
   date: string;
@@ -11,32 +12,68 @@ interface Props {
   speakers: readonly WithId<Speaker>[];
   ward: Ward | null;
   templateJson: string | null;
+  /** Per-meeting override for the program footer note. Undefined →
+   *  default ("Quietly ponder…"); empty string → hide. The
+   *  congregation prepare tab passes a draft value here so the
+   *  preview updates live as the user types. */
+  footerNoteOverride?: string | undefined;
 }
 
 /** Pure rendering of one congregation copy (with its own header). The
  *  print route emits this twice in a two-column landscape grid; the
  *  prepare-to-print preview emits it once. */
-export function CongregationProgramBody({ date, meeting, speakers, ward, templateJson }: Props) {
+export function CongregationProgramBody({
+  date,
+  meeting,
+  speakers,
+  ward,
+  templateJson,
+  footerNoteOverride,
+}: Props) {
   const wardName = ward?.name ?? "Ward";
   const dateLong = formatLongDate(date);
+  const footerSource =
+    footerNoteOverride !== undefined ? footerNoteOverride : meeting?.programFooterNote;
+  const footerNote = resolveProgramFooterNote(footerSource);
 
-  if (templateJson) {
-    const variables = buildMeetingVariables({ date, meeting, speakers, ward });
-    return (
-      <>
-        <CopyHeader wardName={wardName} dateLong={dateLong} />
-        {renderProgramState(templateJson, variables)}
-      </>
-    );
-  }
+  const body = templateJson ? (
+    <>
+      <CopyHeader wardName={wardName} dateLong={dateLong} />
+      {renderProgramState(templateJson, buildMeetingVariables({ date, meeting, speakers, ward }))}
+    </>
+  ) : (
+    <LegacyBody meeting={meeting} wardName={wardName} dateLong={dateLong} speakers={speakers} />
+  );
 
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 min-h-0">{body}</div>
+      {footerNote && (
+        <p className="mt-3 pt-2 border-t border-brass-soft font-serif italic text-[12px] text-walnut-2 text-center m-0 shrink-0">
+          {footerNote}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LegacyBody({
+  meeting,
+  wardName,
+  dateLong,
+  speakers,
+}: {
+  meeting: SacramentMeeting | null;
+  wardName: string;
+  dateLong: string;
+  speakers: readonly WithId<Speaker>[];
+}) {
   const speakerList = orderedSpeakers(speakers);
   const sequence = speakerSequence(speakerList, meeting?.mid);
   const visitors = (meeting?.visitors ?? []).filter((v) => v.name.trim().length > 0);
   const visitorText = visitors
     .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
     .join(", ");
-
   return (
     <LegacyCongregationCopy
       m={meeting}
@@ -50,7 +87,7 @@ export function CongregationProgramBody({ date, meeting, speakers, ward, templat
 
 function CopyHeader({ wardName, dateLong }: { wardName: string; dateLong: string }) {
   return (
-    <header className="mb-3 border-b-2 border-walnut pb-2">
+    <header className="mb-6 border-b-2 border-walnut pb-2">
       <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
         Sacrament meeting · {wardName}
       </div>

--- a/src/features/print/CongregationProgramBody.tsx
+++ b/src/features/print/CongregationProgramBody.tsx
@@ -13,9 +13,9 @@ interface Props {
   ward: Ward | null;
   templateJson: string | null;
   /** Per-meeting override for the program footer note. Undefined →
-   *  default ("Quietly ponder…"); empty string → hide. The
-   *  congregation prepare tab passes a draft value here so the
-   *  preview updates live as the user types. */
+   *  fall through to ward default → built-in default; empty string
+   *  → hide. The congregation prepare tab passes a draft value here
+   *  so the preview updates live as the user types. */
   footerNoteOverride?: string | undefined;
 }
 
@@ -32,9 +32,12 @@ export function CongregationProgramBody({
 }: Props) {
   const wardName = ward?.name ?? "Ward";
   const dateLong = formatLongDate(date);
-  const footerSource =
+  const meetingFooterSource =
     footerNoteOverride !== undefined ? footerNoteOverride : meeting?.programFooterNote;
-  const footerNote = resolveProgramFooterNote(footerSource);
+  const footerNote = resolveProgramFooterNote(
+    meetingFooterSource,
+    ward?.congregationDefaults?.programFooterNote,
+  );
 
   const body = templateJson ? (
     <>

--- a/src/features/print/CongregationTemplateForm.tsx
+++ b/src/features/print/CongregationTemplateForm.tsx
@@ -1,0 +1,53 @@
+import { DEFAULT_PROGRAM_FOOTER_NOTE } from "./utils/programFooter";
+
+interface Props {
+  imageUrl: string;
+  footerNote: string;
+  onImageChange: (next: string) => void;
+  onFooterNoteChange: (next: string) => void;
+}
+
+/** Two-field form for the congregation-copy template editor: cover
+ *  image URL and program footer note. Announcements are intentionally
+ *  excluded — those are per-meeting content, edited on the prepare
+ *  page. */
+export function CongregationTemplateForm({
+  imageUrl,
+  footerNote,
+  onImageChange,
+  onFooterNoteChange,
+}: Props) {
+  return (
+    <div className="mx-auto max-w-[11in] grid gap-4 mb-1 rounded-md border border-border bg-chalk px-4 py-3 sm:grid-cols-2">
+      <Field label="Default cover image URL">
+        <input
+          type="url"
+          value={imageUrl}
+          onChange={(e) => onImageChange(e.target.value)}
+          placeholder="https://… (optional)"
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+      <Field label="Default program footer note">
+        <input
+          type="text"
+          value={footerNote}
+          onChange={(e) => onFooterNoteChange(e.target.value)}
+          placeholder={DEFAULT_PROGRAM_FOOTER_NOTE}
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/src/features/print/CongregationTemplateTab.tsx
+++ b/src/features/print/CongregationTemplateTab.tsx
@@ -1,76 +1,56 @@
 import { useState } from "react";
 import { SaveBar } from "@/components/ui/SaveBar";
-import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
-import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { CongregationCoverForm } from "./CongregationCoverForm";
 import { CongregationCoverPanel } from "./CongregationCoverPanel";
 import { CongregationProgramBody } from "./CongregationProgramBody";
+import { CongregationTemplateForm } from "./CongregationTemplateForm";
 import { formatLongDate } from "./utils/programData";
 import { DEFAULT_PROGRAM_FOOTER_NOTE, resolveCoverImageUrl } from "./utils/programFooter";
-import { writeMeetingCover } from "./utils/writeMeetingCover";
+import { writeWardCongregationDefaults } from "./utils/writeWardCongregationDefaults";
 
-interface Props {
-  date: string;
-}
-
-/** Congregation tab on /week/:date/prepare. Live preview of what
- *  prints — cover panel on the left, program panel on the right —
- *  with two inline form controls for the editable bits: cover image
- *  URL and announcements. Everything else (presiding, hymns, etc.)
- *  is auto-populated from the meeting doc and edited back in
- *  /week/:date. */
-export function CongregationPrepareTab({ date }: Props) {
+/** Congregation-copy template editor on /settings/templates/programs.
+ *  Mirrors the per-Sunday prepare-page UX (form + bulletin preview)
+ *  but writes ward-level defaults — image URL and footer note — that
+ *  drive every Sunday's print unless the bishop overrides them on the
+ *  prepare page. Announcements are intentionally not editable here:
+ *  they're per-week content, not a template concept. */
+export function CongregationTemplateTab() {
   const wardId = useCurrentWardStore((s) => s.wardId);
   const ward = useWardSettings();
-  const meeting = useMeeting(date);
-  const speakers = useSpeakers(date);
-  const template = useProgramTemplate("congregationProgram");
 
   const [imageDraft, setImageDraft] = useState<string | null>(null);
-  const [announceDraft, setAnnounceDraft] = useState<string | null>(null);
   const [footerDraft, setFooterDraft] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
-  // The image input shows the meeting's own override, NOT the ward
-  // default — typing here saves a meeting-level override; clearing
-  // reveals the ward default in the preview again. Same idea for the
-  // footer, with a built-in default behind both for first-time wards.
   const wardDefaults = ward.data?.congregationDefaults;
-  const initialImage = meeting.data?.coverImageUrl ?? "";
-  const initialAnnounce = meeting.data?.announcements ?? "";
-  const initialFooter =
-    meeting.data?.programFooterNote ??
-    wardDefaults?.programFooterNote ??
-    DEFAULT_PROGRAM_FOOTER_NOTE;
+  const initialImage = wardDefaults?.coverImageUrl ?? "";
+  const initialFooter = wardDefaults?.programFooterNote ?? DEFAULT_PROGRAM_FOOTER_NOTE;
   const imageUrl = imageDraft ?? initialImage;
-  const announcements = announceDraft ?? initialAnnounce;
   const footerNote = footerDraft ?? initialFooter;
-  const dirty = imageDraft !== null || announceDraft !== null || footerDraft !== null;
-  // Preview cascades meeting → ward → none (matches print render).
-  const previewImageUrl = resolveCoverImageUrl(imageUrl, wardDefaults?.coverImageUrl);
+  const dirty = imageDraft !== null || footerDraft !== null;
 
   const wardName = ward.data?.name ?? "Ward";
-  const dateLong = formatLongDate(date);
-  const override = meeting.data?.programs?.congregation;
-  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
+  // Preview uses today's date as a stand-in. The actual print resolves
+  // to the meeting date, but visually this lets the bishop see how a
+  // typical bulletin looks against their template.
+  const sampleDate = new Date().toISOString().slice(0, 10);
+  const dateLong = formatLongDate(sampleDate);
+  const previewImageUrl = resolveCoverImageUrl(imageUrl, null);
 
   async function save() {
     if (!wardId) return;
     setSaving(true);
     setError(null);
     try {
-      await writeMeetingCover(wardId, date, {
+      await writeWardCongregationDefaults(wardId, {
         coverImageUrl: imageUrl.trim().length > 0 ? imageUrl.trim() : null,
-        announcements,
         programFooterNote: footerNote.trim().length > 0 ? footerNote.trim() : null,
       });
       setImageDraft(null);
-      setAnnounceDraft(null);
       setFooterDraft(null);
       setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
     } catch (e) {
@@ -82,7 +62,6 @@ export function CongregationPrepareTab({ date }: Props) {
 
   function discard() {
     setImageDraft(null);
-    setAnnounceDraft(null);
     setFooterDraft(null);
     setError(null);
   }
@@ -90,17 +69,17 @@ export function CongregationPrepareTab({ date }: Props) {
   return (
     <>
       <div className="flex-1 min-h-0 overflow-auto bg-parchment py-6 px-4 sm:px-8 pb-24">
-        <CongregationCoverForm
+        <CongregationTemplateForm
           imageUrl={imageUrl}
-          announcements={announcements}
           footerNote={footerNote}
-          onImageChange={(v) => setImageDraft(v)}
-          onAnnouncementsChange={(v) => setAnnounceDraft(v)}
-          onFooterNoteChange={(v) => setFooterDraft(v)}
+          onImageChange={setImageDraft}
+          onFooterNoteChange={setFooterDraft}
         />
 
-        {/* Page sheet — letter landscape (11" × 8.5") at print scale.
-            What you see here is what the printer puts on the paper. */}
+        {/* Letter-landscape sheet at print scale — same dimensions and
+            structure as /print/:date/congregation. Empty meeting fields
+            render as blank lines so the bishop sees where each piece
+            lands on the printed bulletin. */}
         <div
           className="mx-auto mt-6 bg-chalk shadow-[0_4px_24px_rgba(35,24,21,0.08)] border border-border rounded-sm"
           style={{ width: "11in", height: "8.5in" }}
@@ -110,7 +89,7 @@ export function CongregationPrepareTab({ date }: Props) {
               <CongregationCoverPanel
                 wardName={wardName}
                 dateLong={dateLong}
-                announcements={announcements}
+                announcements=""
                 imageUrl={previewImageUrl}
               />
             </div>
@@ -120,19 +99,19 @@ export function CongregationPrepareTab({ date }: Props) {
             />
             <div className="px-[0.35in] py-[0.35in]">
               <CongregationProgramBody
-                date={date}
-                meeting={meeting.data ?? null}
-                speakers={speakers.data}
+                date={sampleDate}
+                meeting={null}
+                speakers={[]}
                 ward={ward.data ?? null}
-                templateJson={templateJson}
+                templateJson={null}
                 footerNoteOverride={footerNote}
               />
             </div>
           </div>
         </div>
         <p className="mt-2 mb-3 text-center font-serif italic text-[11px] text-walnut-3">
-          Letter, landscape · 11" × 8.5" · fold down the middle — cover on the left, program on the
-          right.
+          Letter, landscape · 11" × 8.5" · ward defaults apply when a meeting hasn't been customised
+          on the prepare page.
         </p>
       </div>
 

--- a/src/features/print/LegacyCongregationCopy.tsx
+++ b/src/features/print/LegacyCongregationCopy.tsx
@@ -1,6 +1,6 @@
 import type { SacramentMeeting } from "@/lib/types";
 import { personName, type SequenceEntry } from "./utils/programData";
-import { RowFreeform, RowHymn, RowLabeled, RowSection } from "./utils/programRows";
+import { RowHymn, RowLabeled, RowSection } from "./utils/programRows";
 
 interface Props {
   m: SacramentMeeting | null;
@@ -16,7 +16,7 @@ interface Props {
 export function LegacyCongregationCopy({ m, wardName, dateLong, sequence, visitorText }: Props) {
   return (
     <>
-      <header className="mb-3 border-b-2 border-walnut pb-2">
+      <header className="mb-6 border-b-2 border-walnut pb-2">
         <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
           Sacrament meeting · {wardName}
         </div>
@@ -30,12 +30,6 @@ export function LegacyCongregationCopy({ m, wardName, dateLong, sequence, visito
         <RowLabeled label="Conducting" value={personName(m?.conducting)} dense />
         {visitorText && <RowLabeled label="Visitors" value={visitorText} dense />}
       </RowSection>
-
-      {m?.showAnnouncements && (m?.announcements ?? "").trim().length > 0 && (
-        <RowSection title="Announcements" dense>
-          <RowFreeform label="Announcements" value={m.announcements} dense />
-        </RowSection>
-      )}
 
       <RowSection title="Music" dense>
         <RowLabeled label="Pianist" value={personName(m?.pianist)} dense />

--- a/src/features/print/NotReadyBlock.tsx
+++ b/src/features/print/NotReadyBlock.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@/lib/nav";
+import type { ReadinessReport } from "@/features/meetings/utils/readiness";
+import { formatLongDate } from "./utils/programData";
+
+interface Props {
+  date: string;
+  report: ReadinessReport;
+}
+
+/** Centred "not ready" card. Caller wraps in whatever container fits the
+ *  context (full-viewport for the print routes, AppShell content area
+ *  for the prepare page). */
+export function NotReadyBlock({ date, report }: Props) {
+  const remaining = report.missing.length + report.unconfirmed.length;
+  return (
+    <div className="max-w-lg mx-auto text-center">
+      <p className="font-display text-[20px] text-walnut mb-2">Not ready to print</p>
+      <p className="font-serif italic text-[13.5px] text-walnut-2 mb-4">
+        The program for <strong>{formatLongDate(date)}</strong> still has {remaining} item
+        {remaining === 1 ? "" : "s"} to fill before it's ready.
+      </p>
+      <ul className="text-left inline-block list-disc text-[13.5px] text-walnut-2 mb-4 max-h-60 overflow-y-auto">
+        {report.missing.map((m) => (
+          <li key={`m-${m}`}>{m}</li>
+        ))}
+        {report.unconfirmed.map((u) => (
+          <li key={`u-${u}`}>{u}</li>
+        ))}
+      </ul>
+      <div>
+        <Link
+          to={`/week/${date}`}
+          className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep transition-colors"
+        >
+          Back to the program
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/print/PreparePrintHeader.tsx
+++ b/src/features/print/PreparePrintHeader.tsx
@@ -29,12 +29,14 @@ export function PreparePrintHeader({ date, printSegment, usingOverride }: Props)
       </div>
       <div className="flex items-center gap-2">
         <StatusPill usingOverride={usingOverride} />
-        <Link
-          to={`/print/${date}/${printSegment}`}
+        <a
+          href={`/print/${date}/${printSegment}`}
+          target="_blank"
+          rel="noopener noreferrer"
           className="inline-flex items-center gap-1.5 font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
         >
           Print {printSegment}
-        </Link>
+        </a>
       </div>
     </header>
   );

--- a/src/features/print/PreparePrintHeader.tsx
+++ b/src/features/print/PreparePrintHeader.tsx
@@ -1,0 +1,51 @@
+import { Link } from "@/lib/nav";
+import { formatLongDate } from "./utils/programData";
+
+interface Props {
+  date: string;
+  printSegment: string;
+  usingOverride: boolean;
+}
+
+/** Top bar of /week/:date/prepare. Mirrors the chrome of the program-
+ *  templates editor: eyebrow back link, title, date, and a primary
+ *  "Print …" CTA whose label tracks the active tab. A small green
+ *  "Customised for this Sunday" pill appears once a per-Sunday
+ *  override has been saved — there's no chrome in the default state. */
+export function PreparePrintHeader({ date, printSegment, usingOverride }: Props) {
+  return (
+    <header className="shrink-0 border-b border-border bg-chalk px-5 sm:px-8 py-4 flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-1 min-w-0">
+        <Link
+          to={`/week/${date}`}
+          className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep hover:text-walnut"
+        >
+          ← Back to the program
+        </Link>
+        <h1 className="font-display text-[22px] sm:text-[26px] font-semibold text-walnut leading-tight">
+          Prepare to print
+        </h1>
+        <p className="font-serif italic text-[12.5px] text-walnut-2 m-0">{formatLongDate(date)}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusPill usingOverride={usingOverride} />
+        <Link
+          to={`/print/${date}/${printSegment}`}
+          className="inline-flex items-center gap-1.5 font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
+        >
+          Print {printSegment}
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function StatusPill({ usingOverride }: { usingOverride: boolean }) {
+  if (!usingOverride) return null;
+  return (
+    <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-success-soft bg-success/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-success">
+      <span aria-hidden>●</span>
+      Customised for this Sunday
+    </span>
+  );
+}

--- a/src/features/print/PreparePrintView.tsx
+++ b/src/features/print/PreparePrintView.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useMeeting } from "@/hooks/useMeeting";
+import { useAuthStore } from "@/stores/authStore";
+import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
+import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
+import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
+import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
+import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
+import { PreparePrintHeader } from "./PreparePrintHeader";
+import { writeMeetingProgram } from "./utils/writeMeetingProgram";
+
+interface Props {
+  date: string;
+}
+
+const TABS: { key: ProgramTemplateKey; label: string; printSegment: string }[] = [
+  { key: "conductingProgram", label: "Conducting copy", printSegment: "conducting" },
+  { key: "congregationProgram", label: "Congregation copy", printSegment: "congregation" },
+];
+
+/** /week/:date/prepare — per-Sunday program editor. Same WYSIWYG shell
+ *  as `/settings/templates/programs`, but writes land on the meeting
+ *  doc (under `programs.{conducting|congregation}`) so each Sunday
+ *  carries its own saved version. The print routes prefer this
+ *  override; if the bishopric never opens this page for a given week,
+ *  the ward-level template is used instead. */
+export function PreparePrintView({ date }: Props) {
+  useFullViewportLayout();
+  const isMobile = useIsMobile();
+  const authed = useAuthStore((s) => s.status === "signed_in");
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const meeting = useMeeting(date);
+  const conductingTpl = useProgramTemplate("conductingProgram");
+  const congregationTpl = useProgramTemplate("congregationProgram");
+
+  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
+  const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
+    conductingProgram: null,
+    congregationProgram: null,
+  });
+  const [pageStyleDraft, setPageStyleDraft] = useState<
+    Record<ProgramTemplateKey, LetterPageStyle | null>
+  >({ conductingProgram: null, congregationProgram: null });
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  // Re-mount Lexical when the active tab changes so it hydrates from
+  // the new tab's initial state.
+  useEffect(() => {
+    setEditorKey((k) => k + 1);
+  }, [activeKey]);
+
+  if (!authed) return <Navigate to="/login" replace />;
+  if (isMobile) return <DesktopOnlyNotice title="Prepare to print" />;
+
+  const meetingOverride =
+    activeKey === "conductingProgram"
+      ? meeting.data?.programs?.conducting
+      : meeting.data?.programs?.congregation;
+  const wardTemplate =
+    activeKey === "conductingProgram" ? conductingTpl.data : congregationTpl.data;
+  const initialJson =
+    meetingOverride?.editorStateJson ??
+    wardTemplate?.editorStateJson ??
+    defaultProgramTemplate(activeKey);
+  const initialPageStyle = meetingOverride?.pageStyle ?? wardTemplate?.pageStyle ?? null;
+  const margins = meetingOverride?.margins ?? wardTemplate?.margins ?? DEFAULT_MARGINS[activeKey];
+  const usingOverride = Boolean(meetingOverride);
+
+  const editorJson = draft[activeKey] ?? initialJson;
+  const activePageStyle = pageStyleDraft[activeKey] ?? initialPageStyle;
+  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
+  const styleDirty =
+    pageStyleDraft[activeKey] !== null &&
+    JSON.stringify(pageStyleDraft[activeKey]) !== JSON.stringify(initialPageStyle);
+  const dirty = jsonDirty || styleDirty;
+
+  async function save() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMeetingProgram(
+        wardId,
+        date,
+        activeKey,
+        draft[activeKey] ?? initialJson,
+        margins,
+        activePageStyle ?? null,
+      );
+      setDraft((d) => ({ ...d, [activeKey]: null }));
+      setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setDraft((d) => ({ ...d, [activeKey]: null }));
+    setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  const activeTab = TABS.find((t) => t.key === activeKey)!;
+
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PreparePrintHeader
+        date={date}
+        printSegment={activeTab.printSegment}
+        usingOverride={usingOverride}
+      />
+
+      <nav className="shrink-0 flex gap-1 border-b border-border bg-parchment-2/30 px-5 sm:px-8 pt-3">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setActiveKey(t.key)}
+            className={
+              activeKey === t.key
+                ? "px-3 py-2 -mb-px border-b-2 border-bordeaux font-sans text-[13.5px] font-semibold text-walnut"
+                : "px-3 py-2 -mb-px border-b-2 border-transparent font-sans text-[13.5px] text-walnut-2 hover:text-walnut"
+            }
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="flex-1 min-h-0 pb-16">
+        <ProgramPageEditor
+          key={`${activeKey}-${editorKey}`}
+          variant={activeKey}
+          initialJson={editorJson}
+          pageStyle={activePageStyle}
+          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
+          onPageStyleChange={(next) => setPageStyleDraft((d) => ({ ...d, [activeKey]: next }))}
+          ariaLabel={activeTab.label}
+        />
+      </div>
+
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </main>
+  );
+}

--- a/src/features/print/PreparePrintView.tsx
+++ b/src/features/print/PreparePrintView.tsx
@@ -1,20 +1,13 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Navigate } from "react-router";
-import { SaveBar } from "@/components/ui/SaveBar";
-import { useMeeting } from "@/hooks/useMeeting";
 import { useAuthStore } from "@/stores/authStore";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useCurrentWardStore } from "@/stores/currentWardStore";
-import { friendlyWriteError } from "@/stores/saveStatusStore";
-import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
-import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
 import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
-import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
-import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
+import type { ProgramTemplateKey } from "@/lib/types";
+import { CongregationPrepareTab } from "./CongregationPrepareTab";
+import { ConductingPrepareTab } from "./ConductingPrepareTab";
 import { PreparePrintHeader } from "./PreparePrintHeader";
-import { writeMeetingProgram } from "./utils/writeMeetingProgram";
 
 interface Props {
   date: string;
@@ -25,96 +18,25 @@ const TABS: { key: ProgramTemplateKey; label: string; printSegment: string }[] =
   { key: "congregationProgram", label: "Congregation copy", printSegment: "congregation" },
 ];
 
-/** /week/:date/prepare — per-Sunday program editor. Same WYSIWYG shell
- *  as `/settings/templates/programs`, but writes land on the meeting
- *  doc (under `programs.{conducting|congregation}`) so each Sunday
- *  carries its own saved version. The print routes prefer this
- *  override; if the bishopric never opens this page for a given week,
- *  the ward-level template is used instead. */
+/** /week/:date/prepare — chrome + tab switcher. Each tab is a self-
+ *  contained component: the conducting tab is a Lexical WYSIWYG
+ *  editor; the congregation tab is a live cover+program preview with
+ *  inline form controls for the editable bits (image URL,
+ *  announcements). */
 export function PreparePrintView({ date }: Props) {
   useFullViewportLayout();
   const isMobile = useIsMobile();
   const authed = useAuthStore((s) => s.status === "signed_in");
-  const wardId = useCurrentWardStore((s) => s.wardId);
-  const meeting = useMeeting(date);
-  const conductingTpl = useProgramTemplate("conductingProgram");
-  const congregationTpl = useProgramTemplate("congregationProgram");
-
   const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
-  const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
-    conductingProgram: null,
-    congregationProgram: null,
-  });
-  const [pageStyleDraft, setPageStyleDraft] = useState<
-    Record<ProgramTemplateKey, LetterPageStyle | null>
-  >({ conductingProgram: null, congregationProgram: null });
-  const [editorKey, setEditorKey] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedAt, setSavedAt] = useState<string | null>(null);
-
-  // Re-mount Lexical when the active tab changes so it hydrates from
-  // the new tab's initial state.
-  useEffect(() => {
-    setEditorKey((k) => k + 1);
-  }, [activeKey]);
+  const [conductingOverride, setConductingOverride] = useState(false);
 
   if (!authed) return <Navigate to="/login" replace />;
   if (isMobile) return <DesktopOnlyNotice title="Prepare to print" />;
 
-  const meetingOverride =
-    activeKey === "conductingProgram"
-      ? meeting.data?.programs?.conducting
-      : meeting.data?.programs?.congregation;
-  const wardTemplate =
-    activeKey === "conductingProgram" ? conductingTpl.data : congregationTpl.data;
-  const initialJson =
-    meetingOverride?.editorStateJson ??
-    wardTemplate?.editorStateJson ??
-    defaultProgramTemplate(activeKey);
-  const initialPageStyle = meetingOverride?.pageStyle ?? wardTemplate?.pageStyle ?? null;
-  const margins = meetingOverride?.margins ?? wardTemplate?.margins ?? DEFAULT_MARGINS[activeKey];
-  const usingOverride = Boolean(meetingOverride);
-
-  const editorJson = draft[activeKey] ?? initialJson;
-  const activePageStyle = pageStyleDraft[activeKey] ?? initialPageStyle;
-  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
-  const styleDirty =
-    pageStyleDraft[activeKey] !== null &&
-    JSON.stringify(pageStyleDraft[activeKey]) !== JSON.stringify(initialPageStyle);
-  const dirty = jsonDirty || styleDirty;
-
-  async function save() {
-    if (!wardId) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await writeMeetingProgram(
-        wardId,
-        date,
-        activeKey,
-        draft[activeKey] ?? initialJson,
-        margins,
-        activePageStyle ?? null,
-      );
-      setDraft((d) => ({ ...d, [activeKey]: null }));
-      setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
-    } catch (e) {
-      setError(friendlyWriteError(e));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function discard() {
-    setDraft((d) => ({ ...d, [activeKey]: null }));
-    setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-    setEditorKey((k) => k + 1);
-    setError(null);
-  }
-
   const activeTab = TABS.find((t) => t.key === activeKey)!;
+  // Status pill on conducting reflects the Lexical override state.
+  // Congregation tab manages its own preview and doesn't use the pill.
+  const usingOverride = activeKey === "conductingProgram" && conductingOverride;
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
@@ -141,26 +63,11 @@ export function PreparePrintView({ date }: Props) {
         ))}
       </nav>
 
-      <div className="flex-1 min-h-0 pb-16">
-        <ProgramPageEditor
-          key={`${activeKey}-${editorKey}`}
-          variant={activeKey}
-          initialJson={editorJson}
-          pageStyle={activePageStyle}
-          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
-          onPageStyleChange={(next) => setPageStyleDraft((d) => ({ ...d, [activeKey]: next }))}
-          ariaLabel={activeTab.label}
-        />
-      </div>
-
-      <SaveBar
-        dirty={dirty}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={discard}
-        onSave={() => void save()}
-      />
+      {activeKey === "conductingProgram" ? (
+        <ConductingPrepareTab date={date} onUsingOverrideChange={setConductingOverride} />
+      ) : (
+        <CongregationPrepareTab date={date} />
+      )}
     </main>
   );
 }

--- a/src/features/print/PrintLayout.tsx
+++ b/src/features/print/PrintLayout.tsx
@@ -38,12 +38,12 @@ export function PrintLayout({ ready, dense, landscape, children }: Props) {
   }, [ready]);
 
   return (
-    <div className="min-h-screen bg-chalk text-walnut font-serif print:bg-white print:min-h-screen print:flex print:flex-col print:justify-center">
+    <div className="min-h-screen bg-chalk text-walnut font-serif print:bg-white print:min-h-0 print:block">
       <div
         className={
           dense
-            ? "mx-auto max-w-4xl px-6 py-6 print:px-2 print:py-0 print:w-full"
-            : "mx-auto max-w-4xl px-10 py-10 print:px-6 print:py-0 print:w-full"
+            ? "mx-auto max-w-4xl px-6 py-6 print:max-w-none print:p-0 print:w-full"
+            : "mx-auto max-w-4xl px-10 py-10 print:max-w-none print:p-0 print:w-full"
         }
       >
         {children}

--- a/src/features/print/utils/programFooter.ts
+++ b/src/features/print/utils/programFooter.ts
@@ -1,0 +1,14 @@
+/** Default footer note shown at the bottom of the congregation
+ *  copy's program panel. Bishopric can override per-Sunday from
+ *  /week/:date/prepare. An explicit empty string hides the footer. */
+export const DEFAULT_PROGRAM_FOOTER_NOTE =
+  "Quietly ponder the prelude music 10 minutes before the meeting begins";
+
+/** Resolve the footer text to render, given the per-meeting override.
+ *  Undefined → default; empty string → null (hide); otherwise the
+ *  override wins. */
+export function resolveProgramFooterNote(override: string | undefined | null): string | null {
+  if (override === undefined || override === null) return DEFAULT_PROGRAM_FOOTER_NOTE;
+  if (override.trim().length === 0) return null;
+  return override;
+}

--- a/src/features/print/utils/programFooter.ts
+++ b/src/features/print/utils/programFooter.ts
@@ -1,14 +1,38 @@
-/** Default footer note shown at the bottom of the congregation
- *  copy's program panel. Bishopric can override per-Sunday from
- *  /week/:date/prepare. An explicit empty string hides the footer. */
+/** Built-in default footer note shown at the bottom of the
+ *  congregation copy's program panel. Wards can override the default
+ *  from /settings/templates/programs; per-Sunday overrides on the
+ *  meeting doc beat both. Empty string at any level hides the footer
+ *  outright (caller wanted no footer that week / for that ward). */
 export const DEFAULT_PROGRAM_FOOTER_NOTE =
   "Quietly ponder the prelude music 10 minutes before the meeting begins";
 
-/** Resolve the footer text to render, given the per-meeting override.
- *  Undefined → default; empty string → null (hide); otherwise the
- *  override wins. */
-export function resolveProgramFooterNote(override: string | undefined | null): string | null {
-  if (override === undefined || override === null) return DEFAULT_PROGRAM_FOOTER_NOTE;
-  if (override.trim().length === 0) return null;
-  return override;
+/** Resolve the footer text to render. Cascades meeting → ward → built-in
+ *  default. At each level: undefined falls through; empty string is an
+ *  explicit "hide" and short-circuits to null; non-empty wins. */
+export function resolveProgramFooterNote(
+  meetingOverride: string | undefined | null,
+  wardDefault?: string | undefined | null,
+): string | null {
+  for (const value of [meetingOverride, wardDefault]) {
+    if (value === undefined || value === null) continue;
+    if (value.trim().length === 0) return null;
+    return value;
+  }
+  return DEFAULT_PROGRAM_FOOTER_NOTE;
+}
+
+/** Resolve the cover image URL to render. Cascades meeting → ward →
+ *  null. Empty strings at either level are treated as "no override
+ *  here" (a placeholder shows when nothing is set). */
+export function resolveCoverImageUrl(
+  meetingOverride: string | undefined | null,
+  wardDefault?: string | undefined | null,
+): string | null {
+  for (const value of [meetingOverride, wardDefault]) {
+    if (value === undefined || value === null) continue;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) continue;
+    return trimmed;
+  }
+  return null;
 }

--- a/src/features/print/utils/writeMeetingCover.ts
+++ b/src/features/print/utils/writeMeetingCover.ts
@@ -1,0 +1,32 @@
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/** Write the editable bits surfaced on the congregation prepare page
+ *  — cover image URL, announcements, and program footer note — to the
+ *  meeting doc. Partial update; `null` on `coverImageUrl` /
+ *  `programFooterNote` clears the field. `programFooterNote === null`
+ *  also reverts to the built-in default at render time. */
+export async function writeMeetingCover(
+  wardId: string,
+  date: string,
+  fields: {
+    coverImageUrl: string | null;
+    announcements: string;
+    programFooterNote: string | null;
+  },
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(doc(db, "wards", wardId, "meetings", date), {
+      coverImageUrl: fields.coverImageUrl ?? null,
+      announcements: fields.announcements,
+      programFooterNote: fields.programFooterNote ?? null,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/print/utils/writeMeetingProgram.ts
+++ b/src/features/print/utils/writeMeetingProgram.ts
@@ -1,0 +1,49 @@
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { LetterPageStyle, ProgramMargins, ProgramTemplateKey } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/** Map between the ward-template key (`conductingProgram` /
+ *  `congregationProgram`) and the meeting-doc field on
+ *  `meeting.programs` (`conducting` / `congregation`). The shorter
+ *  meeting-side names live under `programs.*`, so they don't collide
+ *  with the assignment field `meeting.conducting`. */
+const MEETING_FIELD: Record<ProgramTemplateKey, "conducting" | "congregation"> = {
+  conductingProgram: "conducting",
+  congregationProgram: "congregation",
+};
+
+/** Write the per-Sunday program override to the meeting doc. Stored
+ *  under `meeting.programs.{conducting|congregation}` so it can be
+ *  loaded standalone (no extra round-trips) and the print routes can
+ *  prefer it over the ward template. */
+export async function writeMeetingProgram(
+  wardId: string,
+  date: string,
+  key: ProgramTemplateKey,
+  editorStateJson: string,
+  margins: ProgramMargins,
+  pageStyle: LetterPageStyle | null,
+): Promise<void> {
+  reportSaving();
+  try {
+    const field = MEETING_FIELD[key];
+    await updateDoc(doc(db, "wards", wardId, "meetings", date), {
+      [`programs.${field}`]: {
+        editorStateJson,
+        margins,
+        pageStyle: pageStyle ?? null,
+        updatedAt: serverTimestamp(),
+      },
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+export function meetingProgramField(key: ProgramTemplateKey): "conducting" | "congregation" {
+  return MEETING_FIELD[key];
+}

--- a/src/features/print/utils/writeWardCongregationDefaults.ts
+++ b/src/features/print/utils/writeWardCongregationDefaults.ts
@@ -1,0 +1,29 @@
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/** Write the ward-level defaults that drive the congregation print
+ *  bulletin when no per-meeting override is set: cover image URL and
+ *  program footer note. Configurable from /settings/templates/programs.
+ *  Stored under `wards/{wardId}.congregationDefaults`.
+ *
+ *  `null` clears the field — at render time, an absent value falls
+ *  through to the next layer (built-in default for the footer; no
+ *  image for the cover). */
+export async function writeWardCongregationDefaults(
+  wardId: string,
+  fields: { coverImageUrl: string | null; programFooterNote: string | null },
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(doc(db, "wards", wardId), {
+      "congregationDefaults.coverImageUrl": fields.coverImageUrl ?? null,
+      "congregationDefaults.programFooterNote": fields.programFooterNote ?? null,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/program-templates/ConductingTemplateTab.tsx
+++ b/src/features/program-templates/ConductingTemplateTab.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import type { LetterPageStyle } from "@/lib/types";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
+import { DEFAULT_MARGINS } from "./ProgramCanvas";
+import { useProgramTemplate } from "./hooks/useProgramTemplate";
+import { defaultProgramTemplate } from "./utils/programTemplateDefaults";
+import { writeProgramTemplate } from "./utils/writeProgramTemplate";
+
+const KEY = "conductingProgram";
+
+interface Props {
+  onUsingDefaultChange?: (using: boolean) => void;
+}
+
+/** Conducting-copy template editor on /settings/templates/programs.
+ *  Lexical WYSIWYG with variable chips — saves to the ward template
+ *  doc at `wards/{wardId}/templates/conductingProgram`. */
+export function ConductingTemplateTab({ onUsingDefaultChange }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const me = useCurrentMember();
+  const canEdit = Boolean(me?.data.active);
+  const tpl = useProgramTemplate(KEY);
+
+  const initialJson = tpl.data?.editorStateJson ?? defaultProgramTemplate(KEY);
+  const usingDefault = !tpl.data?.editorStateJson;
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [pageStyleDraft, setPageStyleDraft] = useState<LetterPageStyle | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    onUsingDefaultChange?.(usingDefault);
+  }, [usingDefault, onUsingDefaultChange]);
+
+  const editorJson = draft ?? initialJson;
+  const activePageStyle = pageStyleDraft ?? tpl.data?.pageStyle ?? null;
+  const jsonDirty = draft !== null && draft !== initialJson;
+  const styleDirty =
+    pageStyleDraft !== null &&
+    JSON.stringify(pageStyleDraft) !== JSON.stringify(tpl.data?.pageStyle ?? null);
+  const dirty = jsonDirty || styleDirty;
+
+  async function save() {
+    if (!wardId) return;
+    const margins = tpl.data?.margins ?? DEFAULT_MARGINS[KEY];
+    setSaving(true);
+    setError(null);
+    try {
+      await writeProgramTemplate(wardId, KEY, draft ?? initialJson, margins, activePageStyle);
+      setDraft(null);
+      setPageStyleDraft(null);
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setDraft(null);
+    setPageStyleDraft(null);
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="flex-1 min-h-0 pb-16">
+        <ProgramPageEditor
+          key={`conducting-${editorKey}`}
+          variant={KEY}
+          initialJson={editorJson}
+          pageStyle={activePageStyle}
+          showSampleNotice
+          onChange={setDraft}
+          onPageStyleChange={canEdit ? setPageStyleDraft : undefined}
+          ariaLabel="Conducting copy"
+          editorDisabled={!canEdit}
+        />
+      </div>
+
+      <SaveBar
+        dirty={dirty && canEdit}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </>
+  );
+}

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -93,15 +93,16 @@ export const sacramentMeetingSchema = z.object({
   conducting: assignmentSchema.optional(),
   visitors: z.array(visitorSchema).default([]),
   /** URL of the cover image shown on the congregation copy's left
-   *  panel (above the announcements). Optional — when absent the
-   *  cover renders ward branding + announcements only. */
-  coverImageUrl: z.string().optional(),
+   *  panel (above the announcements). Nullish — when absent or null
+   *  the cover renders ward branding + announcements only. The write
+   *  helper clears with `null`, so the schema must accept it. */
+  coverImageUrl: z.string().nullish(),
   /** Footer note printed at the bottom of the congregation copy's
    *  right (program) panel — typically a reverence prompt like
-   *  "Quietly ponder the prelude music…". Undefined falls back to
-   *  the built-in default; an explicit empty string hides the
-   *  footer. */
-  programFooterNote: z.string().optional(),
+   *  "Quietly ponder the prelude music…". Undefined / null falls
+   *  back to the ward default → built-in default; an explicit empty
+   *  string hides the footer. */
+  programFooterNote: z.string().nullish(),
   /** Per-Sunday overrides for the printed program. When present, the
    *  prepare-to-print + print routes use these saved Lexical states
    *  instead of the ward-level template — so the bishopric can tailor

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { programTemplateSchema } from "./template";
 import { assignmentSchema } from "./person";
 
 export const MEETING_TYPES = ["regular", "fast", "stake", "general"] as const;
@@ -91,6 +92,18 @@ export const sacramentMeetingSchema = z.object({
   presiding: assignmentSchema.optional(),
   conducting: assignmentSchema.optional(),
   visitors: z.array(visitorSchema).default([]),
+  /** Per-Sunday overrides for the printed program. When present, the
+   *  prepare-to-print + print routes use these saved Lexical states
+   *  instead of the ward-level template — so the bishopric can tailor
+   *  one Sunday's program without changing the template that future
+   *  weeks inherit. The shape mirrors the ward template doc so the
+   *  same editor + render path can read either. */
+  programs: z
+    .object({
+      conducting: programTemplateSchema.optional(),
+      congregation: programTemplateSchema.optional(),
+    })
+    .optional(),
   updatedAt: z.any().optional(),
   createdAt: z.any().optional(),
 });

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -92,6 +92,16 @@ export const sacramentMeetingSchema = z.object({
   presiding: assignmentSchema.optional(),
   conducting: assignmentSchema.optional(),
   visitors: z.array(visitorSchema).default([]),
+  /** URL of the cover image shown on the congregation copy's left
+   *  panel (above the announcements). Optional — when absent the
+   *  cover renders ward branding + announcements only. */
+  coverImageUrl: z.string().optional(),
+  /** Footer note printed at the bottom of the congregation copy's
+   *  right (program) panel — typically a reverence prompt like
+   *  "Quietly ponder the prelude music…". Undefined falls back to
+   *  the built-in default; an explicit empty string hides the
+   *  footer. */
+  programFooterNote: z.string().optional(),
   /** Per-Sunday overrides for the printed program. When present, the
    *  prepare-to-print + print routes use these saved Lexical states
    *  instead of the ward-level template — so the bishopric can tailor

--- a/src/lib/types/ward.ts
+++ b/src/lib/types/ward.ts
@@ -18,9 +18,25 @@ export const wardSettingsSchema = z.object({
 });
 export type WardSettings = z.infer<typeof wardSettingsSchema>;
 
+/** Ward-level defaults for the congregation print bulletin. Per-meeting
+ *  overrides on the meeting doc (`coverImageUrl`, `programFooterNote`)
+ *  win when set; otherwise the print + prepare paths fall back to
+ *  these. Configurable from /settings/templates/programs.
+ *
+ *  Fields are `nullish` because the write helper clears values by
+ *  storing `null` (rather than `deleteField()`) — Zod must accept
+ *  `string | null | undefined` so the ward doc still parses after a
+ *  clear. */
+export const congregationDefaultsSchema = z.object({
+  coverImageUrl: z.string().nullish(),
+  programFooterNote: z.string().nullish(),
+});
+export type CongregationDefaults = z.infer<typeof congregationDefaultsSchema>;
+
 export const wardSchema = z.object({
   name: z.string().min(1),
   settings: wardSettingsSchema,
+  congregationDefaults: congregationDefaultsSchema.optional(),
   createdAt: z.any().optional(),
 });
 export type Ward = z.infer<typeof wardSchema>;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -462,8 +462,11 @@
     height: auto !important;
   }
 
-  /* Hide every top-level body child except the portal. */
-  body > *:not([data-print-only-letter]) {
+  /* Hide every top-level body child except the portal — only when a
+     letter portal is actually mounted (otherwise this rule blanks out
+     every other print route, like the congregation / conducting
+     program prints which render in #root, not via portal). */
+  body:has([data-print-only-letter]) > *:not([data-print-only-letter]) {
     display: none !important;
   }
 


### PR DESCRIPTION
## Summary

Adds an intermediate **/week/:date/prepare** step between the editor and the print routes — a Lexical WYSIWYG for the conducting copy and a form-and-preview editor for the new congregation bulletin (cover panel + program panel on a single landscape sheet, fold down the middle). Per-Sunday saves on the meeting doc; ward-level defaults on `/settings/templates/programs` cascade in when no override is set.

## What changed

- **New route** `/week/:date/prepare` (full-viewport, AppShell-less) with two tabs:
  - **Conducting** — Lexical editor (same shell as the templates page); per-Sunday save under `meeting.programs.conducting`.
  - **Congregation** — live bulletin preview at letter-landscape scale, with three inline form fields: cover image URL, announcements, program footer note. The footer pre-fills the built-in default ("Quietly ponder…") so bishops have concrete text to tweak.
- **New congregation print layout**: `/print/:date/congregation` now prints **one** bulletin per landscape sheet — left half is the cover (church name eyebrow + ward name + image + announcements), right half is the brass-label program panel — instead of "two identical copies, cut down the middle".
- **Editor → templates page parity**: `/settings/templates/programs` Congregation tab gets a matching form-and-preview editor (image URL + footer note only — announcements stay per-week). Saves to `ward.congregationDefaults`.
- **Cascade**: at render time, cover image and footer note resolve `meeting → ward.congregationDefaults → built-in default`. Empty string at any level is an explicit "hide" for the footer.
- **Editor entry point**: the two direct-print buttons (`PrintReadinessPanel`, `ProgramSaveBar`) collapse into a single "Prepare to print" CTA. Print buttons on the prepare page open `/print/...` in a new tab so draft state survives.
- **Print plumbing fixes**:
  - Scoped a global `@media print` rule (`body > *:not([data-print-only-letter])`) with `:has()` so it only fires when a letter portal is mounted — was hiding every other print route's content silently.
  - Dropped `max-w-4xl` + `print:flex print:justify-center` in `PrintLayout` so bulletins fill the printable area instead of getting squeezed into a 9.3in column or overflowing off-page from vertical centering.

## Schema additions

- `meeting.coverImageUrl?: string | null`, `meeting.programFooterNote?: string | null`, `meeting.programs?: { conducting?, congregation? }` — all `nullish` so cleared values (stored as `null`) still parse.
- `ward.congregationDefaults?: { coverImageUrl?, programFooterNote? }` — same nullish treatment.

## Test plan

- [ ] On the upcoming Sunday's `/week/:date`: readiness panel shows "Prepare to print" CTA when the meeting is ready; disabled with a tooltip otherwise.
- [ ] Click "Prepare to print" → `/week/:date/prepare` loads with two tabs.
- [ ] Conducting tab: edit, Save, reload — saved state restored; print button opens `/print/:date/conducting` in a new tab and triggers the print dialog.
- [ ] Congregation tab: type in the three fields → preview updates live; Save persists; reload → values restored; clearing the footer reverts to ward default → built-in default.
- [ ] `/print/:date/congregation` prints one bulletin per landscape page — cover left, program right, fold line down the middle, no blank preview.
- [ ] `/settings/templates/programs` Congregation tab: edit + save → reload → values restored; the prepare page picks up the ward defaults when the meeting hasn't been customised.
- [ ] Untouched meeting docs still load (`Meeting not created yet` doesn't get stuck) — schema accepts the `null` values written by clearing fields.
- [ ] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test` (495/495 pass locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)