### PR TITLE
Release: v0.24.0 — prepare-to-print + congregation bulletin layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ documented in [README.md](README.md#versioning--releases).
 
 ## [Unreleased]
 
+## [0.24.0] — 2026-05-04
+
+Print bulletin rethink. The congregation copy becomes a single fold-down-the-middle bulletin (cover left, program right) printed on landscape letter, replacing the old "two identical copies, cut down the middle". A new prepare-to-print page sits between the meeting form and the print routes, with per-Sunday saves on the meeting doc and ward-level defaults on the templates page. Conducting chips on the prepare page now render real meeting data instead of generic samples.
+
+### Added
+
+- **Prepare-to-print page (`/week/:date/prepare`).** Full-viewport editor between the meeting form and the print routes — Congregation copy first, Conducting copy second. Per-Sunday saves land on the meeting doc under `programs.{conducting|congregation}`; print routes prefer per-Sunday overrides and cascade to the ward template when absent. The two old direct-print buttons in the editor (in `PrintReadinessPanel` + `ProgramSaveBar`) collapse into a single "Prepare to print" CTA.
+- **New congregation bulletin layout.** `/print/:date/congregation` now prints **one** bulletin per landscape sheet — left half is a cover panel (church name eyebrow + ward name + image + announcements), right half is the brass-label program panel — instead of two identical cut-down-the-middle copies. Cover image URL, announcements, and program footer note are editable per-Sunday on the prepare page; defaults come from the ward template.
+- **Congregation copy template editor on `/settings/templates/programs`.** Form-and-preview UI (default cover image URL + default program footer note; no announcements, since those are per-week content) saves ward-level defaults under `ward.congregationDefaults`. Render time cascades meeting → ward → built-in default; explicit empty string at any layer is an "explicit hide" for the footer.
+- **Built-in default footer note** — *"Quietly ponder the prelude music 10 minutes before the meeting begins"*. Pre-fills the form on the prepare page so bishops have concrete text to tweak instead of an empty box.
+
+### Changed
+
+- **Conducting chips render this Sunday's real data on the prepare page.** New optional `vars` prop on `ProgramPageEditor` (mirrors `LetterPageEditor`'s `vars`) overrides each variable's `sample` with a live value. The conducting prepare tab passes `buildMeetingVariables({ date, meeting, speakers, ward })` so chips show the actual presider, hymns, and speakers — not "Bishop Reeves / hymn #19". The templates page intentionally still shows the built-in samples; its bordeaux preview banner explains why.
+- **Tab order swap.** Congregation copy is the first and default active tab on both `/week/:date/prepare` and `/settings/templates/programs`.
+- **Print pipeline fixes.** A global `@media print` rule that was silently hiding every print route's content (intended for the speaker-letter portal flow only) is now scoped with `:has([data-print-only-letter])` so it fires only when a letter portal is mounted. `PrintLayout` drops `max-w-4xl` + `print:flex print:justify-center` so bulletins fill the printable area instead of getting squeezed into a 9.3in column or overflowing off-page from vertical centering.
+- **Print CTAs open in a new tab** so the prepare page keeps its draft state when the bishop sends a sheet to the printer.
+
+### Fixed
+
+- **Meeting init / load failures surface in the UI.** The readiness panel previously got stuck on "Meeting not created yet" when the ward doc failed Zod parsing (e.g. a saved `null` field on a schema that only accepted `string | undefined`). A new `MeetingInitErrorBanner` shows the underlying error so the bishop can act on it; ward + meeting schemas now use `.nullish()` on optional string fields so cleared values written as `null` by the form helpers continue to parse cleanly.
+
+### Infrastructure
+
+- **Schema additions** — `meeting.coverImageUrl`, `meeting.programFooterNote`, `meeting.programs.{conducting|congregation}`, `ward.congregationDefaults.{coverImageUrl|programFooterNote}`. All nullish: undefined falls through the cascade; empty-string is "explicit hide" (footer); non-empty wins. No migration required — Zod accepts existing docs unchanged.
+
 ## [0.23.1] — 2026-05-03
 
 Patch release: mobile layout fix for the schedule's planning-open banner.
@@ -2575,7 +2601,8 @@ correctness fixes shipped to `steward-prod-65a36`.
 - Biome format check gated in CI; `design/` and `emulator-data/`
   excluded; tailwindDirectives enabled so `styles/index.css` parses.
 
