### PR TITLE
feat: live meeting data in conducting prepare-tab chips + tab swap

### DIFF
--- a/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
+++ b/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
@@ -8,8 +8,8 @@ import { ConductingTemplateTab } from "@/features/program-templates/ConductingTe
 import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
 
 const TABS: { key: ProgramTemplateKey; label: string }[] = [
-  { key: "conductingProgram", label: "Conducting copy" },
   { key: "congregationProgram", label: "Congregation copy" },
+  { key: "conductingProgram", label: "Conducting copy" },
 ];
 
 /** /settings/templates/programs — chrome + tab switcher. The
@@ -21,7 +21,7 @@ const TABS: { key: ProgramTemplateKey; label: string }[] = [
 export function ProgramTemplatesPage(): React.ReactElement {
   useFullViewportLayout();
   const isMobile = useIsMobile();
-  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
+  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("congregationProgram");
   const [conductingUsingDefault, setConductingUsingDefault] = useState(false);
 
   if (isMobile) return <DesktopOnlyNotice title="Program templates" />;

--- a/src/features/page-editor/ProgramPageEditor.tsx
+++ b/src/features/page-editor/ProgramPageEditor.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
 import {
   GROUP_LABEL,
   PROGRAM_VARIABLES,
+  type ProgramVariable,
 } from "@/features/program-templates/utils/programVariables";
 import { PAGE_EDITOR_BASE_NODES } from "./utils/pageEditorNodes";
 import { PageEditorComposer } from "./PageEditorComposer";
@@ -28,6 +29,13 @@ interface Props {
    *  are placeholders that resolve to real meeting data at print
    *  time. */
   showSampleNotice?: boolean;