-[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.23.1...HEAD
+[Unreleased]: https://github.com/aylabyuk/steward/compare/v0.24.0...HEAD
+[0.24.0]: https://github.com/aylabyuk/steward/releases/tag/v0.24.0
 [0.23.1]: https://github.com/aylabyuk/steward/releases/tag/v0.23.1
 [0.23.0]: https://github.com/aylabyuk/steward/releases/tag/v0.23.0
 [0.22.0]: https://github.com/aylabyuk/steward/releases/tag/v0.22.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "steward",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -20,6 +20,7 @@ import { ProgramTemplatesPage } from "./routes/templates-programs";
 import { SpeakerLetterTemplatePage } from "./routes/templates-speaker-letter";
 import { WardSettingsPage } from "./routes/ward-settings";
 import { Week } from "./routes/week";
+import { PreparePrintRoute } from "./routes/week-prepare";
 
 export const router = createBrowserRouter([
   {
@@ -61,6 +62,7 @@ export const router = createBrowserRouter([
       },
       { path: "/print/:date/congregation", element: <CongregationProgram /> },
       { path: "/print/:date/conducting", element: <ConductingProgram /> },
+      { path: "/week/:date/prepare", element: <PreparePrintRoute /> },
       {
         path: "/settings/templates/speaker-letter",
         element: <SpeakerLetterTemplatePage />,

--- a/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
+++ b/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
@@ -8,8 +8,8 @@ import { ConductingTemplateTab } from "@/features/program-templates/ConductingTe
 import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
 
 const TABS: { key: ProgramTemplateKey; label: string }[] = [
-  { key: "conductingProgram", label: "Conducting copy" },
   { key: "congregationProgram", label: "Congregation copy" },
+  { key: "conductingProgram", label: "Conducting copy" },
 ];
 
 /** /settings/templates/programs — chrome + tab switcher. The
@@ -21,7 +21,7 @@ const TABS: { key: ProgramTemplateKey; label: string }[] = [
 export function ProgramTemplatesPage(): React.ReactElement {
   useFullViewportLayout();
   const isMobile = useIsMobile();
-  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
+  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("congregationProgram");
   const [conductingUsingDefault, setConductingUsingDefault] = useState(false);
 
   if (isMobile) return <DesktopOnlyNotice title="Program templates" />;

--- a/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
+++ b/src/app/routes/templates-programs/ProgramTemplatesPage.tsx
@@ -1,95 +1,32 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router";
-import { SaveBar } from "@/components/ui/SaveBar";
-import { useCurrentMember } from "@/hooks/useCurrentMember";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useCurrentWardStore } from "@/stores/currentWardStore";
-import { friendlyWriteError } from "@/stores/saveStatusStore";
-import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
-import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
-import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
-import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { writeProgramTemplate } from "@/features/program-templates/utils/writeProgramTemplate";
+import type { ProgramTemplateKey } from "@/lib/types";
+import { CongregationTemplateTab } from "@/features/print/CongregationTemplateTab";
+import { ConductingTemplateTab } from "@/features/program-templates/ConductingTemplateTab";
 import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
-import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
 
 const TABS: { key: ProgramTemplateKey; label: string }[] = [
   { key: "conductingProgram", label: "Conducting copy" },
   { key: "congregationProgram", label: "Congregation copy" },
 ];
 
-/** /settings/templates/programs — WYSIWYG editor for both program
- *  copies. The editor IS the page; chrome (eyebrow + paper frame)
- *  renders around a single contenteditable. Tab switches between
- *  conducting + congregation copies, each with its own draft state. */
+/** /settings/templates/programs — chrome + tab switcher. The
+ *  conducting tab hosts a Lexical WYSIWYG editor (variable chips +
+ *  free-form layout); the congregation tab hosts a form-and-preview
+ *  editor for the bulletin's editable bits (cover image URL +
+ *  program footer note). Each tab manages its own dirty/save state
+ *  and SaveBar. */
 export function ProgramTemplatesPage(): React.ReactElement {
   useFullViewportLayout();
   const isMobile = useIsMobile();
-  const wardId = useCurrentWardStore((s) => s.wardId);
-  const me = useCurrentMember();
-  const canEdit = Boolean(me?.data.active);
-
   const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
-  const conducting = useProgramTemplate("conductingProgram");
-  const congregation = useProgramTemplate("congregationProgram");
-  const activeDoc = activeKey === "conductingProgram" ? conducting.data : congregation.data;
-  const initialJson = activeDoc?.editorStateJson ?? defaultProgramTemplate(activeKey);
-  const usingDefault = !activeDoc?.editorStateJson;
-
-  const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
-    conductingProgram: null,
-    congregationProgram: null,
-  });
-  const [pageStyleDraft, setPageStyleDraft] = useState<
-    Record<ProgramTemplateKey, LetterPageStyle | null>
-  >({ conductingProgram: null, congregationProgram: null });
-  const [editorKey, setEditorKey] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedAt, setSavedAt] = useState<string | null>(null);
-
-  // Reset the editor's mount key whenever the active tab flips so
-  // Lexical hydrates from the new tab's initial state.
-  useEffect(() => {
-    setEditorKey((k) => k + 1);
-  }, [activeKey]);
-
-  const editorJson = draft[activeKey] ?? initialJson;
-  const activePageStyle = pageStyleDraft[activeKey] ?? activeDoc?.pageStyle ?? null;
-  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
-  const styleDirty =
-    pageStyleDraft[activeKey] !== null &&
-    JSON.stringify(pageStyleDraft[activeKey]) !== JSON.stringify(activeDoc?.pageStyle ?? null);
-  const dirty = jsonDirty || styleDirty;
-
-  async function save() {
-    if (!wardId) return;
-    const jsonToSave = draft[activeKey] ?? initialJson;
-    const margins = activeDoc?.margins ?? DEFAULT_MARGINS[activeKey];
-    const pageStyleToSave = activePageStyle ?? null;
-    setSaving(true);
-    setError(null);
-    try {
-      await writeProgramTemplate(wardId, activeKey, jsonToSave, margins, pageStyleToSave);
-      setDraft((d) => ({ ...d, [activeKey]: null }));
-      setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
-    } catch (e) {
-      setError(friendlyWriteError(e));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function discard() {
-    setDraft((d) => ({ ...d, [activeKey]: null }));
-    setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-    setEditorKey((k) => k + 1);
-    setError(null);
-  }
+  const [conductingUsingDefault, setConductingUsingDefault] = useState(false);
 
   if (isMobile) return <DesktopOnlyNotice title="Program templates" />;
+
+  const showSystemDefaultPill = activeKey === "conductingProgram" && conductingUsingDefault;
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
@@ -106,7 +43,7 @@ export function ProgramTemplatesPage(): React.ReactElement {
           </h1>
         </div>
         <div className="flex items-center gap-2">
-          {usingDefault && (
+          {showSystemDefaultPill && (
             <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-brass-soft bg-brass-soft/30 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-brass-deep">
               <span aria-hidden>★</span>
               System default — save to lock in
@@ -132,30 +69,11 @@ export function ProgramTemplatesPage(): React.ReactElement {
         ))}
       </nav>
 
-      <div className="flex-1 min-h-0 pb-16">
-        <ProgramPageEditor
-          key={`${activeKey}-${editorKey}`}
-          variant={activeKey}
-          initialJson={editorJson}
-          pageStyle={activePageStyle}
-          showSampleNotice
-          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
-          onPageStyleChange={
-            canEdit ? (next) => setPageStyleDraft((d) => ({ ...d, [activeKey]: next })) : undefined
-          }
-          ariaLabel={TABS.find((t) => t.key === activeKey)!.label}
-          editorDisabled={!canEdit}
-        />
-      </div>
-
-      <SaveBar
-        dirty={dirty && canEdit}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={discard}
-        onSave={() => void save()}
-      />
+      {activeKey === "conductingProgram" ? (
+        <ConductingTemplateTab onUsingDefaultChange={setConductingUsingDefault} />
+      ) : (
+        <CongregationTemplateTab />
+      )}
     </main>
   );
 }

--- a/src/app/routes/week-prepare/PreparePrintRoute.tsx
+++ b/src/app/routes/week-prepare/PreparePrintRoute.tsx
@@ -1,0 +1,12 @@
+import { Navigate, useParams } from "react-router";
+import { PreparePrintView } from "@/features/print/PreparePrintView";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function PreparePrintRoute() {
+  const { date } = useParams<{ date: string }>();
+  if (!date || !ISO_DATE.test(date)) {
+    return <Navigate to="/schedule" replace />;
+  }
+  return <PreparePrintView date={date} />;
+}

--- a/src/app/routes/week-prepare/index.tsx
+++ b/src/app/routes/week-prepare/index.tsx
@@ -1,0 +1,1 @@
+export * from "./PreparePrintRoute";

--- a/src/features/meetings/MeetingInitErrorBanner.tsx
+++ b/src/features/meetings/MeetingInitErrorBanner.tsx
@@ -1,0 +1,62 @@
+interface Props {
+  error: Error;
+  /** Where the error came from — drives the headline copy. `init`
+   *  means `ensureMeetingDoc` threw (most often a rules denial on
+   *  the meeting/history transaction). `subscription` means the live
+   *  meeting doc subscription failed — usually a Zod parse error
+   *  against an existing-but-malformed doc, or a permission denial
+   *  on the read. */
+  source: "init" | "subscription";
+  onRetry: () => void;
+}
+
+const HEADLINE: Record<Props["source"], string> = {
+  init: "Couldn't initialize this Sunday's meeting.",
+  subscription: "Couldn't load this Sunday's meeting.",
+};
+
+/** Surfaces silent failures on the week editor so the bishop sees
+ *  what went wrong instead of an indefinite "Meeting not created
+ *  yet" placeholder. */
+export function MeetingInitErrorBanner({ error, source, onRetry }: Props) {
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex flex-wrap items-center gap-3 rounded-xl border border-bordeaux/40 bg-bordeaux/5 px-4 py-3"
+    >
+      <WarnIcon />
+      <div className="flex-1 min-w-0">
+        <p className="font-sans text-[13.5px] font-semibold text-bordeaux">{HEADLINE[source]}</p>
+        <p className="font-sans text-[12.5px] text-walnut-2 mt-1 break-words">{error.message}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="font-sans text-[13px] font-semibold px-3 py-1.5 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors whitespace-nowrap"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}
+
+function WarnIcon() {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.75"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="text-bordeaux shrink-0"
+      aria-hidden
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  );
+}

--- a/src/features/meetings/WeekEditor.tsx
+++ b/src/features/meetings/WeekEditor.tsx
@@ -11,6 +11,7 @@ import { cn } from "@/lib/cn";
 import { CancellationBanner } from "./CancellationBanner";
 import { defaultMeetingType, ensureMeetingDoc } from "./utils/ensureMeetingDoc";
 import { HistoryModal } from "./HistoryModal";
+import { MeetingInitErrorBanner } from "./MeetingInitErrorBanner";
 import { NO_MEETING_TYPES, TYPE_LABELS } from "./utils/meetingLabels";
 import { checkMeetingReadiness } from "./utils/readiness";
 import { PrintReadinessPanel } from "./program/PrintReadinessPanel";
@@ -44,6 +45,9 @@ export function WeekEditor({ date }: Props) {
   const upcoming = getUpcomingSundayIso(new Date(), timezone);
   const editable = date === upcoming;
 
+  const [initError, setInitError] = useState<Error | null>(null);
+  const [initRetryKey, setInitRetryKey] = useState(0);
+
   useEffect(() => {
     // Don't seed a meeting doc for a Sunday that isn't currently open
     // for planning — past meetings shouldn't be auto-created when a
@@ -51,8 +55,15 @@ export function WeekEditor({ date }: Props) {
     // when their week arrives.
     if (!wardId || !settingsLoaded || !editable) return;
     const nonMeetingSundays = settings.data?.settings.nonMeetingSundays ?? [];
-    void ensureMeetingDoc(wardId, date, nonMeetingSundays);
-  }, [wardId, date, settingsLoaded, editable, settings.data]);
+    setInitError(null);
+    ensureMeetingDoc(wardId, date, nonMeetingSundays).catch((err: unknown) => {
+      // Surface the failure to the bishop — without this, a denied
+      // permission or transaction error leaves the readiness panel
+      // stuck at "Meeting not created yet" with no way to recover.
+      console.error("ensureMeetingDoc failed", err);
+      setInitError(err instanceof Error ? err : new Error(String(err)));
+    });
+  }, [wardId, date, settingsLoaded, editable, settings.data, initRetryKey]);
 
   if (!wardId) return null;
 
@@ -82,6 +93,13 @@ export function WeekEditor({ date }: Props) {
               </div>
             ) : (
               <>
+                {(initError || meeting.error) && (
+                  <MeetingInitErrorBanner
+                    error={initError ?? meeting.error!}
+                    source={initError ? "init" : "subscription"}
+                    onRetry={() => setInitRetryKey((k) => k + 1)}
+                  />
+                )}
                 <PrintReadinessPanel date={date} report={report} />
                 <div className="flex justify-center mb-4 lg:hidden">
                   <StatusLegend />

--- a/src/features/meetings/program/PrintReadinessPanel.tsx
+++ b/src/features/meetings/program/PrintReadinessPanel.tsx
@@ -17,7 +17,7 @@ const PATH_PRINTER = "M6 9V2h12v7";
 const PATH_PRINTER_TRAY = "M6 14h12v7H6z";
 
 /** Top-of-editor panel that drives printing. When ready, it surfaces
- *  the two print-nav links front and centre; when not, it lists what
+ *  the Prepare-to-print CTA front and centre; when not, it lists what
  *  still needs filling so the bishop knows where to look. There's no
  *  approval workflow — readiness alone gates print. */
 export function PrintReadinessPanel({ date, report }: Props) {
@@ -61,18 +61,19 @@ function ReadyBody({ date }: { date: string }) {
       <p className="font-display text-[17px] font-semibold text-walnut tracking-[-0.005em] m-0 mb-2.5">
         All items assigned and confirmed.
       </p>
-      <div className="mt-1 flex flex-col sm:flex-row gap-2.5 flex-wrap">
-        <PrintLink
-          href={`/print/${date}/congregation`}
-          title="Congregation"
-          subtitle="Hand out to attendees — hymns, prayers, speakers with topics."
-        />
-        <PrintLink
-          href={`/print/${date}/conducting`}
-          title="Conducting"
-          subtitle="Conductor's desk copy — script cues + ward / stake business space."
-        />
-      </div>
+      <p className="font-serif italic text-[12.5px] text-walnut-3 m-0 mb-3">
+        Review both programs side-by-side, then print each one.
+      </p>
+      <Link
+        to={`/week/${date}/prepare`}
+        className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors font-sans text-[13px] font-semibold"
+      >
+        <Icon paths={[PATH_PRINTER, PATH_PRINTER_TRAY]} rect />
+        Prepare to print
+        <span aria-hidden className="ml-0.5">
+          →
+        </span>
+      </Link>
     </>
   );
 }
@@ -98,21 +99,6 @@ function MissingBody({ missing, unconfirmed }: { missing: string[]; unconfirmed:
         ))}
       </ul>
     </>
-  );
-}
-
-function PrintLink({ href, title, subtitle }: { href: string; title: string; subtitle: string }) {
-  return (
-    <Link
-      to={href}
-      className="flex-1 inline-flex flex-col gap-0.5 px-3.5 py-2.5 rounded-md border border-border-strong bg-chalk text-walnut hover:bg-parchment-2 hover:border-walnut-3 transition-colors"
-    >
-      <span className="font-sans text-[13px] font-semibold inline-flex items-center gap-1.5">
-        <Icon paths={[PATH_PRINTER, PATH_PRINTER_TRAY]} rect />
-        Print {title.toLowerCase()} program
-      </span>
-      <span className="font-serif italic text-[12px] text-walnut-3 leading-snug">{subtitle}</span>
-    </Link>
   );
 }
 

--- a/src/features/meetings/program/ProgramSaveBar.tsx
+++ b/src/features/meetings/program/ProgramSaveBar.tsx
@@ -6,63 +6,39 @@ interface Props {
   date: string;
   ready: boolean;
   remaining: number;
-  onPreview?: () => void;
 }
 
-/** Floating bottom save bar. Left: save indicator. Right: print
- *  shortcuts. Print buttons are always visible — disabled with a
+/** Floating bottom save bar. Left: save indicator. Right: prepare-to-
+ *  print shortcut. The button is always visible — disabled with a
  *  tooltip when the meeting still has unfilled items, so the bishop
  *  knows the action exists and what's blocking it. */
-export function ProgramSaveBar({ date, ready, remaining, onPreview }: Props) {
+export function ProgramSaveBar({ date, ready, remaining }: Props) {
   const blockedTitle = ready
     ? undefined
     : `Finish ${remaining} item${remaining === 1 ? "" : "s"} to print`;
 
   return (
     <div className="fixed bottom-0 left-0 right-0 z-30 bg-chalk border-t border-border shadow-[0_-6px_20px_rgba(35,24,21,0.08)]">
-      {/* Mobile: stack the indicator above the buttons so a long error
+      {/* Mobile: stack the indicator above the button so a long error
           message ("Couldn't save — Connection failed…") doesn't wrap
           inside a cramped row next to a big CTA. Desktop: everything
           on one line. */}
       <div className="flex flex-col gap-2 px-4 py-2.5 pb-[max(0.625rem,env(safe-area-inset-bottom))] sm:flex-row sm:items-center sm:gap-3.5 sm:px-8 sm:py-3 sm:pb-[max(0.75rem,env(safe-area-inset-bottom))]">
         <SaveIndicator />
         <span className="hidden sm:block sm:flex-1" />
-        <div className="flex items-center gap-2.5">
-          {onPreview && (
-            <button
-              type="button"
-              onClick={onPreview}
-              className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-transparent text-walnut-2 hover:bg-parchment-2 hover:text-walnut transition-colors"
-            >
-              Preview print
-            </button>
-          )}
-          <PrintLink
-            href={`/print/${date}/congregation`}
-            label="Congregation"
-            ready={ready}
-            blockedTitle={blockedTitle}
-          />
-          <PrintLink
-            href={`/print/${date}/conducting`}
-            label="Conducting"
-            ready={ready}
-            blockedTitle={blockedTitle}
-          />
-        </div>
+        <PrepareLink date={date} ready={ready} blockedTitle={blockedTitle} />
       </div>
     </div>
   );
 }
 
 interface LinkProps {
-  href: string;
-  label: string;
+  date: string;
   ready: boolean;
   blockedTitle: string | undefined;
 }
 
-function PrintLink({ href, label, ready, blockedTitle }: LinkProps) {
+function PrepareLink({ date, ready, blockedTitle }: LinkProps) {
   const className = cn(
     "font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border inline-flex items-center gap-1.5 transition-colors",
     ready
@@ -73,14 +49,14 @@ function PrintLink({ href, label, ready, blockedTitle }: LinkProps) {
     return (
       <span className={className} aria-disabled="true" title={blockedTitle}>
         <PrinterIcon />
-        Print {label.toLowerCase()}
+        Prepare to print
       </span>
     );
   }
   return (
-    <Link to={href} className={className}>
+    <Link to={`/week/${date}/prepare`} className={className}>
       <PrinterIcon />
-      Print {label.toLowerCase()}
+      Prepare to print
     </Link>
   );
 }

--- a/src/features/page-editor/ProgramPageEditor.tsx
+++ b/src/features/page-editor/ProgramPageEditor.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
 import {
   GROUP_LABEL,
   PROGRAM_VARIABLES,
+  type ProgramVariable,
 } from "@/features/program-templates/utils/programVariables";
 import { PAGE_EDITOR_BASE_NODES } from "./utils/pageEditorNodes";
 import { PageEditorComposer } from "./PageEditorComposer";
@@ -28,6 +29,13 @@ interface Props {
    *  are placeholders that resolve to real meeting data at print
    *  time. */
   showSampleNotice?: boolean;
+  /** Override the chip sample values with a real-data bag (e.g. from
+   *  `buildMeetingVariables`). Per-Sunday hosts (the prepare page)
+   *  pass this so chips render the actual meeting's presider, hymns,
+   *  and speakers — not the generic Bishop Reeves / hymn #19 stand-
+   *  ins. Template editors omit this and the chips fall back to the
+   *  built-in samples. */
+  vars?: Readonly<Record<string, string>>;
 }
 
 /** WYSIWYG program template editor — Word-style layout: full-width
@@ -44,6 +52,7 @@ export function ProgramPageEditor({
   ariaLabel,
   editorDisabled,
   showSampleNotice,
+  vars,
 }: Props) {
   const canvasVariant = variant === "conductingProgram" ? "conducting" : "congregation";
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -55,8 +64,20 @@ export function ProgramPageEditor({
       : zoomMode.kind === "fit-page"
         ? fits.fitPage
         : zoomMode.value;
+  // When a `vars` bag is supplied, swap each variable's `sample` for
+  // the live value so chips render real meeting data inside the
+  // editor (instead of the generic Bishop Reeves / hymn #19). Empty
+  // strings fall back to the built-in sample so an unfilled hymn
+  // still renders meaningful guidance text.
+  const effectiveVariables = useMemo<readonly ProgramVariable[]>(() => {
+    if (!vars) return PROGRAM_VARIABLES;
+    return PROGRAM_VARIABLES.map((v) => {
+      const live = vars[v.token];
+      return live && live.trim().length > 0 ? { ...v, sample: live } : v;
+    });
+  }, [vars]);
   return (
-    <VariableRegistryProvider variables={PROGRAM_VARIABLES} groupLabels={GROUP_LABEL}>
+    <VariableRegistryProvider variables={effectiveVariables} groupLabels={GROUP_LABEL}>
       <div
         className={`flex flex-col h-full w-full ${editorDisabled ? "opacity-60 pointer-events-none" : ""}`}
       >
@@ -71,7 +92,7 @@ export function ProgramPageEditor({
           pageToolbar={
             <PageToolbar
               slashCommands={PROGRAM_SLASH_COMMANDS}
-              variables={PROGRAM_VARIABLES}
+              variables={effectiveVariables}
               variableGroupLabels={GROUP_LABEL}
               pageStyle={pageStyle}
               zoom={zoom}

--- a/src/features/prayers/utils/prayerActions.ts
+++ b/src/features/prayers/utils/prayerActions.ts
@@ -1,4 +1,4 @@
-import { deleteField, doc, serverTimestamp, setDoc, writeBatch } from "firebase/firestore";
+import { doc, serverTimestamp, setDoc, writeBatch } from "firebase/firestore";
 import { ensureMeetingDoc } from "@/features/meetings/utils/ensureMeetingDoc";
 import { db } from "@/lib/firebase";
 import type { InvitationStatus, NonMeetingSunday, PrayerRole } from "@/lib/types";
@@ -128,9 +128,13 @@ export async function clearPrayerParticipant(
     const meetingRef = doc(db, "wards", wardId, "meetings", date);
     const batch = writeBatch(db);
     batch.delete(participantRef);
+    // Use `person: null` rather than `deleteField()` so the resulting
+    // assignment object stays parseable by `assignmentSchema` — a
+    // missing `person` key produces a doc that fails Zod parse and
+    // surfaces as "Meeting not created yet" on the week editor.
     batch.set(
       meetingRef,
-      { [MEETING_FIELD[role]]: { person: deleteField(), confirmed: false } },
+      { [MEETING_FIELD[role]]: { person: null, confirmed: false } },
       { merge: true },
     );
     await batch.commit();

--- a/src/features/print/ConductingDesignPage1.tsx
+++ b/src/features/print/ConductingDesignPage1.tsx
@@ -1,0 +1,151 @@
+import type { ReactNode } from "react";
+import {
+  DividerStrong,
+  DividerThin,
+  EmDash,
+  Masthead,
+  SectionLabel,
+  Sheet,
+  SheetFooter,
+} from "./ConductingDesignParts";
+
+export interface AgendaCue {
+  text: string;
+}
+export interface AgendaSub {
+  label: string;
+  value: ReactNode;
+}
+export interface AgendaItem {
+  num: string;
+  label: string;
+  value: ReactNode;
+  sub?: AgendaSub | undefined;
+  cue?: AgendaCue | undefined;
+}
+export interface Page1Props {
+  wardName: string;
+  dateLong: string;
+  timeText: string;
+  presiding: string;
+  conducting: string;
+  pianist: string;
+  chorister: string;
+  visitors: string;
+  agenda: AgendaItem[];
+  footerLeft: string;
+}
+
+/** Page 1 of the conducting copy — masthead, officers grid, numbered
+ *  agenda with sub-rows + italic stage cues, footer with ornament.
+ *  Pixel-mirrors the Conductors Page.html design from Claude Design. */
+export function ConductingDesignPage1(p: Page1Props) {
+  return (
+    <Sheet>
+      <Masthead
+        eyebrow="Conducting copy"
+        title="Sacrament meeting"
+        meta={[p.wardName, p.dateLong, p.timeText]}
+      />
+      <DividerStrong />
+      <Officers
+        presiding={p.presiding}
+        conducting={p.conducting}
+        pianist={p.pianist}
+        chorister={p.chorister}
+        visitors={p.visitors}
+      />
+      <DividerThin />
+      <Agenda items={p.agenda} />
+      <SheetFooter left={p.footerLeft} right="Conducting copy" />
+    </Sheet>
+  );
+}
+
+interface OfficersProps {
+  presiding: string;
+  conducting: string;
+  pianist: string;
+  chorister: string;
+  visitors: string;
+}
+
+function Officers({ presiding, conducting, pianist, chorister, visitors }: OfficersProps) {
+  return (
+    <section>
+      <SectionLabel>Officers</SectionLabel>
+      <div className="grid grid-cols-2 gap-x-9 gap-y-2 text-[16px] leading-[1.5] text-ink">
+        <OfficerRow role="Presiding" name={presiding} />
+        <OfficerRow role="Conducting" name={conducting} />
+        <OfficerRow role="Pianist" name={pianist} />
+        <OfficerRow role="Chorister" name={chorister} />
+        <div className="col-span-2">
+          <OfficerRow role="Visitors" name={visitors} />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function OfficerRow({ role, name }: { role: string; name: string }) {
+  return (
+    <div>
+      <span className="font-semibold">{role}</span>
+      <span className="mx-1.5 text-walnut-3">·</span>
+      <span>{name}</span>
+    </div>
+  );
+}
+
+function Agenda({ items }: { items: AgendaItem[] }) {
+  return (
+    <section>
+      <SectionLabel>Order of meeting</SectionLabel>
+      <div className="mt-1">
+        {items.map((item, i) => (
+          <AgendaRow key={item.num} item={item} isLast={i === items.length - 1} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function AgendaRow({ item, isLast }: { item: AgendaItem; isLast: boolean }) {
+  const noBorder = isLast && !item.sub && !item.cue;
+  return (
+    <>
+      <div
+        className={`grid grid-cols-[36px_1fr] items-baseline gap-x-1 py-[7px] ${
+          noBorder ? "" : "border-b border-dotted border-[#e3d7be]"
+        }`}
+      >
+        <div className="font-serif font-semibold text-[22px] leading-none text-brass-deep pt-0.5">
+          {item.num}
+        </div>
+        <div className="text-[17px] leading-[1.45] text-ink">
+          <span className="font-semibold">{item.label}</span>
+          <EmDash />
+          {item.value}
+        </div>
+      </div>
+      {item.sub && (
+        <div className="grid grid-cols-[36px_1fr] gap-x-1 pt-1 pb-1.5">
+          <div />
+          <div className="text-[16px] text-ink">
+            <span className="font-semibold">{item.sub.label}</span>
+            <EmDash />
+            {item.sub.value}
+          </div>
+        </div>
+      )}
+      {item.cue && (
+        <div className="grid grid-cols-[36px_1fr] gap-x-1 pt-0.5 pb-1">
+          <div />
+          <div className="font-serif italic text-[14.5px] leading-[1.45] text-walnut-3 border-l-2 border-brass-soft pl-2.5 -ml-0.5">
+            {item.cue.text}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/features/print/ConductingDesignPage2.tsx
+++ b/src/features/print/ConductingDesignPage2.tsx
@@ -1,0 +1,113 @@
+import {
+  DividerStrong,
+  DividerThin,
+  Masthead,
+  SectionLabel,
+  Sheet,
+  SheetFooter,
+} from "./ConductingDesignParts";
+
+export interface Page2Props {
+  wardName: string;
+  dateLong: string;
+  announcements: string;
+  wardBusiness: string;
+  stakeBusiness: string;
+  footerLeft: string;
+}
+
+interface SectionConfig {
+  step: string;
+  label: string;
+  body: string;
+  emptyHint: string;
+}
+
+/** Page 2 of the conducting copy — long-form items pointed at from
+ *  page 1's "See page 2" rows. Per current scope, the section bodies
+ *  are simple plain text from the meeting doc (announcements, ward
+ *  business, stake business). The structured numbered list, calling
+ *  list, and stage-cue script blocks from the original mockup are
+ *  deferred — the headers + step tags stay so the document still
+ *  reads as the matching second sheet. */
+export function ConductingDesignPage2(p: Page2Props) {
+  const sections: SectionConfig[] = [
+    {
+      step: "Step 1",
+      label: "Announcements",
+      body: p.announcements,
+      emptyHint: "Per-week announcements appear here when filled in on the prepare page.",
+    },
+    {
+      step: "Step 3",
+      label: "Ward business",
+      body: p.wardBusiness,
+      emptyHint: "Releases, sustainings, and other ward business — typed in during planning.",
+    },
+    {
+      step: "Step 3",
+      label: "Stake business",
+      body: p.stakeBusiness,
+      emptyHint: "Stake-level items, e.g. handing time over to a high councillor.",
+    },
+  ];
+
+  return (
+    <Sheet>
+      <Masthead
+        eyebrow="Conducting copy · Page 2"
+        title="Notes & long-form items"
+        meta={[p.wardName, p.dateLong]}
+      />
+      <DividerStrong />
+      {sections.map((section, i) => (
+        <Section
+          key={section.label}
+          step={section.step}
+          label={section.label}
+          body={section.body}
+          emptyHint={section.emptyHint}
+          showThinDivider={i > 0}
+        />
+      ))}
+      <SheetFooter left={p.footerLeft} right="Conducting copy" />
+    </Sheet>
+  );
+}
+
+interface SectionProps extends SectionConfig {
+  showThinDivider: boolean;
+}
+
+function Section({ step, label, body, emptyHint, showThinDivider }: SectionProps) {
+  return (
+    <>
+      {showThinDivider && <DividerThin />}
+      <section className="mb-[18px]">
+        <div className="flex items-baseline gap-3 mb-[14px]">
+          <span className="font-mono text-[10px] tracking-[0.16em] uppercase text-white bg-brass-deep px-2 py-[2px] rounded-[3px]">
+            {step}
+          </span>
+          <SectionLabel>{label}</SectionLabel>
+        </div>
+        <Body body={body} emptyHint={emptyHint} />
+      </section>
+    </>
+  );
+}
+
+function Body({ body, emptyHint }: { body: string; emptyHint: string }) {
+  const trimmed = body.trim();
+  if (trimmed.length === 0) {
+    return (
+      <p className="font-serif italic text-[14.5px] leading-[1.45] text-walnut-3 border-l-2 border-brass-soft pl-2.5 m-0">
+        {emptyHint}
+      </p>
+    );
+  }
+  return (
+    <p className="font-serif text-[16px] leading-[1.6] text-ink whitespace-pre-wrap m-0">
+      {trimmed}
+    </p>
+  );
+}

--- a/src/features/print/ConductingDesignParts.tsx
+++ b/src/features/print/ConductingDesignParts.tsx
@@ -1,0 +1,80 @@
+import type { ReactNode } from "react";
+
+/** Shared visual primitives for the conducting copy design — used by
+ *  both Page 1 (numbered agenda) and Page 2 (long-form notes). Maps
+ *  Steward design tokens onto the typography vocabulary from
+ *  Conductors Page.html: Newsreader serif body, IBM Plex Mono
+ *  eyebrows, walnut/brass-deep ink, hairline rules in #d3c6ad. */
+
+/** A single 8.5×11 white sheet at print scale. The on-screen preview
+ *  centres it on a parchment surround; print routes drop the
+ *  shadow and let `@page` margins handle the bleed. */
+export function Sheet({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="relative bg-white shadow-[0_2px_6px_rgba(0,0,0,0.06),0_18px_50px_rgba(0,0,0,0.12)] mx-auto print:shadow-none"
+      style={{ width: "8.5in", minHeight: "11in", padding: "0.85in" }}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function Masthead({
+  eyebrow,
+  title,
+  meta,
+}: {
+  eyebrow: string;
+  title: string;
+  meta: string[];
+}) {
+  return (
+    <header className="text-center mb-[22px]">
+      <p className="font-mono text-[11px] tracking-[0.22em] uppercase text-brass-deep m-0 mb-2.5">
+        {eyebrow}
+      </p>
+      <h1 className="font-serif italic font-medium text-[36px] leading-none text-ink m-0 mb-3 tracking-[-0.005em]">
+        {title}
+      </h1>
+      <p className="font-mono text-[12.5px] tracking-[0.06em] text-walnut-2 m-0">
+        {meta.map((part, i) => (
+          <span key={part}>
+            {i > 0 && <span className="mx-2.5 text-walnut-3">·</span>}
+            <span style={{ whiteSpace: "nowrap" }}>{part}</span>
+          </span>
+        ))}
+      </p>
+    </header>
+  );
+}
+
+export function SectionLabel({ children }: { children: ReactNode }) {
+  return (
+    <p className="font-mono text-[11px] tracking-[0.20em] uppercase text-brass-deep m-0 mb-2.5">
+      {children}
+    </p>
+  );
+}
+
+export function DividerStrong() {
+  return <hr className="border-0 border-t-[1.5px] border-walnut mt-[18px] mb-[16px]" />;
+}
+
+export function DividerThin() {
+  return <hr className="border-0 border-t border-[#d3c6ad] my-[14px]" />;
+}
+
+export function SheetFooter({ left, right }: { left: string; right: string }) {
+  return (
+    <footer className="mt-7 pt-3 border-t border-[#d3c6ad] flex justify-between items-baseline font-mono text-[10.5px] tracking-[0.10em] uppercase text-walnut-3">
+      <span>{left}</span>
+      <span className="tracking-[0.4em] text-brass-deep">✦ ✦ ✦</span>
+      <span>{right}</span>
+    </footer>
+  );
+}
+
+export function EmDash() {
+  return <span className="mx-1.5 text-walnut-3">—</span>;
+}

--- a/src/features/print/ConductingPrepareTab.tsx
+++ b/src/features/print/ConductingPrepareTab.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SaveBar } from "@/components/ui/SaveBar";
-import { useMeeting } from "@/hooks/useMeeting";
+import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
+import { useWardSettings } from "@/hooks/useWardSettings";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
@@ -8,6 +9,7 @@ import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
 import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
 import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
 import type { LetterPageStyle } from "@/lib/types";
+import { buildMeetingVariables } from "./utils/buildMeetingVariables";
 import { writeMeetingProgram } from "./utils/writeMeetingProgram";
 
 interface Props {
@@ -23,6 +25,8 @@ const KEY = "conductingProgram";
 export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId);
   const meeting = useMeeting(date);
+  const speakers = useSpeakers(date);
+  const ward = useWardSettings();
   const tpl = useProgramTemplate(KEY);
 
   const [draft, setDraft] = useState<string | null>(null);
@@ -37,6 +41,22 @@ export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
     override?.editorStateJson ?? tpl.data?.editorStateJson ?? defaultProgramTemplate(KEY);
   const initialPageStyle = override?.pageStyle ?? tpl.data?.pageStyle ?? null;
   const margins = override?.margins ?? tpl.data?.margins ?? DEFAULT_MARGINS[KEY];
+
+  // Build the live variable bag so chips render *this* Sunday's
+  // presider, hymns, and speakers — not the generic template
+  // samples. Falls through to the built-in samples for any field
+  // that's still empty (e.g. an unassigned speaker), so the editor
+  // never shows a literally blank chip.
+  const liveVars = useMemo(
+    () =>
+      buildMeetingVariables({
+        date,
+        meeting: meeting.data ?? null,
+        speakers: speakers.data,
+        ward: ward.data ?? null,
+      }),
+    [date, meeting.data, speakers.data, ward.data],
+  );
 
   useEffect(() => {
     onUsingOverrideChange?.(Boolean(override));
@@ -80,6 +100,7 @@ export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
           variant={KEY}
           initialJson={editorJson}
           pageStyle={activePageStyle}
+          vars={liveVars}
           onChange={setDraft}
           onPageStyleChange={setPageStyleDraft}
           ariaLabel="Conducting copy"

--- a/src/features/print/ConductingPrepareTab.tsx
+++ b/src/features/print/ConductingPrepareTab.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useMeeting } from "@/hooks/useMeeting";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
+import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
+import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
+import type { LetterPageStyle } from "@/lib/types";
+import { writeMeetingProgram } from "./utils/writeMeetingProgram";
+
+interface Props {
+  date: string;
+  onUsingOverrideChange?: (using: boolean) => void;
+}
+
+const KEY = "conductingProgram";
+
+/** Conducting tab on /week/:date/prepare. WYSIWYG Lexical editor with
+ *  per-Sunday save under `meeting.programs.conducting`. Initial state
+ *  cascades: per-Sunday saved → ward template → built-in default. */
+export function ConductingPrepareTab({ date, onUsingOverrideChange }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const meeting = useMeeting(date);
+  const tpl = useProgramTemplate(KEY);
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [pageStyleDraft, setPageStyleDraft] = useState<LetterPageStyle | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const override = meeting.data?.programs?.conducting;
+  const initialJson =
+    override?.editorStateJson ?? tpl.data?.editorStateJson ?? defaultProgramTemplate(KEY);
+  const initialPageStyle = override?.pageStyle ?? tpl.data?.pageStyle ?? null;
+  const margins = override?.margins ?? tpl.data?.margins ?? DEFAULT_MARGINS[KEY];
+
+  useEffect(() => {
+    onUsingOverrideChange?.(Boolean(override));
+  }, [override, onUsingOverrideChange]);
+
+  const editorJson = draft ?? initialJson;
+  const activePageStyle = pageStyleDraft ?? initialPageStyle;
+  const jsonDirty = draft !== null && draft !== initialJson;
+  const styleDirty =
+    pageStyleDraft !== null && JSON.stringify(pageStyleDraft) !== JSON.stringify(initialPageStyle);
+  const dirty = jsonDirty || styleDirty;
+
+  async function save() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMeetingProgram(wardId, date, KEY, draft ?? initialJson, margins, activePageStyle);
+      setDraft(null);
+      setPageStyleDraft(null);
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setDraft(null);
+    setPageStyleDraft(null);
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="flex-1 min-h-0 pb-16">
+        <ProgramPageEditor
+          key={`conducting-${editorKey}`}
+          variant={KEY}
+          initialJson={editorJson}
+          pageStyle={activePageStyle}
+          onChange={setDraft}
+          onPageStyleChange={setPageStyleDraft}
+          ariaLabel="Conducting copy"
+        />
+      </div>
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </>
+  );
+}

--- a/src/features/print/ConductingProgram.tsx
+++ b/src/features/print/ConductingProgram.tsx
@@ -1,15 +1,13 @@
-import { useParams, Navigate, Link } from "react-router";
+import { useParams, Navigate } from "react-router";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
-import { checkMeetingReadiness, type ReadinessReport } from "@/features/meetings/utils/readiness";
+import { checkMeetingReadiness } from "@/features/meetings/utils/readiness";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import { ConductingProgramBody } from "./ConductingProgramBody";
+import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
-import { buildMeetingVariables } from "./utils/buildMeetingVariables";
-import { LegacyConductingCopy } from "./LegacyConductingCopy";
-import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -30,86 +28,29 @@ export function ConductingProgram() {
   const meetingType = m?.meetingType ?? defaultMeetingType(date, nonMeeting);
   const report = checkMeetingReadiness(m, speakers.data, meetingType);
 
-  if (ready && !report.ready) return <NotReady date={date} report={report} />;
-
-  const wardName = ward.data?.name ?? "our ward";
-  const dateLong = formatLongDate(date);
-
-  const header = (
-    <header className="mb-3 border-b-2 border-walnut pb-2">
-      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
-        Conductor's copy · {wardName}
-      </div>
-      <h1 className="font-display text-[22px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
-        {dateLong}
-      </h1>
-    </header>
-  );
-
-  // Template-driven rendering closes the loop between the WYSIWYG
-  // editor and the printed output. Falls back to the hardcoded
-  // layout for wards that haven't customized yet.
-  if (template.data?.editorStateJson) {
-    const variables = buildMeetingVariables({
-      date,
-      meeting: m ?? null,
-      speakers: speakers.data,
-      ward: ward.data ?? null,
-    });
+  if (ready && !report.ready) {
     return (
-      <PrintLayout ready={ready && report.ready} dense>
-        {header}
-        {renderProgramState(template.data.editorStateJson, variables)}
-      </PrintLayout>
+      <div className="min-h-screen grid place-items-center bg-parchment p-8">
+        <NotReadyBlock date={date} report={report} />
+      </div>
     );
   }
 
-  const speakerList = orderedSpeakers(speakers.data);
-  const sequence = speakerSequence(speakerList, m?.mid);
-  const visitors = (m?.visitors ?? []).filter((v) => v.name.trim().length > 0);
+  // Per-Sunday override (saved from /week/:date/prepare) takes
+  // precedence over the ward-level template — the bishopric tailored
+  // this Sunday's program for this meeting.
+  const override = m?.programs?.conducting;
+  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
 
   return (
     <PrintLayout ready={ready && report.ready} dense>
-      {header}
-      <LegacyConductingCopy
-        m={m ?? null}
-        wardName={wardName}
-        dateLong={dateLong}
-        speakerList={speakerList}
-        sequence={sequence}
-        visitors={visitors}
+      <ConductingProgramBody
+        date={date}
+        meeting={m ?? null}
+        speakers={speakers.data}
+        ward={ward.data ?? null}
+        templateJson={templateJson}
       />
     </PrintLayout>
-  );
-}
-
-function NotReady({ date, report }: { date: string; report: ReadinessReport }) {
-  const remaining = report.missing.length + report.unconfirmed.length;
-  return (
-    <div className="min-h-screen grid place-items-center bg-parchment p-8 text-center">
-      <div className="max-w-lg">
-        <p className="font-display text-[20px] text-walnut mb-2">Not ready to print</p>
-        <p className="font-serif italic text-[13.5px] text-walnut-2 mb-4">
-          The program for <strong>{formatLongDate(date)}</strong> still has {remaining} item
-          {remaining === 1 ? "" : "s"} to fill before it's ready.
-        </p>
-        <ul className="text-left inline-block list-disc text-[13.5px] text-walnut-2 mb-4 max-h-60 overflow-y-auto">
-          {report.missing.map((m) => (
-            <li key={`m-${m}`}>{m}</li>
-          ))}
-          {report.unconfirmed.map((u) => (
-            <li key={`u-${u}`}>{u}</li>
-          ))}
-        </ul>
-        <div>
-          <Link
-            to={`/week/${date}`}
-            className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep transition-colors"
-          >
-            Back to the program
-          </Link>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/src/features/print/ConductingProgramBody.tsx
+++ b/src/features/print/ConductingProgramBody.tsx
@@ -1,0 +1,62 @@
+import type { WithId } from "@/hooks/_sub";
+import type { SacramentMeeting, Speaker, Ward } from "@/lib/types";
+import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
+import { LegacyConductingCopy } from "./LegacyConductingCopy";
+import { buildMeetingVariables } from "./utils/buildMeetingVariables";
+import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
+
+interface Props {
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: readonly WithId<Speaker>[];
+  ward: Ward | null;
+  templateJson: string | null;
+}
+
+/** Pure rendering of the conducting copy: header + (template path |
+ *  legacy fallback). No data loading, no readiness gate, no print
+ *  trigger. Both the print route and the on-screen prepare-to-print
+ *  preview render through this. */
+export function ConductingProgramBody({ date, meeting, speakers, ward, templateJson }: Props) {
+  const wardName = ward?.name ?? "our ward";
+  const dateLong = formatLongDate(date);
+
+  const header = (
+    <header className="mb-3 border-b-2 border-walnut pb-2">
+      <div className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        Conductor's copy · {wardName}
+      </div>
+      <h1 className="font-display text-[22px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
+        {dateLong}
+      </h1>
+    </header>
+  );
+
+  if (templateJson) {
+    const variables = buildMeetingVariables({ date, meeting, speakers, ward });
+    return (
+      <>
+        {header}
+        {renderProgramState(templateJson, variables)}
+      </>
+    );
+  }
+
+  const speakerList = orderedSpeakers(speakers);
+  const sequence = speakerSequence(speakerList, meeting?.mid);
+  const visitors = (meeting?.visitors ?? []).filter((v) => v.name.trim().length > 0);
+
+  return (
+    <>
+      {header}
+      <LegacyConductingCopy
+        m={meeting}
+        wardName={wardName}
+        dateLong={dateLong}
+        speakerList={speakerList}
+        sequence={sequence}
+        visitors={visitors}
+      />
+    </>
+  );
+}

--- a/src/features/print/CongregationCoverForm.tsx
+++ b/src/features/print/CongregationCoverForm.tsx
@@ -1,0 +1,74 @@
+import { DEFAULT_PROGRAM_FOOTER_NOTE } from "./utils/programFooter";
+
+interface Props {
+  imageUrl: string;
+  announcements: string;
+  footerNote: string;
+  onImageChange: (next: string) => void;
+  onAnnouncementsChange: (next: string) => void;
+  onFooterNoteChange: (next: string) => void;
+}
+
+/** Inline form for the editable bits of the congregation prepare
+ *  page — rendered above the live preview. Cover image + announcements
+ *  populate the left panel; footer note prints at the bottom of the
+ *  right (program) panel. */
+export function CongregationCoverForm({
+  imageUrl,
+  announcements,
+  footerNote,
+  onImageChange,
+  onAnnouncementsChange,
+  onFooterNoteChange,
+}: Props) {
+  return (
+    <div className="mx-auto max-w-[11in] grid gap-4 mb-1 rounded-md border border-border bg-chalk px-4 py-3 sm:grid-cols-2">
+      <Field label="Cover image URL">
+        <input
+          type="url"
+          value={imageUrl}
+          onChange={(e) => onImageChange(e.target.value)}
+          placeholder="https://… (optional)"
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+      <Field label="Announcements">
+        <textarea
+          value={announcements}
+          onChange={(e) => onAnnouncementsChange(e.target.value)}
+          rows={3}
+          placeholder="One announcement per line."
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 resize-y focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+      <Field label="Program footer note" className="sm:col-span-2">
+        <input
+          type="text"
+          value={footerNote}
+          onChange={(e) => onFooterNoteChange(e.target.value)}
+          placeholder={DEFAULT_PROGRAM_FOOTER_NOTE}
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className={`flex flex-col gap-1 ${className ?? ""}`}>
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/src/features/print/CongregationCoverPanel.tsx
+++ b/src/features/print/CongregationCoverPanel.tsx
@@ -1,0 +1,65 @@
+interface Props {
+  wardName: string;
+  dateLong: string;
+  announcements: string;
+  imageUrl: string | null;
+}
+
+/** Left half of the printed congregation bulletin. Pairs with
+ *  `LegacyCongregationCopy` (the program panel on the right). The
+ *  bulletin folds down the middle — this panel becomes the cover
+ *  when folded. Uses a vertical flex column so the image expands to
+ *  fill the page height, anchoring the header at the top and
+ *  announcements at the bottom. Requires the parent grid item to
+ *  have an explicit height (set in the print route + prepare page). */
+export function CongregationCoverPanel({ wardName, dateLong, announcements, imageUrl }: Props) {
+  const trimmed = announcements.trim();
+  return (
+    <div className="flex flex-col h-full">
+      <header className="text-center mb-4 shrink-0">
+        <p className="font-mono text-[9.5px] uppercase tracking-[0.18em] text-walnut-3 m-0">
+          The Church of Jesus Christ of Latter-day Saints
+        </p>
+        <h2 className="font-display text-[24px] font-semibold text-walnut tracking-[-0.01em] m-0 mt-1">
+          {wardName}
+        </h2>
+        <p className="font-serif italic text-[12px] text-walnut-3 m-0 mt-1">{dateLong}</p>
+      </header>
+
+      <CoverImage imageUrl={imageUrl} />
+
+      <section className="mt-4 shrink-0">
+        <h3 className="font-display text-[13px] font-semibold text-walnut border-b border-brass-soft pb-1 mb-2">
+          Announcements
+        </h3>
+        {trimmed.length > 0 ? (
+          <p className="font-serif text-[12.5px] text-walnut-2 whitespace-pre-wrap leading-relaxed m-0">
+            {trimmed}
+          </p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <span className="print-blank block w-full" />
+            <span className="print-blank block w-full" />
+            <span className="print-blank block w-full" />
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}
+
+function CoverImage({ imageUrl }: { imageUrl: string | null }) {
+  if (imageUrl) {
+    return (
+      <div className="flex-1 min-h-0 flex items-center justify-center my-3">
+        {/* biome-ignore lint/performance/noImgElement: print output, not Next.js */}
+        <img src={imageUrl} alt="" className="max-w-full max-h-full object-contain" />
+      </div>
+    );
+  }
+  return (
+    <div className="flex-1 min-h-0 grid place-items-center my-3 border border-dashed border-walnut-3/40 rounded-md bg-parchment-2/30 print:bg-transparent">
+      <span className="font-serif italic text-[12px] text-walnut-3">Image (optional)</span>
+    </div>
+  );
+}

--- a/src/features/print/CongregationPrepareTab.tsx
+++ b/src/features/print/CongregationPrepareTab.tsx
@@ -1,0 +1,142 @@
+import { useState } from "react";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
+import { useWardSettings } from "@/hooks/useWardSettings";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
+import { CongregationCoverForm } from "./CongregationCoverForm";
+import { CongregationCoverPanel } from "./CongregationCoverPanel";
+import { CongregationProgramBody } from "./CongregationProgramBody";
+import { formatLongDate } from "./utils/programData";
+import { DEFAULT_PROGRAM_FOOTER_NOTE } from "./utils/programFooter";
+import { writeMeetingCover } from "./utils/writeMeetingCover";
+
+interface Props {
+  date: string;
+}
+
+/** Congregation tab on /week/:date/prepare. Live preview of what
+ *  prints — cover panel on the left, program panel on the right —
+ *  with two inline form controls for the editable bits: cover image
+ *  URL and announcements. Everything else (presiding, hymns, etc.)
+ *  is auto-populated from the meeting doc and edited back in
+ *  /week/:date. */
+export function CongregationPrepareTab({ date }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const ward = useWardSettings();
+  const meeting = useMeeting(date);
+  const speakers = useSpeakers(date);
+  const template = useProgramTemplate("congregationProgram");
+
+  const [imageDraft, setImageDraft] = useState<string | null>(null);
+  const [announceDraft, setAnnounceDraft] = useState<string | null>(null);
+  const [footerDraft, setFooterDraft] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  const initialImage = meeting.data?.coverImageUrl ?? "";
+  const initialAnnounce = meeting.data?.announcements ?? "";
+  // Pre-fill with the built-in default when nothing's saved — gives
+  // the bishop concrete text to tweak instead of an empty box. The
+  // form stays "clean" (dirty stays false) until they actually edit.
+  const initialFooter = meeting.data?.programFooterNote ?? DEFAULT_PROGRAM_FOOTER_NOTE;
+  const imageUrl = imageDraft ?? initialImage;
+  const announcements = announceDraft ?? initialAnnounce;
+  const footerNote = footerDraft ?? initialFooter;
+  const dirty = imageDraft !== null || announceDraft !== null || footerDraft !== null;
+
+  const wardName = ward.data?.name ?? "Ward";
+  const dateLong = formatLongDate(date);
+  const override = meeting.data?.programs?.congregation;
+  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
+
+  async function save() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMeetingCover(wardId, date, {
+        coverImageUrl: imageUrl.trim().length > 0 ? imageUrl.trim() : null,
+        announcements,
+        programFooterNote: footerNote.trim().length > 0 ? footerNote.trim() : null,
+      });
+      setImageDraft(null);
+      setAnnounceDraft(null);
+      setFooterDraft(null);
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setImageDraft(null);
+    setAnnounceDraft(null);
+    setFooterDraft(null);
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="flex-1 min-h-0 overflow-auto bg-parchment py-6 px-4 sm:px-8 pb-24">
+        <CongregationCoverForm
+          imageUrl={imageUrl}
+          announcements={announcements}
+          footerNote={footerNote}
+          onImageChange={(v) => setImageDraft(v)}
+          onAnnouncementsChange={(v) => setAnnounceDraft(v)}
+          onFooterNoteChange={(v) => setFooterDraft(v)}
+        />
+
+        {/* Page sheet — letter landscape (11" × 8.5") at print scale.
+            What you see here is what the printer puts on the paper. */}
+        <div
+          className="mx-auto mt-6 bg-chalk shadow-[0_4px_24px_rgba(35,24,21,0.08)] border border-border rounded-sm"
+          style={{ width: "11in", height: "8.5in" }}
+        >
+          <div className="relative grid grid-cols-2 h-full">
+            <div className="px-[0.35in] py-[0.35in]">
+              <CongregationCoverPanel
+                wardName={wardName}
+                dateLong={dateLong}
+                announcements={announcements}
+                imageUrl={imageUrl.trim().length > 0 ? imageUrl.trim() : null}
+              />
+            </div>
+            <div
+              aria-hidden
+              className="pointer-events-none absolute inset-y-0 left-1/2 border-l border-dashed border-walnut-3"
+            />
+            <div className="px-[0.35in] py-[0.35in]">
+              <CongregationProgramBody
+                date={date}
+                meeting={meeting.data ?? null}
+                speakers={speakers.data}
+                ward={ward.data ?? null}
+                templateJson={templateJson}
+                footerNoteOverride={footerNote}
+              />
+            </div>
+          </div>
+        </div>
+        <p className="mt-2 mb-3 text-center font-serif italic text-[11px] text-walnut-3">
+          Letter, landscape · 11" × 8.5" · fold down the middle — cover on the left, program on the
+          right.
+        </p>
+      </div>
+
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </>
+  );
+}

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -1,15 +1,13 @@
-import { useParams, Navigate, Link } from "react-router";
+import { useParams, Navigate } from "react-router";
 import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useAuthStore } from "@/stores/authStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
-import { checkMeetingReadiness, type ReadinessReport } from "@/features/meetings/utils/readiness";
+import { checkMeetingReadiness } from "@/features/meetings/utils/readiness";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import { CongregationProgramBody } from "./CongregationProgramBody";
+import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
-import { buildMeetingVariables } from "./utils/buildMeetingVariables";
-import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
-import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -30,36 +28,26 @@ export function CongregationProgram() {
   const meetingType = m?.meetingType ?? defaultMeetingType(date, nonMeeting);
   const report = checkMeetingReadiness(m, speakers.data, meetingType);
 
-  if (ready && !report.ready) return <NotReady date={date} report={report} />;
+  if (ready && !report.ready) {
+    return (
+      <div className="min-h-screen grid place-items-center bg-parchment p-8">
+        <NotReadyBlock date={date} report={report} />
+      </div>
+    );
+  }
 
-  const speakerList = orderedSpeakers(speakers.data);
-  const sequence = speakerSequence(speakerList, m?.mid);
-  const visitors = (m?.visitors ?? []).filter((v) => v.name.trim().length > 0);
-  const wardName = ward.data?.name ?? "Ward";
-  const dateLong = formatLongDate(date);
-  const visitorText = visitors
-    .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
-    .join(", ");
+  // Per-Sunday override (saved from /week/:date/prepare) takes
+  // precedence over the ward-level template.
+  const override = m?.programs?.congregation;
+  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
 
-  const copy = template.data?.editorStateJson ? (
-    <TemplateCopy
-      wardName={wardName}
-      dateLong={dateLong}
-      json={template.data.editorStateJson}
-      variables={buildMeetingVariables({
-        date,
-        meeting: m ?? null,
-        speakers: speakers.data,
-        ward: ward.data ?? null,
-      })}
-    />
-  ) : (
-    <LegacyCongregationCopy
-      m={m ?? null}
-      wardName={wardName}
-      dateLong={dateLong}
-      sequence={sequence}
-      visitorText={visitorText}
+  const copy = (
+    <CongregationProgramBody
+      date={date}
+      meeting={m ?? null}
+      speakers={speakers.data}
+      ward={ward.data ?? null}
+      templateJson={templateJson}
     />
   );
 
@@ -77,62 +65,5 @@ export function CongregationProgram() {
         Two copies per page — cut down the middle.
       </p>
     </PrintLayout>
-  );
-}
-
-function TemplateCopy({
-  wardName,
-  dateLong,
-  json,
-  variables,
-}: {
-  wardName: string;
-  dateLong: string;
-  json: string;
-  variables: Record<string, string>;
-}) {
-  return (
-    <>
-      <header className="mb-3 border-b-2 border-walnut pb-2">
-        <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
-          Sacrament meeting · {wardName}
-        </div>
-        <h1 className="font-display text-[17px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
-          {dateLong}
-        </h1>
-      </header>
-      {renderProgramState(json, variables)}
-    </>
-  );
-}
-
-function NotReady({ date, report }: { date: string; report: ReadinessReport }) {
-  const remaining = report.missing.length + report.unconfirmed.length;
-  return (
-    <div className="min-h-screen grid place-items-center bg-parchment p-8 text-center">
-      <div className="max-w-lg">
-        <p className="font-display text-[20px] text-walnut mb-2">Not ready to print</p>
-        <p className="font-serif italic text-[13.5px] text-walnut-2 mb-4">
-          The program for <strong>{formatLongDate(date)}</strong> still has {remaining} item
-          {remaining === 1 ? "" : "s"} to fill before it's ready.
-        </p>
-        <ul className="text-left inline-block list-disc text-[13.5px] text-walnut-2 mb-4 max-h-60 overflow-y-auto">
-          {report.missing.map((m) => (
-            <li key={`m-${m}`}>{m}</li>
-          ))}
-          {report.unconfirmed.map((u) => (
-            <li key={`u-${u}`}>{u}</li>
-          ))}
-        </ul>
-        <div>
-          <Link
-            to={`/week/${date}`}
-            className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep transition-colors"
-          >
-            Back to the program
-          </Link>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -10,6 +10,7 @@ import { CongregationProgramBody } from "./CongregationProgramBody";
 import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
 import { formatLongDate } from "./utils/programData";
+import { resolveCoverImageUrl } from "./utils/programFooter";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -44,6 +45,10 @@ export function CongregationProgram() {
   const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
   const wardName = ward.data?.name ?? "Ward";
   const dateLong = formatLongDate(date);
+  const coverImageUrl = resolveCoverImageUrl(
+    m?.coverImageUrl,
+    ward.data?.congregationDefaults?.coverImageUrl,
+  );
 
   return (
     <PrintLayout ready={ready && report.ready} dense landscape>
@@ -53,7 +58,7 @@ export function CongregationProgram() {
             wardName={wardName}
             dateLong={dateLong}
             announcements={m?.announcements ?? ""}
-            imageUrl={m?.coverImageUrl ?? null}
+            imageUrl={coverImageUrl}
           />
         </div>
         <div

--- a/src/features/print/CongregationProgram.tsx
+++ b/src/features/print/CongregationProgram.tsx
@@ -5,9 +5,11 @@ import { useAuthStore } from "@/stores/authStore";
 import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
 import { checkMeetingReadiness } from "@/features/meetings/utils/readiness";
 import { defaultMeetingType } from "@/features/meetings/utils/ensureMeetingDoc";
+import { CongregationCoverPanel } from "./CongregationCoverPanel";
 import { CongregationProgramBody } from "./CongregationProgramBody";
 import { NotReadyBlock } from "./NotReadyBlock";
 import { PrintLayout } from "./PrintLayout";
+import { formatLongDate } from "./utils/programData";
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -40,29 +42,36 @@ export function CongregationProgram() {
   // precedence over the ward-level template.
   const override = m?.programs?.congregation;
   const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
-
-  const copy = (
-    <CongregationProgramBody
-      date={date}
-      meeting={m ?? null}
-      speakers={speakers.data}
-      ward={ward.data ?? null}
-      templateJson={templateJson}
-    />
-  );
+  const wardName = ward.data?.name ?? "Ward";
+  const dateLong = formatLongDate(date);
 
   return (
     <PrintLayout ready={ready && report.ready} dense landscape>
-      <div className="relative grid grid-cols-2 print:-mx-2">
-        <div className="px-[0.35in]">{copy}</div>
+      <div className="relative grid grid-cols-2 print:h-screen">
+        <div className="px-[0.35in] py-[0.1in]">
+          <CongregationCoverPanel
+            wardName={wardName}
+            dateLong={dateLong}
+            announcements={m?.announcements ?? ""}
+            imageUrl={m?.coverImageUrl ?? null}
+          />
+        </div>
         <div
           aria-hidden
           className="pointer-events-none absolute inset-y-0 left-1/2 border-l border-dashed border-walnut-3"
         />
-        <div className="px-[0.35in]">{copy}</div>
+        <div className="px-[0.35in] py-[0.1in]">
+          <CongregationProgramBody
+            date={date}
+            meeting={m ?? null}
+            speakers={speakers.data}
+            ward={ward.data ?? null}
+            templateJson={templateJson}
+          />
+        </div>
       </div>
       <p className="mt-4 text-center font-serif italic text-[11px] text-walnut-3 print-hidden">
-        Two copies per page — cut down the middle.
+        Fold down the middle — cover on the left, program on the right.
       </p>
     </PrintLayout>
   );

--- a/src/features/print/CongregationProgramBody.tsx
+++ b/src/features/print/CongregationProgramBody.tsx
@@ -1,0 +1,62 @@
+import type { WithId } from "@/hooks/_sub";
+import type { SacramentMeeting, Speaker, Ward } from "@/lib/types";
+import { renderProgramState } from "@/features/program-templates/utils/programTemplateRender";
+import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
+import { buildMeetingVariables } from "./utils/buildMeetingVariables";
+import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
+
+interface Props {
+  date: string;
+  meeting: SacramentMeeting | null;
+  speakers: readonly WithId<Speaker>[];
+  ward: Ward | null;
+  templateJson: string | null;
+}
+
+/** Pure rendering of one congregation copy (with its own header). The
+ *  print route emits this twice in a two-column landscape grid; the
+ *  prepare-to-print preview emits it once. */
+export function CongregationProgramBody({ date, meeting, speakers, ward, templateJson }: Props) {
+  const wardName = ward?.name ?? "Ward";
+  const dateLong = formatLongDate(date);
+
+  if (templateJson) {
+    const variables = buildMeetingVariables({ date, meeting, speakers, ward });
+    return (
+      <>
+        <CopyHeader wardName={wardName} dateLong={dateLong} />
+        {renderProgramState(templateJson, variables)}
+      </>
+    );
+  }
+
+  const speakerList = orderedSpeakers(speakers);
+  const sequence = speakerSequence(speakerList, meeting?.mid);
+  const visitors = (meeting?.visitors ?? []).filter((v) => v.name.trim().length > 0);
+  const visitorText = visitors
+    .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
+    .join(", ");
+
+  return (
+    <LegacyCongregationCopy
+      m={meeting}
+      wardName={wardName}
+      dateLong={dateLong}
+      sequence={sequence}
+      visitorText={visitorText}
+    />
+  );
+}
+
+function CopyHeader({ wardName, dateLong }: { wardName: string; dateLong: string }) {
+  return (
+    <header className="mb-3 border-b-2 border-walnut pb-2">
+      <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
+        Sacrament meeting · {wardName}
+      </div>
+      <h1 className="font-display text-[17px] font-semibold text-walnut tracking-[-0.02em] m-0 mt-0.5">
+        {dateLong}
+      </h1>
+    </header>
+  );
+}

--- a/src/features/print/CongregationProgramBody.tsx
+++ b/src/features/print/CongregationProgramBody.tsx
@@ -4,6 +4,7 @@ import { renderProgramState } from "@/features/program-templates/utils/programTe
 import { LegacyCongregationCopy } from "./LegacyCongregationCopy";
 import { buildMeetingVariables } from "./utils/buildMeetingVariables";
 import { formatLongDate, orderedSpeakers, speakerSequence } from "./utils/programData";
+import { resolveProgramFooterNote } from "./utils/programFooter";
 
 interface Props {
   date: string;
@@ -11,32 +12,68 @@ interface Props {
   speakers: readonly WithId<Speaker>[];
   ward: Ward | null;
   templateJson: string | null;
+  /** Per-meeting override for the program footer note. Undefined →
+   *  default ("Quietly ponder…"); empty string → hide. The
+   *  congregation prepare tab passes a draft value here so the
+   *  preview updates live as the user types. */
+  footerNoteOverride?: string | undefined;
 }
 
 /** Pure rendering of one congregation copy (with its own header). The
  *  print route emits this twice in a two-column landscape grid; the
  *  prepare-to-print preview emits it once. */
-export function CongregationProgramBody({ date, meeting, speakers, ward, templateJson }: Props) {
+export function CongregationProgramBody({
+  date,
+  meeting,
+  speakers,
+  ward,
+  templateJson,
+  footerNoteOverride,
+}: Props) {
   const wardName = ward?.name ?? "Ward";
   const dateLong = formatLongDate(date);
+  const footerSource =
+    footerNoteOverride !== undefined ? footerNoteOverride : meeting?.programFooterNote;
+  const footerNote = resolveProgramFooterNote(footerSource);
 
-  if (templateJson) {
-    const variables = buildMeetingVariables({ date, meeting, speakers, ward });
-    return (
-      <>
-        <CopyHeader wardName={wardName} dateLong={dateLong} />
-        {renderProgramState(templateJson, variables)}
-      </>
-    );
-  }
+  const body = templateJson ? (
+    <>
+      <CopyHeader wardName={wardName} dateLong={dateLong} />
+      {renderProgramState(templateJson, buildMeetingVariables({ date, meeting, speakers, ward }))}
+    </>
+  ) : (
+    <LegacyBody meeting={meeting} wardName={wardName} dateLong={dateLong} speakers={speakers} />
+  );
 
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 min-h-0">{body}</div>
+      {footerNote && (
+        <p className="mt-3 pt-2 border-t border-brass-soft font-serif italic text-[12px] text-walnut-2 text-center m-0 shrink-0">
+          {footerNote}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function LegacyBody({
+  meeting,
+  wardName,
+  dateLong,
+  speakers,
+}: {
+  meeting: SacramentMeeting | null;
+  wardName: string;
+  dateLong: string;
+  speakers: readonly WithId<Speaker>[];
+}) {
   const speakerList = orderedSpeakers(speakers);
   const sequence = speakerSequence(speakerList, meeting?.mid);
   const visitors = (meeting?.visitors ?? []).filter((v) => v.name.trim().length > 0);
   const visitorText = visitors
     .map((v) => (v.details ? `${v.name} (${v.details})` : v.name))
     .join(", ");
-
   return (
     <LegacyCongregationCopy
       m={meeting}
@@ -50,7 +87,7 @@ export function CongregationProgramBody({ date, meeting, speakers, ward, templat
 
 function CopyHeader({ wardName, dateLong }: { wardName: string; dateLong: string }) {
   return (
-    <header className="mb-3 border-b-2 border-walnut pb-2">
+    <header className="mb-6 border-b-2 border-walnut pb-2">
       <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
         Sacrament meeting · {wardName}
       </div>

--- a/src/features/print/CongregationProgramBody.tsx
+++ b/src/features/print/CongregationProgramBody.tsx
@@ -13,9 +13,9 @@ interface Props {
   ward: Ward | null;
   templateJson: string | null;
   /** Per-meeting override for the program footer note. Undefined →
-   *  default ("Quietly ponder…"); empty string → hide. The
-   *  congregation prepare tab passes a draft value here so the
-   *  preview updates live as the user types. */
+   *  fall through to ward default → built-in default; empty string
+   *  → hide. The congregation prepare tab passes a draft value here
+   *  so the preview updates live as the user types. */
   footerNoteOverride?: string | undefined;
 }
 
@@ -32,9 +32,12 @@ export function CongregationProgramBody({
 }: Props) {
   const wardName = ward?.name ?? "Ward";
   const dateLong = formatLongDate(date);
-  const footerSource =
+  const meetingFooterSource =
     footerNoteOverride !== undefined ? footerNoteOverride : meeting?.programFooterNote;
-  const footerNote = resolveProgramFooterNote(footerSource);
+  const footerNote = resolveProgramFooterNote(
+    meetingFooterSource,
+    ward?.congregationDefaults?.programFooterNote,
+  );
 
   const body = templateJson ? (
     <>

--- a/src/features/print/CongregationTemplateForm.tsx
+++ b/src/features/print/CongregationTemplateForm.tsx
@@ -1,0 +1,53 @@
+import { DEFAULT_PROGRAM_FOOTER_NOTE } from "./utils/programFooter";
+
+interface Props {
+  imageUrl: string;
+  footerNote: string;
+  onImageChange: (next: string) => void;
+  onFooterNoteChange: (next: string) => void;
+}
+
+/** Two-field form for the congregation-copy template editor: cover
+ *  image URL and program footer note. Announcements are intentionally
+ *  excluded — those are per-meeting content, edited on the prepare
+ *  page. */
+export function CongregationTemplateForm({
+  imageUrl,
+  footerNote,
+  onImageChange,
+  onFooterNoteChange,
+}: Props) {
+  return (
+    <div className="mx-auto max-w-[11in] grid gap-4 mb-1 rounded-md border border-border bg-chalk px-4 py-3 sm:grid-cols-2">
+      <Field label="Default cover image URL">
+        <input
+          type="url"
+          value={imageUrl}
+          onChange={(e) => onImageChange(e.target.value)}
+          placeholder="https://… (optional)"
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+      <Field label="Default program footer note">
+        <input
+          type="text"
+          value={footerNote}
+          onChange={(e) => onFooterNoteChange(e.target.value)}
+          placeholder={DEFAULT_PROGRAM_FOOTER_NOTE}
+          className="w-full font-sans text-[13px] text-walnut placeholder-walnut-3 bg-parchment border border-border rounded px-2 py-1.5 focus:outline-none focus:border-bordeaux"
+        />
+      </Field>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1">
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-brass-deep">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}

--- a/src/features/print/CongregationTemplateTab.tsx
+++ b/src/features/print/CongregationTemplateTab.tsx
@@ -1,76 +1,56 @@
 import { useState } from "react";
 import { SaveBar } from "@/components/ui/SaveBar";
-import { useMeeting, useSpeakers } from "@/hooks/useMeeting";
 import { useWardSettings } from "@/hooks/useWardSettings";
 import { useCurrentWardStore } from "@/stores/currentWardStore";
 import { friendlyWriteError } from "@/stores/saveStatusStore";
-import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { CongregationCoverForm } from "./CongregationCoverForm";
 import { CongregationCoverPanel } from "./CongregationCoverPanel";
 import { CongregationProgramBody } from "./CongregationProgramBody";
+import { CongregationTemplateForm } from "./CongregationTemplateForm";
 import { formatLongDate } from "./utils/programData";
 import { DEFAULT_PROGRAM_FOOTER_NOTE, resolveCoverImageUrl } from "./utils/programFooter";
-import { writeMeetingCover } from "./utils/writeMeetingCover";
+import { writeWardCongregationDefaults } from "./utils/writeWardCongregationDefaults";
 
-interface Props {
-  date: string;
-}
-
-/** Congregation tab on /week/:date/prepare. Live preview of what
- *  prints — cover panel on the left, program panel on the right —
- *  with two inline form controls for the editable bits: cover image
- *  URL and announcements. Everything else (presiding, hymns, etc.)
- *  is auto-populated from the meeting doc and edited back in
- *  /week/:date. */
-export function CongregationPrepareTab({ date }: Props) {
+/** Congregation-copy template editor on /settings/templates/programs.
+ *  Mirrors the per-Sunday prepare-page UX (form + bulletin preview)
+ *  but writes ward-level defaults — image URL and footer note — that
+ *  drive every Sunday's print unless the bishop overrides them on the
+ *  prepare page. Announcements are intentionally not editable here:
+ *  they're per-week content, not a template concept. */
+export function CongregationTemplateTab() {
   const wardId = useCurrentWardStore((s) => s.wardId);
   const ward = useWardSettings();
-  const meeting = useMeeting(date);
-  const speakers = useSpeakers(date);
-  const template = useProgramTemplate("congregationProgram");
 
   const [imageDraft, setImageDraft] = useState<string | null>(null);
-  const [announceDraft, setAnnounceDraft] = useState<string | null>(null);
   const [footerDraft, setFooterDraft] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
 
-  // The image input shows the meeting's own override, NOT the ward
-  // default — typing here saves a meeting-level override; clearing
-  // reveals the ward default in the preview again. Same idea for the
-  // footer, with a built-in default behind both for first-time wards.
   const wardDefaults = ward.data?.congregationDefaults;
-  const initialImage = meeting.data?.coverImageUrl ?? "";
-  const initialAnnounce = meeting.data?.announcements ?? "";
-  const initialFooter =
-    meeting.data?.programFooterNote ??
-    wardDefaults?.programFooterNote ??
-    DEFAULT_PROGRAM_FOOTER_NOTE;
+  const initialImage = wardDefaults?.coverImageUrl ?? "";
+  const initialFooter = wardDefaults?.programFooterNote ?? DEFAULT_PROGRAM_FOOTER_NOTE;
   const imageUrl = imageDraft ?? initialImage;
-  const announcements = announceDraft ?? initialAnnounce;
   const footerNote = footerDraft ?? initialFooter;
-  const dirty = imageDraft !== null || announceDraft !== null || footerDraft !== null;
-  // Preview cascades meeting → ward → none (matches print render).
-  const previewImageUrl = resolveCoverImageUrl(imageUrl, wardDefaults?.coverImageUrl);
+  const dirty = imageDraft !== null || footerDraft !== null;
 
   const wardName = ward.data?.name ?? "Ward";
-  const dateLong = formatLongDate(date);
-  const override = meeting.data?.programs?.congregation;
-  const templateJson = override?.editorStateJson ?? template.data?.editorStateJson ?? null;
+  // Preview uses today's date as a stand-in. The actual print resolves
+  // to the meeting date, but visually this lets the bishop see how a
+  // typical bulletin looks against their template.
+  const sampleDate = new Date().toISOString().slice(0, 10);
+  const dateLong = formatLongDate(sampleDate);
+  const previewImageUrl = resolveCoverImageUrl(imageUrl, null);
 
   async function save() {
     if (!wardId) return;
     setSaving(true);
     setError(null);
     try {
-      await writeMeetingCover(wardId, date, {
+      await writeWardCongregationDefaults(wardId, {
         coverImageUrl: imageUrl.trim().length > 0 ? imageUrl.trim() : null,
-        announcements,
         programFooterNote: footerNote.trim().length > 0 ? footerNote.trim() : null,
       });
       setImageDraft(null);
-      setAnnounceDraft(null);
       setFooterDraft(null);
       setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
     } catch (e) {
@@ -82,7 +62,6 @@ export function CongregationPrepareTab({ date }: Props) {
 
   function discard() {
     setImageDraft(null);
-    setAnnounceDraft(null);
     setFooterDraft(null);
     setError(null);
   }
@@ -90,17 +69,17 @@ export function CongregationPrepareTab({ date }: Props) {
   return (
     <>
       <div className="flex-1 min-h-0 overflow-auto bg-parchment py-6 px-4 sm:px-8 pb-24">
-        <CongregationCoverForm
+        <CongregationTemplateForm
           imageUrl={imageUrl}
-          announcements={announcements}
           footerNote={footerNote}
-          onImageChange={(v) => setImageDraft(v)}
-          onAnnouncementsChange={(v) => setAnnounceDraft(v)}
-          onFooterNoteChange={(v) => setFooterDraft(v)}
+          onImageChange={setImageDraft}
+          onFooterNoteChange={setFooterDraft}
         />
 
-        {/* Page sheet — letter landscape (11" × 8.5") at print scale.
-            What you see here is what the printer puts on the paper. */}
+        {/* Letter-landscape sheet at print scale — same dimensions and
+            structure as /print/:date/congregation. Empty meeting fields
+            render as blank lines so the bishop sees where each piece
+            lands on the printed bulletin. */}
         <div
           className="mx-auto mt-6 bg-chalk shadow-[0_4px_24px_rgba(35,24,21,0.08)] border border-border rounded-sm"
           style={{ width: "11in", height: "8.5in" }}
@@ -110,7 +89,7 @@ export function CongregationPrepareTab({ date }: Props) {
               <CongregationCoverPanel
                 wardName={wardName}
                 dateLong={dateLong}
-                announcements={announcements}
+                announcements=""
                 imageUrl={previewImageUrl}
               />
             </div>
@@ -120,19 +99,19 @@ export function CongregationPrepareTab({ date }: Props) {
             />
             <div className="px-[0.35in] py-[0.35in]">
               <CongregationProgramBody
-                date={date}
-                meeting={meeting.data ?? null}
-                speakers={speakers.data}
+                date={sampleDate}
+                meeting={null}
+                speakers={[]}
                 ward={ward.data ?? null}
-                templateJson={templateJson}
+                templateJson={null}
                 footerNoteOverride={footerNote}
               />
             </div>
           </div>
         </div>
         <p className="mt-2 mb-3 text-center font-serif italic text-[11px] text-walnut-3">
-          Letter, landscape · 11" × 8.5" · fold down the middle — cover on the left, program on the
-          right.
+          Letter, landscape · 11" × 8.5" · ward defaults apply when a meeting hasn't been customised
+          on the prepare page.
         </p>
       </div>
 

--- a/src/features/print/LegacyCongregationCopy.tsx
+++ b/src/features/print/LegacyCongregationCopy.tsx
@@ -1,6 +1,6 @@
 import type { SacramentMeeting } from "@/lib/types";
 import { personName, type SequenceEntry } from "./utils/programData";
-import { RowFreeform, RowHymn, RowLabeled, RowSection } from "./utils/programRows";
+import { RowHymn, RowLabeled, RowSection } from "./utils/programRows";
 
 interface Props {
   m: SacramentMeeting | null;
@@ -16,7 +16,7 @@ interface Props {
 export function LegacyCongregationCopy({ m, wardName, dateLong, sequence, visitorText }: Props) {
   return (
     <>
-      <header className="mb-3 border-b-2 border-walnut pb-2">
+      <header className="mb-6 border-b-2 border-walnut pb-2">
         <div className="font-mono text-[9.5px] uppercase tracking-[0.16em] text-brass-deep">
           Sacrament meeting · {wardName}
         </div>
@@ -30,12 +30,6 @@ export function LegacyCongregationCopy({ m, wardName, dateLong, sequence, visito
         <RowLabeled label="Conducting" value={personName(m?.conducting)} dense />
         {visitorText && <RowLabeled label="Visitors" value={visitorText} dense />}
       </RowSection>
-
-      {m?.showAnnouncements && (m?.announcements ?? "").trim().length > 0 && (
-        <RowSection title="Announcements" dense>
-          <RowFreeform label="Announcements" value={m.announcements} dense />
-        </RowSection>
-      )}
 
       <RowSection title="Music" dense>
         <RowLabeled label="Pianist" value={personName(m?.pianist)} dense />

--- a/src/features/print/NotReadyBlock.tsx
+++ b/src/features/print/NotReadyBlock.tsx
@@ -1,0 +1,40 @@
+import { Link } from "@/lib/nav";
+import type { ReadinessReport } from "@/features/meetings/utils/readiness";
+import { formatLongDate } from "./utils/programData";
+
+interface Props {
+  date: string;
+  report: ReadinessReport;
+}
+
+/** Centred "not ready" card. Caller wraps in whatever container fits the
+ *  context (full-viewport for the print routes, AppShell content area
+ *  for the prepare page). */
+export function NotReadyBlock({ date, report }: Props) {
+  const remaining = report.missing.length + report.unconfirmed.length;
+  return (
+    <div className="max-w-lg mx-auto text-center">
+      <p className="font-display text-[20px] text-walnut mb-2">Not ready to print</p>
+      <p className="font-serif italic text-[13.5px] text-walnut-2 mb-4">
+        The program for <strong>{formatLongDate(date)}</strong> still has {remaining} item
+        {remaining === 1 ? "" : "s"} to fill before it's ready.
+      </p>
+      <ul className="text-left inline-block list-disc text-[13.5px] text-walnut-2 mb-4 max-h-60 overflow-y-auto">
+        {report.missing.map((m) => (
+          <li key={`m-${m}`}>{m}</li>
+        ))}
+        {report.unconfirmed.map((u) => (
+          <li key={`u-${u}`}>{u}</li>
+        ))}
+      </ul>
+      <div>
+        <Link
+          to={`/week/${date}`}
+          className="font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment hover:bg-bordeaux-deep transition-colors"
+        >
+          Back to the program
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/features/print/PreparePrintHeader.tsx
+++ b/src/features/print/PreparePrintHeader.tsx
@@ -29,12 +29,14 @@ export function PreparePrintHeader({ date, printSegment, usingOverride }: Props)
       </div>
       <div className="flex items-center gap-2">
         <StatusPill usingOverride={usingOverride} />
-        <Link
-          to={`/print/${date}/${printSegment}`}
+        <a
+          href={`/print/${date}/${printSegment}`}
+          target="_blank"
+          rel="noopener noreferrer"
           className="inline-flex items-center gap-1.5 font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
         >
           Print {printSegment}
-        </Link>
+        </a>
       </div>
     </header>
   );

--- a/src/features/print/PreparePrintHeader.tsx
+++ b/src/features/print/PreparePrintHeader.tsx
@@ -1,0 +1,51 @@
+import { Link } from "@/lib/nav";
+import { formatLongDate } from "./utils/programData";
+
+interface Props {
+  date: string;
+  printSegment: string;
+  usingOverride: boolean;
+}
+
+/** Top bar of /week/:date/prepare. Mirrors the chrome of the program-
+ *  templates editor: eyebrow back link, title, date, and a primary
+ *  "Print …" CTA whose label tracks the active tab. A small green
+ *  "Customised for this Sunday" pill appears once a per-Sunday
+ *  override has been saved — there's no chrome in the default state. */
+export function PreparePrintHeader({ date, printSegment, usingOverride }: Props) {
+  return (
+    <header className="shrink-0 border-b border-border bg-chalk px-5 sm:px-8 py-4 flex items-center justify-between gap-4">
+      <div className="flex flex-col gap-1 min-w-0">
+        <Link
+          to={`/week/${date}`}
+          className="font-mono text-[10.5px] uppercase tracking-[0.16em] text-brass-deep hover:text-walnut"
+        >
+          ← Back to the program
+        </Link>
+        <h1 className="font-display text-[22px] sm:text-[26px] font-semibold text-walnut leading-tight">
+          Prepare to print
+        </h1>
+        <p className="font-serif italic text-[12.5px] text-walnut-2 m-0">{formatLongDate(date)}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <StatusPill usingOverride={usingOverride} />
+        <Link
+          to={`/print/${date}/${printSegment}`}
+          className="inline-flex items-center gap-1.5 font-sans text-[13px] font-semibold px-3.5 py-2 rounded-md border border-bordeaux-deep bg-bordeaux text-parchment shadow-[0_1px_0_rgba(35,24,21,0.18)] hover:bg-bordeaux-deep transition-colors"
+        >
+          Print {printSegment}
+        </Link>
+      </div>
+    </header>
+  );
+}
+
+function StatusPill({ usingOverride }: { usingOverride: boolean }) {
+  if (!usingOverride) return null;
+  return (
+    <span className="hidden sm:inline-flex items-center gap-1.5 rounded-full border border-success-soft bg-success/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.14em] text-success">
+      <span aria-hidden>●</span>
+      Customised for this Sunday
+    </span>
+  );
+}

--- a/src/features/print/PreparePrintView.tsx
+++ b/src/features/print/PreparePrintView.tsx
@@ -14,8 +14,8 @@ interface Props {
 }
 
 const TABS: { key: ProgramTemplateKey; label: string; printSegment: string }[] = [
-  { key: "conductingProgram", label: "Conducting copy", printSegment: "conducting" },
   { key: "congregationProgram", label: "Congregation copy", printSegment: "congregation" },
+  { key: "conductingProgram", label: "Conducting copy", printSegment: "conducting" },
 ];
 
 /** /week/:date/prepare — chrome + tab switcher. Each tab is a self-
@@ -27,7 +27,7 @@ export function PreparePrintView({ date }: Props) {
   useFullViewportLayout();
   const isMobile = useIsMobile();
   const authed = useAuthStore((s) => s.status === "signed_in");
-  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
+  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("congregationProgram");
   const [conductingOverride, setConductingOverride] = useState(false);
 
   if (!authed) return <Navigate to="/login" replace />;

--- a/src/features/print/PreparePrintView.tsx
+++ b/src/features/print/PreparePrintView.tsx
@@ -1,0 +1,166 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useMeeting } from "@/hooks/useMeeting";
+import { useAuthStore } from "@/stores/authStore";
+import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
+import { useIsMobile } from "@/hooks/useMediaQuery";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
+import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
+import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
+import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
+import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
+import { PreparePrintHeader } from "./PreparePrintHeader";
+import { writeMeetingProgram } from "./utils/writeMeetingProgram";
+
+interface Props {
+  date: string;
+}
+
+const TABS: { key: ProgramTemplateKey; label: string; printSegment: string }[] = [
+  { key: "conductingProgram", label: "Conducting copy", printSegment: "conducting" },
+  { key: "congregationProgram", label: "Congregation copy", printSegment: "congregation" },
+];
+
+/** /week/:date/prepare — per-Sunday program editor. Same WYSIWYG shell
+ *  as `/settings/templates/programs`, but writes land on the meeting
+ *  doc (under `programs.{conducting|congregation}`) so each Sunday
+ *  carries its own saved version. The print routes prefer this
+ *  override; if the bishopric never opens this page for a given week,
+ *  the ward-level template is used instead. */
+export function PreparePrintView({ date }: Props) {
+  useFullViewportLayout();
+  const isMobile = useIsMobile();
+  const authed = useAuthStore((s) => s.status === "signed_in");
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const meeting = useMeeting(date);
+  const conductingTpl = useProgramTemplate("conductingProgram");
+  const congregationTpl = useProgramTemplate("congregationProgram");
+
+  const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
+  const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
+    conductingProgram: null,
+    congregationProgram: null,
+  });
+  const [pageStyleDraft, setPageStyleDraft] = useState<
+    Record<ProgramTemplateKey, LetterPageStyle | null>
+  >({ conductingProgram: null, congregationProgram: null });
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  // Re-mount Lexical when the active tab changes so it hydrates from
+  // the new tab's initial state.
+  useEffect(() => {
+    setEditorKey((k) => k + 1);
+  }, [activeKey]);
+
+  if (!authed) return <Navigate to="/login" replace />;
+  if (isMobile) return <DesktopOnlyNotice title="Prepare to print" />;
+
+  const meetingOverride =
+    activeKey === "conductingProgram"
+      ? meeting.data?.programs?.conducting
+      : meeting.data?.programs?.congregation;
+  const wardTemplate =
+    activeKey === "conductingProgram" ? conductingTpl.data : congregationTpl.data;
+  const initialJson =
+    meetingOverride?.editorStateJson ??
+    wardTemplate?.editorStateJson ??
+    defaultProgramTemplate(activeKey);
+  const initialPageStyle = meetingOverride?.pageStyle ?? wardTemplate?.pageStyle ?? null;
+  const margins = meetingOverride?.margins ?? wardTemplate?.margins ?? DEFAULT_MARGINS[activeKey];
+  const usingOverride = Boolean(meetingOverride);
+
+  const editorJson = draft[activeKey] ?? initialJson;
+  const activePageStyle = pageStyleDraft[activeKey] ?? initialPageStyle;
+  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
+  const styleDirty =
+    pageStyleDraft[activeKey] !== null &&
+    JSON.stringify(pageStyleDraft[activeKey]) !== JSON.stringify(initialPageStyle);
+  const dirty = jsonDirty || styleDirty;
+
+  async function save() {
+    if (!wardId) return;
+    setSaving(true);
+    setError(null);
+    try {
+      await writeMeetingProgram(
+        wardId,
+        date,
+        activeKey,
+        draft[activeKey] ?? initialJson,
+        margins,
+        activePageStyle ?? null,
+      );
+      setDraft((d) => ({ ...d, [activeKey]: null }));
+      setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setDraft((d) => ({ ...d, [activeKey]: null }));
+    setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  const activeTab = TABS.find((t) => t.key === activeKey)!;
+
+  return (
+    <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
+      <PreparePrintHeader
+        date={date}
+        printSegment={activeTab.printSegment}
+        usingOverride={usingOverride}
+      />
+
+      <nav className="shrink-0 flex gap-1 border-b border-border bg-parchment-2/30 px-5 sm:px-8 pt-3">
+        {TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setActiveKey(t.key)}
+            className={
+              activeKey === t.key
+                ? "px-3 py-2 -mb-px border-b-2 border-bordeaux font-sans text-[13.5px] font-semibold text-walnut"
+                : "px-3 py-2 -mb-px border-b-2 border-transparent font-sans text-[13.5px] text-walnut-2 hover:text-walnut"
+            }
+          >
+            {t.label}
+          </button>
+        ))}
+      </nav>
+
+      <div className="flex-1 min-h-0 pb-16">
+        <ProgramPageEditor
+          key={`${activeKey}-${editorKey}`}
+          variant={activeKey}
+          initialJson={editorJson}
+          pageStyle={activePageStyle}
+          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
+          onPageStyleChange={(next) => setPageStyleDraft((d) => ({ ...d, [activeKey]: next }))}
+          ariaLabel={activeTab.label}
+        />
+      </div>
+
+      <SaveBar
+        dirty={dirty}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </main>
+  );
+}

--- a/src/features/print/PreparePrintView.tsx
+++ b/src/features/print/PreparePrintView.tsx
@@ -1,20 +1,13 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Navigate } from "react-router";
-import { SaveBar } from "@/components/ui/SaveBar";
-import { useMeeting } from "@/hooks/useMeeting";
 import { useAuthStore } from "@/stores/authStore";
 import { useFullViewportLayout } from "@/hooks/useFullViewportLayout";
 import { useIsMobile } from "@/hooks/useMediaQuery";
-import { useCurrentWardStore } from "@/stores/currentWardStore";
-import { friendlyWriteError } from "@/stores/saveStatusStore";
-import { useProgramTemplate } from "@/features/program-templates/hooks/useProgramTemplate";
-import { DEFAULT_MARGINS } from "@/features/program-templates/ProgramCanvas";
-import { defaultProgramTemplate } from "@/features/program-templates/utils/programTemplateDefaults";
 import { DesktopOnlyNotice } from "@/features/page-editor/DesktopOnlyNotice";
-import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
-import type { LetterPageStyle, ProgramTemplateKey } from "@/lib/types";
+import type { ProgramTemplateKey } from "@/lib/types";
+import { CongregationPrepareTab } from "./CongregationPrepareTab";
+import { ConductingPrepareTab } from "./ConductingPrepareTab";
 import { PreparePrintHeader } from "./PreparePrintHeader";
-import { writeMeetingProgram } from "./utils/writeMeetingProgram";
 
 interface Props {
   date: string;
@@ -25,96 +18,25 @@ const TABS: { key: ProgramTemplateKey; label: string; printSegment: string }[] =
   { key: "congregationProgram", label: "Congregation copy", printSegment: "congregation" },
 ];
 
-/** /week/:date/prepare — per-Sunday program editor. Same WYSIWYG shell
- *  as `/settings/templates/programs`, but writes land on the meeting
- *  doc (under `programs.{conducting|congregation}`) so each Sunday
- *  carries its own saved version. The print routes prefer this
- *  override; if the bishopric never opens this page for a given week,
- *  the ward-level template is used instead. */
+/** /week/:date/prepare — chrome + tab switcher. Each tab is a self-
+ *  contained component: the conducting tab is a Lexical WYSIWYG
+ *  editor; the congregation tab is a live cover+program preview with
+ *  inline form controls for the editable bits (image URL,
+ *  announcements). */
 export function PreparePrintView({ date }: Props) {
   useFullViewportLayout();
   const isMobile = useIsMobile();
   const authed = useAuthStore((s) => s.status === "signed_in");
-  const wardId = useCurrentWardStore((s) => s.wardId);
-  const meeting = useMeeting(date);
-  const conductingTpl = useProgramTemplate("conductingProgram");
-  const congregationTpl = useProgramTemplate("congregationProgram");
-
   const [activeKey, setActiveKey] = useState<ProgramTemplateKey>("conductingProgram");
-  const [draft, setDraft] = useState<Record<ProgramTemplateKey, string | null>>({
-    conductingProgram: null,
-    congregationProgram: null,
-  });
-  const [pageStyleDraft, setPageStyleDraft] = useState<
-    Record<ProgramTemplateKey, LetterPageStyle | null>
-  >({ conductingProgram: null, congregationProgram: null });
-  const [editorKey, setEditorKey] = useState(0);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [savedAt, setSavedAt] = useState<string | null>(null);
-
-  // Re-mount Lexical when the active tab changes so it hydrates from
-  // the new tab's initial state.
-  useEffect(() => {
-    setEditorKey((k) => k + 1);
-  }, [activeKey]);
+  const [conductingOverride, setConductingOverride] = useState(false);
 
   if (!authed) return <Navigate to="/login" replace />;
   if (isMobile) return <DesktopOnlyNotice title="Prepare to print" />;
 
-  const meetingOverride =
-    activeKey === "conductingProgram"
-      ? meeting.data?.programs?.conducting
-      : meeting.data?.programs?.congregation;
-  const wardTemplate =
-    activeKey === "conductingProgram" ? conductingTpl.data : congregationTpl.data;
-  const initialJson =
-    meetingOverride?.editorStateJson ??
-    wardTemplate?.editorStateJson ??
-    defaultProgramTemplate(activeKey);
-  const initialPageStyle = meetingOverride?.pageStyle ?? wardTemplate?.pageStyle ?? null;
-  const margins = meetingOverride?.margins ?? wardTemplate?.margins ?? DEFAULT_MARGINS[activeKey];
-  const usingOverride = Boolean(meetingOverride);
-
-  const editorJson = draft[activeKey] ?? initialJson;
-  const activePageStyle = pageStyleDraft[activeKey] ?? initialPageStyle;
-  const jsonDirty = draft[activeKey] !== null && draft[activeKey] !== initialJson;
-  const styleDirty =
-    pageStyleDraft[activeKey] !== null &&
-    JSON.stringify(pageStyleDraft[activeKey]) !== JSON.stringify(initialPageStyle);
-  const dirty = jsonDirty || styleDirty;
-
-  async function save() {
-    if (!wardId) return;
-    setSaving(true);
-    setError(null);
-    try {
-      await writeMeetingProgram(
-        wardId,
-        date,
-        activeKey,
-        draft[activeKey] ?? initialJson,
-        margins,
-        activePageStyle ?? null,
-      );
-      setDraft((d) => ({ ...d, [activeKey]: null }));
-      setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
-    } catch (e) {
-      setError(friendlyWriteError(e));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  function discard() {
-    setDraft((d) => ({ ...d, [activeKey]: null }));
-    setPageStyleDraft((d) => ({ ...d, [activeKey]: null }));
-    setEditorKey((k) => k + 1);
-    setError(null);
-  }
-
   const activeTab = TABS.find((t) => t.key === activeKey)!;
+  // Status pill on conducting reflects the Lexical override state.
+  // Congregation tab manages its own preview and doesn't use the pill.
+  const usingOverride = activeKey === "conductingProgram" && conductingOverride;
 
   return (
     <main className="min-h-dvh lg:h-dvh bg-parchment flex flex-col lg:overflow-hidden">
@@ -141,26 +63,11 @@ export function PreparePrintView({ date }: Props) {
         ))}
       </nav>
 
-      <div className="flex-1 min-h-0 pb-16">
-        <ProgramPageEditor
-          key={`${activeKey}-${editorKey}`}
-          variant={activeKey}
-          initialJson={editorJson}
-          pageStyle={activePageStyle}
-          onChange={(json) => setDraft((d) => ({ ...d, [activeKey]: json }))}
-          onPageStyleChange={(next) => setPageStyleDraft((d) => ({ ...d, [activeKey]: next }))}
-          ariaLabel={activeTab.label}
-        />
-      </div>
-
-      <SaveBar
-        dirty={dirty}
-        saving={saving}
-        savedAt={savedAt}
-        error={error}
-        onDiscard={discard}
-        onSave={() => void save()}
-      />
+      {activeKey === "conductingProgram" ? (
+        <ConductingPrepareTab date={date} onUsingOverrideChange={setConductingOverride} />
+      ) : (
+        <CongregationPrepareTab date={date} />
+      )}
     </main>
   );
 }

--- a/src/features/print/PrintLayout.tsx
+++ b/src/features/print/PrintLayout.tsx
@@ -38,12 +38,12 @@ export function PrintLayout({ ready, dense, landscape, children }: Props) {
   }, [ready]);
 
   return (
-    <div className="min-h-screen bg-chalk text-walnut font-serif print:bg-white print:min-h-screen print:flex print:flex-col print:justify-center">
+    <div className="min-h-screen bg-chalk text-walnut font-serif print:bg-white print:min-h-0 print:block">
       <div
         className={
           dense
-            ? "mx-auto max-w-4xl px-6 py-6 print:px-2 print:py-0 print:w-full"
-            : "mx-auto max-w-4xl px-10 py-10 print:px-6 print:py-0 print:w-full"
+            ? "mx-auto max-w-4xl px-6 py-6 print:max-w-none print:p-0 print:w-full"
+            : "mx-auto max-w-4xl px-10 py-10 print:max-w-none print:p-0 print:w-full"
         }
       >
         {children}

--- a/src/features/print/utils/conductingSampleData.tsx
+++ b/src/features/print/utils/conductingSampleData.tsx
@@ -1,0 +1,117 @@
+import type { Page1Props } from "../ConductingDesignPage1";
+import type { Page2Props } from "../ConductingDesignPage2";
+
+/** Sample meeting data used to render the conducting copy template
+ *  preview when no real meeting is in scope (e.g. /settings/templates/
+ *  programs). Mirrors the figures from the original Conductors
+ *  Page.html mockup — Test Ward, May 31 2026, 9:00 a.m. — so the
+ *  bishop sees the same realistic preview shipped with the design. */
+
+export function sampleConductingPage1(wardName: string): Page1Props {
+  const dateLong = "Sunday, May 31, 2026";
+  return {
+    wardName,
+    dateLong,
+    timeText: "9:00 a.m.",
+    presiding: "Bishop Reeves",
+    conducting: "Brother Tan",
+    pianist: "Sister Lee",
+    chorister: "Sister Park",
+    visitors: "—",
+    agenda: [
+      {
+        num: "1",
+        label: "Announcements",
+        value: <span className="italic text-brass-deep">See page 2</span>,
+      },
+      {
+        num: "2",
+        label: "Opening hymn",
+        value: <HymnValue number="#19" title="We Thank Thee, O God, for a Prophet" />,
+        sub: { label: "Invocation", value: "Brother Tan" },
+      },
+      {
+        num: "3",
+        label: "Ward business",
+        value: <span className="italic text-brass-deep">See page 2</span>,
+        sub: {
+          label: "Stake business",
+          value: <span className="italic text-brass-deep">See page 2</span>,
+        },
+      },
+      {
+        num: "4",
+        label: "Sacrament hymn",
+        value: <HymnValue number="#172" title="In Humility, Our Savior" />,
+        cue: {
+          text: "Administration of the sacrament — pause for reverence before introducing speakers.",
+        },
+      },
+      {
+        num: "5",
+        label: "Speaker",
+        value: <SpeakerValue name="Brother Park" topic="On the still small voice" />,
+        cue: { text: "Welcome the congregation; introduce the speaker briefly." },
+      },
+      {
+        num: "6",
+        label: "Musical interlude",
+        value: <MusicValue label="Musical number" performer="Sister Lee" />,
+      },
+      {
+        num: "7",
+        label: "Speaker",
+        value: <SpeakerValue name="Sister Reeves" topic="Faith and works" />,
+        cue: { text: "Thank the previous speaker; mention the closing hymn that follows." },
+      },
+      {
+        num: "8",
+        label: "Closing hymn",
+        value: <HymnValue number="#85" title="How Firm a Foundation" />,
+        sub: { label: "Benediction", value: "Sister Park" },
+      },
+    ],
+    footerLeft: `${wardName} · 31 May 2026 · Page 1 of 2`,
+  };
+}
+
+export function sampleConductingPage2(wardName: string): Page2Props {
+  return {
+    wardName,
+    dateLong: "Sunday, May 31, 2026",
+    announcements: "",
+    wardBusiness: "",
+    stakeBusiness: "",
+    footerLeft: `${wardName} · 31 May 2026 · Page 2 of 2`,
+  };
+}
+
+function HymnValue({ number, title }: { number: string; title: string }) {
+  return (
+    <>
+      <span className="font-semibold whitespace-nowrap">{number}</span>
+      <span className="mx-1.5 text-walnut-3">—</span>
+      <span>{title}</span>
+    </>
+  );
+}
+
+function SpeakerValue({ name, topic }: { name: string; topic: string }) {
+  return (
+    <>
+      <span>{name}</span>
+      <span className="mx-1.5 text-walnut-3">—</span>
+      <span className="italic text-walnut-2">{topic}</span>
+    </>
+  );
+}
+
+function MusicValue({ label, performer }: { label: string; performer: string }) {
+  return (
+    <>
+      <span>{label}</span>
+      <span className="mx-1.5 text-walnut-3">—</span>
+      <span>{performer}</span>
+    </>
+  );
+}

--- a/src/features/print/utils/programFooter.ts
+++ b/src/features/print/utils/programFooter.ts
@@ -1,0 +1,14 @@
+/** Default footer note shown at the bottom of the congregation
+ *  copy's program panel. Bishopric can override per-Sunday from
+ *  /week/:date/prepare. An explicit empty string hides the footer. */
+export const DEFAULT_PROGRAM_FOOTER_NOTE =
+  "Quietly ponder the prelude music 10 minutes before the meeting begins";
+
+/** Resolve the footer text to render, given the per-meeting override.
+ *  Undefined → default; empty string → null (hide); otherwise the
+ *  override wins. */
+export function resolveProgramFooterNote(override: string | undefined | null): string | null {
+  if (override === undefined || override === null) return DEFAULT_PROGRAM_FOOTER_NOTE;
+  if (override.trim().length === 0) return null;
+  return override;
+}

--- a/src/features/print/utils/programFooter.ts
+++ b/src/features/print/utils/programFooter.ts
@@ -1,14 +1,38 @@
-/** Default footer note shown at the bottom of the congregation
- *  copy's program panel. Bishopric can override per-Sunday from
- *  /week/:date/prepare. An explicit empty string hides the footer. */
+/** Built-in default footer note shown at the bottom of the
+ *  congregation copy's program panel. Wards can override the default
+ *  from /settings/templates/programs; per-Sunday overrides on the
+ *  meeting doc beat both. Empty string at any level hides the footer
+ *  outright (caller wanted no footer that week / for that ward). */
 export const DEFAULT_PROGRAM_FOOTER_NOTE =
   "Quietly ponder the prelude music 10 minutes before the meeting begins";
 
-/** Resolve the footer text to render, given the per-meeting override.
- *  Undefined → default; empty string → null (hide); otherwise the
- *  override wins. */
-export function resolveProgramFooterNote(override: string | undefined | null): string | null {
-  if (override === undefined || override === null) return DEFAULT_PROGRAM_FOOTER_NOTE;
-  if (override.trim().length === 0) return null;
-  return override;
+/** Resolve the footer text to render. Cascades meeting → ward → built-in
+ *  default. At each level: undefined falls through; empty string is an
+ *  explicit "hide" and short-circuits to null; non-empty wins. */
+export function resolveProgramFooterNote(
+  meetingOverride: string | undefined | null,
+  wardDefault?: string | undefined | null,
+): string | null {
+  for (const value of [meetingOverride, wardDefault]) {
+    if (value === undefined || value === null) continue;
+    if (value.trim().length === 0) return null;
+    return value;
+  }
+  return DEFAULT_PROGRAM_FOOTER_NOTE;
+}
+
+/** Resolve the cover image URL to render. Cascades meeting → ward →
+ *  null. Empty strings at either level are treated as "no override
+ *  here" (a placeholder shows when nothing is set). */
+export function resolveCoverImageUrl(
+  meetingOverride: string | undefined | null,
+  wardDefault?: string | undefined | null,
+): string | null {
+  for (const value of [meetingOverride, wardDefault]) {
+    if (value === undefined || value === null) continue;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) continue;
+    return trimmed;
+  }
+  return null;
 }

--- a/src/features/print/utils/writeMeetingCover.ts
+++ b/src/features/print/utils/writeMeetingCover.ts
@@ -1,0 +1,32 @@
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/** Write the editable bits surfaced on the congregation prepare page
+ *  — cover image URL, announcements, and program footer note — to the
+ *  meeting doc. Partial update; `null` on `coverImageUrl` /
+ *  `programFooterNote` clears the field. `programFooterNote === null`
+ *  also reverts to the built-in default at render time. */
+export async function writeMeetingCover(
+  wardId: string,
+  date: string,
+  fields: {
+    coverImageUrl: string | null;
+    announcements: string;
+    programFooterNote: string | null;
+  },
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(doc(db, "wards", wardId, "meetings", date), {
+      coverImageUrl: fields.coverImageUrl ?? null,
+      announcements: fields.announcements,
+      programFooterNote: fields.programFooterNote ?? null,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/print/utils/writeMeetingProgram.ts
+++ b/src/features/print/utils/writeMeetingProgram.ts
@@ -1,0 +1,49 @@
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import type { LetterPageStyle, ProgramMargins, ProgramTemplateKey } from "@/lib/types";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/** Map between the ward-template key (`conductingProgram` /
+ *  `congregationProgram`) and the meeting-doc field on
+ *  `meeting.programs` (`conducting` / `congregation`). The shorter
+ *  meeting-side names live under `programs.*`, so they don't collide
+ *  with the assignment field `meeting.conducting`. */
+const MEETING_FIELD: Record<ProgramTemplateKey, "conducting" | "congregation"> = {
+  conductingProgram: "conducting",
+  congregationProgram: "congregation",
+};
+
+/** Write the per-Sunday program override to the meeting doc. Stored
+ *  under `meeting.programs.{conducting|congregation}` so it can be
+ *  loaded standalone (no extra round-trips) and the print routes can
+ *  prefer it over the ward template. */
+export async function writeMeetingProgram(
+  wardId: string,
+  date: string,
+  key: ProgramTemplateKey,
+  editorStateJson: string,
+  margins: ProgramMargins,
+  pageStyle: LetterPageStyle | null,
+): Promise<void> {
+  reportSaving();
+  try {
+    const field = MEETING_FIELD[key];
+    await updateDoc(doc(db, "wards", wardId, "meetings", date), {
+      [`programs.${field}`]: {
+        editorStateJson,
+        margins,
+        pageStyle: pageStyle ?? null,
+        updatedAt: serverTimestamp(),
+      },
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}
+
+export function meetingProgramField(key: ProgramTemplateKey): "conducting" | "congregation" {
+  return MEETING_FIELD[key];
+}

--- a/src/features/print/utils/writeWardCongregationDefaults.ts
+++ b/src/features/print/utils/writeWardCongregationDefaults.ts
@@ -1,0 +1,29 @@
+import { doc, serverTimestamp, updateDoc } from "firebase/firestore";
+import { db } from "@/lib/firebase";
+import { reportSaved, reportSaveError, reportSaving } from "@/stores/saveStatusStore";
+
+/** Write the ward-level defaults that drive the congregation print
+ *  bulletin when no per-meeting override is set: cover image URL and
+ *  program footer note. Configurable from /settings/templates/programs.
+ *  Stored under `wards/{wardId}.congregationDefaults`.
+ *
+ *  `null` clears the field — at render time, an absent value falls
+ *  through to the next layer (built-in default for the footer; no
+ *  image for the cover). */
+export async function writeWardCongregationDefaults(
+  wardId: string,
+  fields: { coverImageUrl: string | null; programFooterNote: string | null },
+): Promise<void> {
+  reportSaving();
+  try {
+    await updateDoc(doc(db, "wards", wardId), {
+      "congregationDefaults.coverImageUrl": fields.coverImageUrl ?? null,
+      "congregationDefaults.programFooterNote": fields.programFooterNote ?? null,
+      updatedAt: serverTimestamp(),
+    });
+    reportSaved();
+  } catch (e) {
+    reportSaveError(e);
+    throw e;
+  }
+}

--- a/src/features/program-templates/ConductingTemplateTab.tsx
+++ b/src/features/program-templates/ConductingTemplateTab.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from "react";
+import { SaveBar } from "@/components/ui/SaveBar";
+import { useCurrentMember } from "@/hooks/useCurrentMember";
+import { useCurrentWardStore } from "@/stores/currentWardStore";
+import { friendlyWriteError } from "@/stores/saveStatusStore";
+import type { LetterPageStyle } from "@/lib/types";
+import { ProgramPageEditor } from "@/features/page-editor/ProgramPageEditor";
+import { DEFAULT_MARGINS } from "./ProgramCanvas";
+import { useProgramTemplate } from "./hooks/useProgramTemplate";
+import { defaultProgramTemplate } from "./utils/programTemplateDefaults";
+import { writeProgramTemplate } from "./utils/writeProgramTemplate";
+
+const KEY = "conductingProgram";
+
+interface Props {
+  onUsingDefaultChange?: (using: boolean) => void;
+}
+
+/** Conducting-copy template editor on /settings/templates/programs.
+ *  Lexical WYSIWYG with variable chips — saves to the ward template
+ *  doc at `wards/{wardId}/templates/conductingProgram`. */
+export function ConductingTemplateTab({ onUsingDefaultChange }: Props) {
+  const wardId = useCurrentWardStore((s) => s.wardId);
+  const me = useCurrentMember();
+  const canEdit = Boolean(me?.data.active);
+  const tpl = useProgramTemplate(KEY);
+
+  const initialJson = tpl.data?.editorStateJson ?? defaultProgramTemplate(KEY);
+  const usingDefault = !tpl.data?.editorStateJson;
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [pageStyleDraft, setPageStyleDraft] = useState<LetterPageStyle | null>(null);
+  const [editorKey, setEditorKey] = useState(0);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedAt, setSavedAt] = useState<string | null>(null);
+
+  useEffect(() => {
+    onUsingDefaultChange?.(usingDefault);
+  }, [usingDefault, onUsingDefaultChange]);
+
+  const editorJson = draft ?? initialJson;
+  const activePageStyle = pageStyleDraft ?? tpl.data?.pageStyle ?? null;
+  const jsonDirty = draft !== null && draft !== initialJson;
+  const styleDirty =
+    pageStyleDraft !== null &&
+    JSON.stringify(pageStyleDraft) !== JSON.stringify(tpl.data?.pageStyle ?? null);
+  const dirty = jsonDirty || styleDirty;
+
+  async function save() {
+    if (!wardId) return;
+    const margins = tpl.data?.margins ?? DEFAULT_MARGINS[KEY];
+    setSaving(true);
+    setError(null);
+    try {
+      await writeProgramTemplate(wardId, KEY, draft ?? initialJson, margins, activePageStyle);
+      setDraft(null);
+      setPageStyleDraft(null);
+      setSavedAt(new Date().toLocaleTimeString([], { hour: "numeric", minute: "2-digit" }));
+    } catch (e) {
+      setError(friendlyWriteError(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function discard() {
+    setDraft(null);
+    setPageStyleDraft(null);
+    setEditorKey((k) => k + 1);
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="flex-1 min-h-0 pb-16">
+        <ProgramPageEditor
+          key={`conducting-${editorKey}`}
+          variant={KEY}
+          initialJson={editorJson}
+          pageStyle={activePageStyle}
+          showSampleNotice
+          onChange={setDraft}
+          onPageStyleChange={canEdit ? setPageStyleDraft : undefined}
+          ariaLabel="Conducting copy"
+          editorDisabled={!canEdit}
+        />
+      </div>
+
+      <SaveBar
+        dirty={dirty && canEdit}
+        saving={saving}
+        savedAt={savedAt}
+        error={error}
+        onDiscard={discard}
+        onSave={() => void save()}
+      />
+    </>
+  );
+}

--- a/src/features/program-templates/ConductingTemplateTab.tsx
+++ b/src/features/program-templates/ConductingTemplateTab.tsx
@@ -17,7 +17,8 @@ interface Props {
 }
 
 /** Conducting-copy template editor on /settings/templates/programs.
- *  Lexical WYSIWYG with variable chips — saves to the ward template
+ *  Lexical WYSIWYG with variable chips — same authoring surface as
+ *  the speaker + prayer letter editors, scoped to the ward template
  *  doc at `wards/{wardId}/templates/conductingProgram`. */
 export function ConductingTemplateTab({ onUsingDefaultChange }: Props) {
   const wardId = useCurrentWardStore((s) => s.wardId);

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -93,15 +93,16 @@ export const sacramentMeetingSchema = z.object({
   conducting: assignmentSchema.optional(),
   visitors: z.array(visitorSchema).default([]),
   /** URL of the cover image shown on the congregation copy's left
-   *  panel (above the announcements). Optional — when absent the
-   *  cover renders ward branding + announcements only. */
-  coverImageUrl: z.string().optional(),
+   *  panel (above the announcements). Nullish — when absent or null
+   *  the cover renders ward branding + announcements only. The write
+   *  helper clears with `null`, so the schema must accept it. */
+  coverImageUrl: z.string().nullish(),
   /** Footer note printed at the bottom of the congregation copy's
    *  right (program) panel — typically a reverence prompt like
-   *  "Quietly ponder the prelude music…". Undefined falls back to
-   *  the built-in default; an explicit empty string hides the
-   *  footer. */
-  programFooterNote: z.string().optional(),
+   *  "Quietly ponder the prelude music…". Undefined / null falls
+   *  back to the ward default → built-in default; an explicit empty
+   *  string hides the footer. */
+  programFooterNote: z.string().nullish(),
   /** Per-Sunday overrides for the printed program. When present, the
    *  prepare-to-print + print routes use these saved Lexical states
    *  instead of the ward-level template — so the bishopric can tailor

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { programTemplateSchema } from "./template";
 import { assignmentSchema } from "./person";
 
 export const MEETING_TYPES = ["regular", "fast", "stake", "general"] as const;
@@ -91,6 +92,18 @@ export const sacramentMeetingSchema = z.object({
   presiding: assignmentSchema.optional(),
   conducting: assignmentSchema.optional(),
   visitors: z.array(visitorSchema).default([]),
+  /** Per-Sunday overrides for the printed program. When present, the
+   *  prepare-to-print + print routes use these saved Lexical states
+   *  instead of the ward-level template — so the bishopric can tailor
+   *  one Sunday's program without changing the template that future
+   *  weeks inherit. The shape mirrors the ward template doc so the
+   *  same editor + render path can read either. */
+  programs: z
+    .object({
+      conducting: programTemplateSchema.optional(),
+      congregation: programTemplateSchema.optional(),
+    })
+    .optional(),
   updatedAt: z.any().optional(),
   createdAt: z.any().optional(),
 });

--- a/src/lib/types/meeting.ts
+++ b/src/lib/types/meeting.ts
@@ -92,6 +92,16 @@ export const sacramentMeetingSchema = z.object({
   presiding: assignmentSchema.optional(),
   conducting: assignmentSchema.optional(),
   visitors: z.array(visitorSchema).default([]),
+  /** URL of the cover image shown on the congregation copy's left
+   *  panel (above the announcements). Optional — when absent the
+   *  cover renders ward branding + announcements only. */
+  coverImageUrl: z.string().optional(),
+  /** Footer note printed at the bottom of the congregation copy's
+   *  right (program) panel — typically a reverence prompt like
+   *  "Quietly ponder the prelude music…". Undefined falls back to
+   *  the built-in default; an explicit empty string hides the
+   *  footer. */
+  programFooterNote: z.string().optional(),
   /** Per-Sunday overrides for the printed program. When present, the
    *  prepare-to-print + print routes use these saved Lexical states
    *  instead of the ward-level template — so the bishopric can tailor

--- a/src/lib/types/person.ts
+++ b/src/lib/types/person.ts
@@ -7,8 +7,14 @@ export const personSchema = z.object({
 });
 export type Person = z.infer<typeof personSchema>;
 
+// `person` accepts present-as-object, present-as-null, AND absent. The
+// missing-key variant happens when a clear path uses Firestore's
+// `deleteField()` to wipe the person — the resulting doc has the
+// assignment object but no `person` key, which Zod's `nullable()`
+// rejects. Tolerating absence here keeps existing meetings parseable;
+// new writes should still prefer `person: null` (see `clearPrayerParticipant`).
 export const assignmentSchema = z.object({
-  person: personSchema.nullable(),
+  person: personSchema.nullish(),
   confirmed: z.boolean().default(false),
 });
 export type Assignment = z.infer<typeof assignmentSchema>;

--- a/src/lib/types/ward.ts
+++ b/src/lib/types/ward.ts
@@ -18,9 +18,25 @@ export const wardSettingsSchema = z.object({
 });
 export type WardSettings = z.infer<typeof wardSettingsSchema>;
 
+/** Ward-level defaults for the congregation print bulletin. Per-meeting
+ *  overrides on the meeting doc (`coverImageUrl`, `programFooterNote`)
+ *  win when set; otherwise the print + prepare paths fall back to
+ *  these. Configurable from /settings/templates/programs.
+ *
+ *  Fields are `nullish` because the write helper clears values by
+ *  storing `null` (rather than `deleteField()`) — Zod must accept
+ *  `string | null | undefined` so the ward doc still parses after a
+ *  clear. */
+export const congregationDefaultsSchema = z.object({
+  coverImageUrl: z.string().nullish(),
+  programFooterNote: z.string().nullish(),
+});
+export type CongregationDefaults = z.infer<typeof congregationDefaultsSchema>;
+
 export const wardSchema = z.object({
   name: z.string().min(1),
   settings: wardSettingsSchema,
+  congregationDefaults: congregationDefaultsSchema.optional(),
   createdAt: z.any().optional(),
 });
 export type Ward = z.infer<typeof wardSchema>;

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -462,8 +462,11 @@
     height: auto !important;
   }
 
-  /* Hide every top-level body child except the portal. */
-  body > *:not([data-print-only-letter]) {
+  /* Hide every top-level body child except the portal — only when a
+     letter portal is actually mounted (otherwise this rule blanks out
+     every other print route, like the congregation / conducting
+     program prints which render in #root, not via portal). */
+  body:has([data-print-only-letter]) > *:not([data-print-only-letter]) {
     display: none !important;
   }
 


### PR DESCRIPTION
## Summary

Print bulletin rethink. Congregation copy becomes a single fold-down-the-middle bulletin (cover left, program right) printed on landscape letter, replacing the old "two identical copies, cut down the middle". A new prepare-to-print page sits between the meeting form and the print routes, with per-Sunday saves on the meeting doc and ward-level defaults on the templates page. Conducting chips on the prepare page now render real meeting data instead of generic samples.

See [CHANGELOG.md](https://github.com/aylabyuk/steward/blob/develop/CHANGELOG.md#0240--2026-05-04) for the full breakdown.

## What's shipping

- **Prepare-to-print page (`/week/:date/prepare`)** — full-viewport editor with Congregation + Conducting tabs; per-Sunday saves cascade through ward template → built-in defaults at print time.
- **Congregation bulletin layout** — one bulletin per landscape sheet with editable cover image URL, announcements, and program footer note.
- **Templates page congregation editor** — ward-level defaults for cover image + footer note (no announcements; those are per-week).
- **Conducting chips show real data** on the prepare page (built from `buildMeetingVariables`); templates page intentionally still shows samples.
- **Tab order swap** — Congregation copy is the first/default tab on both prepare + templates pages.
- **Print pipeline fixes** — global `@media print` rule scoped with `:has()` so it only fires for the letter portal flow; PrintLayout drops the 9.3in width ceiling so bulletins fill the page.
- **Schema additions** — `meeting.coverImageUrl`, `meeting.programFooterNote`, `meeting.programs.{conducting|congregation}`, `ward.congregationDefaults.*` — all nullish, no migration required.
- **Meeting init failures surface** instead of getting stuck on "Meeting not created yet".

## Test plan

- [ ] `/week/<sunday>/prepare` opens with Congregation tab active; both tabs render real meeting data.
- [ ] Print buttons open `/print/...` in a new tab; landscape congregation bulletin fills the page (cover left, program right, fold-down-the-middle line).
- [ ] `/settings/templates/programs` Congregation tab edits ward defaults; absent per-meeting overrides cascade through.
- [ ] Conducting chips on the prepare page show this Sunday's actual presider/hymns/speakers; templates page chips still show built-in samples.
- [ ] Untouched meeting docs still load — schema accepts `null` values from cleared form fields.
- [ ] CI green on develop.

## Post-merge automation

`.github/workflows/release.yml` will tag `v0.24.0`, publish the GitHub Release, and deploy Firestore rules + Cloud Functions to `steward-prod-65a36`. Vercel handles the frontend deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)