+  /** Override the chip sample values with a real-data bag (e.g. from
+   *  `buildMeetingVariables`). Per-Sunday hosts (the prepare page)
+   *  pass this so chips render the actual meeting's presider, hymns,
+   *  and speakers — not the generic Bishop Reeves / hymn #19 stand-
+   *  ins. Template editors omit this and the chips fall back to the
+   *  built-in samples. */
+  vars?: Readonly<Record<string, string>>;
 }
 
 /** WYSIWYG program template editor — Word-style layout: full-width
@@ -44,6 +52,7 @@ export function ProgramPageEditor({
   ariaLabel,
   editorDisabled,
   showSampleNotice,
+  vars,
 }: Props) {
   const canvasVariant = variant === "conductingProgram" ? "conducting" : "congregation";
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -55,8 +64,20 @@ export function ProgramPageEditor({
       : zoomMode.kind === "fit-page"
         ? fits.fitPage
         : zoomMode.value;
+  // When a `vars` bag is supplied, swap each variable's `sample` for
+  // the live value so chips render real meeting data inside the
+  // editor (instead of the generic Bishop Reeves / hymn #19). Empty
+  // strings fall back to the built-in sample so an unfilled hymn
+  // still renders meaningful guidance text.
+  const effectiveVariables = useMemo<readonly ProgramVariable[]>(() => {
+    if (!vars) return PROGRAM_VARIABLES;
+    return PROGRAM_VARIABLES.map((v) => {
+      const live = vars[v.token];
+      return live && live.trim().length > 0 ? { ...v, sample: live } : v;
+    });
+  }, [vars]);
   return (
-    <VariableRegistryProvider variables={PROGRAM_VARIABLES} groupLabels={GROUP_LABEL}>
+    <VariableRegistryProvider variables={effectiveVariables} groupLabels={GROUP_LABEL}>
       <div
         className={`flex flex-col h-full w-full ${editorDisabled ? "opacity-60 pointer-events-none" : ""}`}
       >
@@ -71,7 +92,7 @@ export function ProgramPageEditor({
           pageToolbar={
             <PageToolbar
               slashCommands={PROGRAM_SLASH_COMMANDS}
-              variables={PROGRAM_VARIABLES}
+              variables={effectiveVariables}
               variableGroupLabels={GROUP_LABEL}
               pageStyle={pageStyle}
               zoom={zoom}

--- a/src/features/print/ConductingDesignPage1.tsx
+++ b/src/features/print/ConductingDesignPage1.tsx
@@ -1,0 +1,151 @@
+import type { ReactNode } from "react";
+import {
+  DividerStrong,
+  DividerThin,
+  EmDash,
+  Masthead,
+  SectionLabel,
+  Sheet,
+  SheetFooter,
+} from "./ConductingDesignParts";
+
+export interface AgendaCue {
+  text: string;
+}
+export interface AgendaSub {
+  label: string;
+  value: ReactNode;
+}
+export interface AgendaItem {
+  num: string;
+  label: string;
+  value: ReactNode;
+  sub?: AgendaSub | undefined;
+  cue?: AgendaCue | undefined;
+}
+export interface Page1Props {
+  wardName: string;
+  dateLong: string;
+  timeText: string;
+  presiding: string;
+  conducting: string;
+  pianist: string;
+  chorister: string;
+  visitors: string;
+  agenda: AgendaItem[];
+  footerLeft: string;
+}
+
+/** Page 1 of the conducting copy — masthead, officers grid, numbered
+ *  agenda with sub-rows + italic stage cues, footer with ornament.
+ *  Pixel-mirrors the Conductors Page.html design from Claude Design. */
+export function ConductingDesignPage1(p: Page1Props) {
+  return (
+    <Sheet>
+      <Masthead
+        eyebrow="Conducting copy"
+        title="Sacrament meeting"
+        meta={[p.wardName, p.dateLong, p.timeText]}
+      />
+      <DividerStrong />
+      <Officers
+        presiding={p.presiding}
+        conducting={p.conducting}
+        pianist={p.pianist}
+        chorister={p.chorister}
+        visitors={p.visitors}
+      />
+      <DividerThin />
+      <Agenda items={p.agenda} />
+      <SheetFooter left={p.footerLeft} right="Conducting copy" />
+    </Sheet>
+  );
+}
+
+interface OfficersProps {
+  presiding: string;
+  conducting: string;
+  pianist: string;
+  chorister: string;
+  visitors: string;
+}
+
+function Officers({ presiding, conducting, pianist, chorister, visitors }: OfficersProps) {
+  return (
+    <section>
+      <SectionLabel>Officers</SectionLabel>
+      <div className="grid grid-cols-2 gap-x-9 gap-y-2 text-[16px] leading-[1.5] text-ink">
+        <OfficerRow role="Presiding" name={presiding} />
+        <OfficerRow role="Conducting" name={conducting} />
+        <OfficerRow role="Pianist" name={pianist} />
+        <OfficerRow role="Chorister" name={chorister} />
+        <div className="col-span-2">
+          <OfficerRow role="Visitors" name={visitors} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function OfficerRow({ role, name }: { role: string; name: string }) {
+  return (
+    <div>
+      <span className="font-semibold">{role}</span>
+      <span className="mx-1.5 text-walnut-3">·</span>
+      <span>{name}</span>
+    </div>
+  );
+}
+
+function Agenda({ items }: { items: AgendaItem[] }) {
+  return (
+    <section>
+      <SectionLabel>Order of meeting</SectionLabel>
+      <div className="mt-1">
+        {items.map((item, i) => (
+          <AgendaRow key={item.num} item={item} isLast={i === items.length - 1} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AgendaRow({ item, isLast }: { item: AgendaItem; isLast: boolean }) {
+  const noBorder = isLast && !item.sub && !item.cue;
+  return (
+    <>
+      <div
+        className={`grid grid-cols-[36px_1fr] items-baseline gap-x-1 py-[7px] ${
+          noBorder ? "" : "border-b border-dotted border-[#e3d7be]"
+        }`}
+      >
+        <div className="font-serif font-semibold text-[22px] leading-none text-brass-deep pt-0.5">
+          {item.num}
+        </div>
+        <div className="text-[17px] leading-[1.45] text-ink">
+          <span className="font-semibold">{item.label}</span>
+          <EmDash />
+          {item.value}
+        </div>
+      </div>
+      {item.sub && (
+        <div className="grid grid-cols-[36px_1fr] gap-x-1 pt-1 pb-1.5">
+          <div />
+          <div className="text-[16px] text-ink">
+            <span className="font-semibold">{item.sub.label}</span>
+            <EmDash />
+            {item.sub.value}
+          </div>
+        </div>
+      )}
+      {item.cue && (
+        <div className="grid grid-cols-[36px_1fr] gap-x-1 pt-0.5 pb-1">
+          <div />
+          <div className="font-serif italic text-[14.5px] leading-[1.45] text-walnut-3 border-l-2 border-brass-soft pl-2.5 -ml-0.5">
+            {item.cue.text}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/features/print/ConductingDesignPage2.tsx
+++ b/src/features/print/ConductingDesignPage2.tsx
@@ -1,0 +1,113 @@
+import {
+  DividerStrong,
+  DividerThin,
+  Masthead,
+  SectionLabel,
+  Sheet,
+  SheetFooter,
+} from "./ConductingDesignParts";
+
+export interface Page2Props {
+  wardName: string;
+  dateLong: string;
+  announcements: string;
+  wardBusiness: string;
+  stakeBusiness: string;
+  footerLeft: string;
+}
+
+interface SectionConfig {
+  step: string;
+  label: string;
+  body: string;
+  emptyHint: string;
+}
+
+/** Page 2 of the conducting copy — long-form items pointed at from
+ *  page 1's "See page 2" rows. Per current scope, the section bodies
+ *  are simple plain text from the meeting doc (announcements, ward
+ *  business, stake business). The structured numbered list, calling
+ *  list, and stage-cue script blocks from the original mockup are
+ *  deferred — the headers + step tags stay so the document still
+ *  reads as the matching second sheet. */
+export function ConductingDesignPage2(p: Page2Props) {
+  const sections: SectionConfig[] = [
+    {
+      step: "Step 1",
+      label: "Announcements",
+      body: p.announcements,
+      emptyHint: "Per-week announcements appear here when filled in on the prepare page.",
+    },
+    {
+      step: "Step 3",
+      label: "Ward business",
+      body: p.wardBusiness,
+      emptyHint: "Releases, sustainings, and other ward business — typed in during planning.",
+    },
+    {
+      step: "Step 3",
+      label: "Stake business",
+      body: p.stakeBusiness,
+      emptyHint: "Stake-level items, e.g. handing time over to a high councillor.",
+    },
+  ];
+
+  return (
+    <Sheet>
+      <Masthead
+        eyebrow="Conducting copy · Page 2"
+        title="Notes & long-form items"
+        meta={[p.wardName, p.dateLong]}
+      />
+      <DividerStrong />
+      {sections.map((section, i) => (
+        <Section
+          key={section.label}
+          step={section.step}
+          label={section.label}
+          body={section.body}
+          emptyHint={section.emptyHint}
+          showThinDivider={i > 0}
+        />
+      ))}
+      <SheetFooter left={p.footerLeft} right="Conducting copy" />
+    </Sheet>
+  );
+}
+
+interface SectionProps extends SectionConfig {
+  showThinDivider: boolean;
+}
+
+function Section({ step, label, body, emptyHint, showThinDivider }: SectionProps) {
+  return (
+    <>
+      {showThinDivider && <DividerThin />}
+      <section className="mb-[18px]">
+        <div className="flex items-baseline gap-3 mb-[14px]">
+          <span className="font-mono text-[10px] tracking-[0.16em] uppercase text-white bg-brass-deep px-2 py-[2px] rounded-[3px]">
+            {step}
+          </span>
+          <SectionLabel>{label}</SectionLabel>
+        </div>
+        <Body body={body} emptyHint={emptyHint} />
+      </section>
+    </>
+  );
+}
+
+function Body({ body, emptyHint }: { body: string; emptyHint: string }) {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) {
+    return (
+      <p className="font-serif italic text-[14.5px] leading-[1.45] text-walnut-3 border-l-2 border-brass-soft pl-2.5 m-0">
+        {emptyHint}
+      </p>
+    );
+  }
+  return (
+    <p className="font-serif text-[16px] leading-[1.6] text-ink whitespace-pre-wrap m-0">
+      {trimmed}
+    </p>
+  );
+}

--- a/src/features/print/ConductingDesignParts.tsx
+++ b/src/features/print/ConductingDesignParts.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+
+/** Shared visual primitives for the conducting copy design — used by
+ *  both Page 1 (numbered agenda) and Page 2 (long-form notes). Maps
+ *  Steward design tokens onto the typography vocabulary from
+ *  Conductors Page.html: Newsreader serif body, IBM Plex Mono
+ *  eyebrows, walnut/brass-deep ink, hairline rules in #d3c6ad. */
+
+/** A single 8.5×11 white sheet at print scale. The on-screen preview
+ *  centres it on a parchment surround; print routes drop the
+ *  shadow and let `@page` margins handle the bleed. */
+export function Sheet({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-white shadow-[0_2px_6px_rgba(0,0,0,0.06),0_18px_50px_rgba(0,0,0,0.12)] mx-auto print:shadow-none"
+      style={{ width: "8.5in", minHeight: "11in", padding: "0.85in" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Masthead({
+  eyebrow,
+  title,
+  meta,
+}: {
+  eyebrow: string;
+  title: string;
+  meta: string[];
+}) {
+  return (
+    <header className="text-center mb-[22px]">
+      <p className="font-mono text-[11px] tracking-[0.22em] uppercase text-brass-deep m-0 mb-2.5">
+        {eyebrow}
+      </p>
+      <h1 className="font-serif italic font-medium text-[36px] leading-none text-ink m-0 mb-3 tracking-[-0.005em]">
+        {title}
+      </h1>
+      <p className="font-mono text-[12.5px] tracking-[0.06em] text-walnut-2 m-0">
+        {meta.map((part, i) => (
+          <span key={part}>
+            {i > 0 && <span className="mx-2.5 text-walnut-3">·</span>}
+            <span style={{ whiteSpace: "nowrap" }}>{part}</span>
+          </span>
+        ))}
+      </p>
+    </header>
+  );
+}
+
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="font-mono text-[11px] tracking-[0.20em] uppercase text-brass-deep m-0 mb-2.5">
+      {children}
+    </p>
+  );
+}
+
+export function DividerStrong() {
+  return <hr className="border-0 border-t-[1.5px] border-walnut mt-[18px] mb-[16px]" />;
+}
+
+export function DividerThin() {
+  return <hr className="border-0 border-t border-[#d3c6ad] my-[14px]" />;
+}
+
+export function SheetFooter({ left, right }: { left: string; right: string }) {
+  return (
+    <footer className="mt-7 pt-3 border-t border-[#d3c6ad] flex justify-between items-baseline font-mono text-[10.5px] tracking-[0.10em] uppercase text-walnut-3">
+      <span>{left}</span>
+      <span className="tracking-[0.4em] text-brass-deep">✦ ✦ ✦</span>
+      <span>{right}</span>
+    </footer>
+  );
+}
+
+export function EmDash() {
+  return <span className="mx-1.5 text-walnut-3">—</span>;
+}

--- a/src/features/print/ConductingPrepareTab.tsx
+++ b/src/features/print/ConductingPrepareTab.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SaveBar } from "@/components/ui/SaveBar";
-import { useMeeting } from "@/hooks/useMeeting";
+import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
+import { useWardSettings } from "@/hooks/useWardSettings";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
@@ -8,6 +9,7 @@ import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
 import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
 import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
 import type { LetterPageStyle } from "@/lib/types";
+import { buildMeetingVariables } from "./utils/buildMeetingVariables";
 import { writeMeetingProgram } from "./utils/writeMeetingProgram";
 
 interface Props {
@@ -23,6 +25,8 @@ const KEY = "conductingProgram";
 export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId);
   const meeting = useMeeting(date);
+  const speakers = useSpeakers(date);
+  const ward = useWardSettings();
   const tpl = useProgramTemplate(KEY);
 
   const [draft, setDraft] = useState<string | null>(null);
@@ -37,6 +41,22 @@ export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
     override?.editorStateJson ?? tpl.data?.editorStateJson ?? defaultProgramTemplate(KEY);
   const initialPageStyle = override?.pageStyle ?? tpl.data?.pageStyle ?? null;
   const margins = override?.margins ?? tpl.data?.margins ?? DEFAULT_MARGINS[KEY];
+
+  // Build the live variable bag so chips render *this* Sunday's
+  // presider, hymns, and speakers — not the generic template
+  // samples. Falls through to the built-in samples for any field
+  // that's still empty (e.g. an unassigned speaker), so the editor
+  // never shows a literally blank chip.
+  const liveVars = useMemo(
+    () =>
+      buildMeetingVariables({
+        date,
+        meeting: meeting.data ?? null,
+        speakers: speakers.data,
+        ward: ward.data ?? null,
+      }),
+    [date, meeting.data, speakers.data, ward.data],
+  );
 
   useEffect(() => {
     onUsingOverrideChange?.(Boolean(override));
@@ -80,6 +100,7 @@ export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
           variant={KEY}
           initialJson={editorJson}
           pageStyle={activePageStyle}
+          vars={liveVars}
           onChange={setDraft}
           onPageStyleChange={setPageStyleDraft}
           ariaLabel="Conducting copy"

--- a/src/features/print/PreparePrintView.tsx
+++ b/src/features/print/PreparePrintView.tsx
@@ -14,8 +14,8 @@ interface Props {
 }
 
 const TABS: { key: ProgramTemplateKey; label: string; printSegment: string }[] = [
-  { key: "conductingProgram", label: "Conducting copy", printSegment: "conducting" },
   { key: "congregationProgram", label: "Congregation copy", printSegment: "congregation" },
+  { key: "conductingProgram", label: "Conducting copy", printSegment: "conducting" },
 ];
 
 /** /week/:date/prepare — chrome + tab switcher. Each tab is a self-
@@ -27,7 +27,7 @@ export function PreparePrintView({ date }: Props) {
   useFullViewportLayout();
   const isMobile = useIsMobile();
   const authed = useAuthStore((s) => s.status === "signed_in");
-  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
+  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("congregationProgram");
   const [conductingOverride, setConductingOverride] = useState(false);
 
   if (!authed) return <Navigate to="/login" replace />;

--- a/src/features/print/utils/conductingSampleData.tsx
+++ b/src/features/print/utils/conductingSampleData.tsx
@@ -1,0 +1,117 @@
+import type { Page1Props } from "../ConductingDesignPage1";
+import type { Page2Props } from "../ConductingDesignPage2";
+
+/** Sample meeting data used to render the conducting copy template
+ *  preview when no real meeting is in scope (e.g. /settings/templates/
+ *  programs). Mirrors the figures from the original Conductors
+ *  Page.html mockup — Test Ward, May 31 2026, 9:00 a.m. — so the
+ *  bishop sees the same realistic preview shipped with the design. */
+
+export function sampleConductingPage1(wardName: string): Page1Props {
+  const dateLong = "Sunday, May 31, 2026";
+  return {
+    wardName,
+    dateLong,
+    timeText: "9:00 a.m.",
+    presiding: "Bishop Reeves",
+    conducting: "Brother Tan",
+    pianist: "Sister Lee",
+    chorister: "Sister Park",
+    visitors: "—",
+    agenda: [
+      {
+        num: "1",
+        label: "Announcements",
+        value: <span className="italic text-brass-deep">See page 2</span>,
+      },
+      {
+        num: "2",
+        label: "Opening hymn",
+        value: <HymnValue number="#19" title="We Thank Thee, O God, for a Prophet" />,
+        sub: { label: "Invocation", value: "Brother Tan" },
+      },
+      {
+        num: "3",
+        label: "Ward business",
+        value: <span className="italic text-brass-deep">See page 2</span>,
+        sub: {
+          label: "Stake business",
+          value: <span className="italic text-brass-deep">See page 2</span>,
+        },
+      },
+      {
+        num: "4",
+        label: "Sacrament hymn",
+        value: <HymnValue number="#172" title="In Humility, Our Savior" />,
+        cue: {
+          text: "Administration of the sacrament — pause for reverence before introducing speakers.",
+        },
+      },
+      {
+        num: "5",
+        label: "Speaker",
+        value: <SpeakerValue name="Brother Park" topic="On the still small voice" />,
+        cue: { text: "Welcome the congregation; introduce the speaker briefly." },
+      },
+      {
+        num: "6",
+        label: "Musical interlude",
+        value: <MusicValue label="Musical number" performer="Sister Lee" />,
+      },
+      {
+        num: "7",
+        label: "Speaker",
+        value: <SpeakerValue name="Sister Reeves" topic="Faith and works" />,
+        cue: { text: "Thank the previous speaker; mention the closing hymn that follows." },
+      },
+      {
+        num: "8",
+        label: "Closing hymn",
+        value: <HymnValue number="#85" title="How Firm a Foundation" />,
+        sub: { label: "Benediction", value: "Sister Park" },
+      },
+    ],
+    footerLeft: `${wardName} · 31 May 2026 · Page 1 of 2`,
+  };
+}
+
+export function sampleConductingPage2(wardName: string): Page2Props {
+  return {
+    wardName,
+    dateLong: "Sunday, May 31, 2026",
+    announcements: "",
+    wardBusiness: "",
+    stakeBusiness: "",
+    footerLeft: `${wardName} · 31 May 2026 · Page 2 of 2`,
+  };
+}
+
+function HymnValue({ number, title }: { number: string; title: string }) {
+  return (
+    <>
+      <span className="font-semibold whitespace-nowrap">{number}</span>
+      <span className="mx-1.5 text-walnut-3">—</span>
+      <span>{title}</span>
+    </>
+  );
+}
+
+function SpeakerValue({ name, topic }: { name: string; topic: string }) {
+  return (
+    <>
+      <span>{name}</span>
+      <span className="mx-1.5 text-walnut-3">—</span>
+      <span className="italic text-walnut-2">{topic}</span>
+    </>
+  );
+}
+
+function MusicValue({ label, performer }: { label: string; performer: string }) {
+  return (
+    <>
+      <span>{label}</span>
+      <span className="mx-1.5 text-walnut-3">—</span>
+      <span>{performer}</span>
+    </>
+  );
+}

--- a/src/features/program-templates/ConductingTemplateTab.tsx
+++ b/src/features/program-templates/ConductingTemplateTab.tsx
@@ -17,7 +17,8 @@ interface Props {
 }
 
 /** Conducting-copy template editor on /settings/templates/programs.
- *  Lexical WYSIWYG with variable chips — saves to the ward template
+ *  Lexical WYSIWYG with variable chips — same authoring surface as
+ *  the speaker + prayer letter editors, scoped to the ward template
  *  doc at `wards/{wardId}/templates/conductingProgram`. */
 export function ConductingTemplateTab({ onUsingDefaultChange }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId);


### PR DESCRIPTION
## Summary

Single-commit slice. Two visible changes plus some unwired groundwork for a follow-up:

- **Live data in conducting chips on the prepare page.** `ProgramPageEditor` gets an optional `vars` prop (same shape as `LetterPageEditor`'s `vars`). When provided, each variable's `sample` is swapped for the live value, so chips render real meeting data inside the editor. The conducting prepare tab now builds that bag with `buildMeetingVariables({ date, meeting, speakers, ward })` and passes it through. Empty fields fall back to the built-in sample so unfilled chips still read as guidance instead of going blank.
- **Templates page is unchanged in behavior.** `/settings/templates/programs` → Conducting copy intentionally omits `vars`; its bordeaux "Preview — variable chips show sample values" banner is correct there because no specific meeting is in scope.
- **Tab order swap.** Congregation comes first on both `/week/:date/prepare` and `/settings/templates/programs`. Default active tab is now `congregationProgram`.
- **Unwired groundwork.** `ConductingDesignPage1` / `Page2` / `Parts` + sample-data helpers — a static React mirror of the Conductors Page design from Claude Design. Currently not consumed anywhere; kept on-branch as a reference for a follow-up that adopts the design on the print + prepare paths.

## Test plan

- [ ] `/week/<sunday>/prepare` → Conducting tab shows this Sunday's real presider, conducting, pianist, chorister, hymns, and speakers in the chips (not "Bishop Reeves / hymn #19").
- [ ] Empty assignments still render the built-in sample text (e.g. unassigned hymn shows the placeholder, not a blank chip).
- [ ] `/settings/templates/programs` → Conducting copy is unchanged: Lexical editor, sample-data chips, bordeaux preview banner.
- [ ] Both `/week/<sunday>/prepare` and `/settings/templates/programs` open with **Congregation copy** as the active tab.
- [ ] `pnpm typecheck && pnpm lint && pnpm format:check && pnpm test` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)